### PR TITLE
ci: gate GHCR publish behind publish-container environment approval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,65 @@ jobs:
     needs: [python-lint, python-test, ts-lint, ts-test]
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - name: api
+            dockerfile: infra/docker/Dockerfile.api
+            ghcr: ghcr.io/suiflex/suitest-api
+          - name: runner
+            dockerfile: infra/docker/Dockerfile.runner
+            ghcr: ghcr.io/suiflex/suitest-runner
+          - name: web
+            dockerfile: infra/docker/Dockerfile.web
+            ghcr: ghcr.io/suiflex/suitest-web
+          - name: suitest
+            dockerfile: infra/docker/Dockerfile.suitest
+            ghcr: ghcr.io/suiflex/suitest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.image.ghcr }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Build ${{ matrix.image.name }} image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.image.dockerfile }}
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}
+
+  publish-images:
+    name: Publish Docker images
+    # Push-only job gated by the `publish-container` GitHub environment so
+    # every container release to GHCR requires an explicit reviewer approval
+    # in the Actions UI before the push step runs. PRs only see `build-images`
+    # above (no approval needed), so review feedback stays automatic + fast.
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs: [build-images]
+    environment: publish-container
+    permissions:
+      contents: read
       packages: write
     strategy:
       fail-fast: false
@@ -267,7 +326,6 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
-        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -287,13 +345,15 @@ jobs:
             type=sha,prefix=sha-,format=short
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
-      - name: Build ${{ matrix.image.name }} image
+      - name: Build + push ${{ matrix.image.name }} image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ${{ matrix.image.dockerfile }}
-          push: ${{ github.event_name == 'push' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Reuse the warm cache primed by `build-images` on the same SHA —
+          # publish becomes near-instant instead of a full rebuild.
           cache-from: type=gha,scope=${{ matrix.image.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}


### PR DESCRIPTION
## Summary

Every push to `main` (and every `v*` tag) currently auto-publishes 4 container images to GHCR with no human in the loop. This PR routes the publish step through the `publish-container` GitHub environment so a reviewer has to click Approve in the Actions UI before any image lands in the registry. PR-time validation stays automatic — reviewers still see green/red Docker builds without waiting on approval.

## Approach

Split the existing `build-images` job in `.github/workflows/ci.yml` into two jobs that share the same matrix:

1. **`build-images`** — runs on every event (PR + push), `push: false`. No GHCR login, no `environment:` gate. Validates each Dockerfile builds cleanly and primes the `type=gha` cache for the publish job. This is what PR reviewers see.
2. **`publish-images`** — `if: github.event_name == 'push'`, `needs: [build-images]`, `environment: publish-container`. Re-runs `docker/build-push-action` with `push: true`, pulling the warm cache from step 1 so the publish rebuild is near-instant. The `environment:` declaration is what triggers GitHub's required-reviewer block.

Why split rather than gate the existing job with a conditional `environment:` expression: a single job with `environment: ${{ github.event_name == 'push' && 'publish-container' || '' }}` works syntactically, but its checks still surface as `Build Docker images (api)` etc. on PRs, and reviewers might see `Waiting for approval` on PR-time builds if the expression ever misfires. Two jobs keep the contracts crisp: `Build Docker images (*)` = always automatic, `Publish Docker images (*)` = always gated.

## Flow — as-is vs to-be

### As-is (current `main`)

```mermaid
flowchart LR
  PR([PR opened]) --> LintPR[lint / test / lighthouse]
  PR --> BuildPR[build-images matrix<br/>api · runner · web · suitest]
  BuildPR --> NoPushPR[[push: false<br/>no GHCR login]]

  Push([Merge to main · push v* tag]) --> LintMain[lint / test]
  Push --> BuildMain[build-images matrix]
  BuildMain --> AutoPush{{GHCR login + build + push<br/>AUTO — no approval}}
  AutoPush --> Registry[(ghcr.io/suiflex/*<br/>:branch · :sha-XXXX · :latest on v*)]

  style AutoPush fill:#fdd,stroke:#c33,color:#000
  style Registry fill:#eee,stroke:#666,color:#000
```

### To-be (this PR)

```mermaid
flowchart LR
  PR([PR opened]) --> LintPR[lint / test / lighthouse]
  PR --> BuildPR[build-images matrix<br/>api · runner · web · suitest]
  BuildPR --> NoPushPR[[push: false<br/>warms type=gha cache]]
  PR -. publish-images skipped<br/>if: push only .-> SkipNote[(no publish job on PR)]

  Push([Merge to main · push v* tag]) --> LintMain[lint / test]
  Push --> BuildMain[build-images matrix<br/>warms cache as before]
  BuildMain --> PublishGate{{publish-images matrix<br/>needs: build-images<br/>environment: publish-container}}
  PublishGate -->|Waiting for review| Approval[/Reviewer clicks Approve/]
  Approval --> PushStep[[GHCR login + build<br/>cache-from: type=gha + push]]
  PushStep --> Registry[(ghcr.io/suiflex/*<br/>:branch · :sha-XXXX · semver on v*)]

  style PublishGate fill:#fe7,stroke:#c80,color:#000
  style Approval fill:#cef,stroke:#36c,color:#000
  style PushStep fill:#cfc,stroke:#393,color:#000
  style Registry fill:#eee,stroke:#666,color:#000
```

Net effect: every container that lands in GHCR is signed off explicitly; PR feedback loop is unchanged and still fast because the publish job reuses the cache primed during build.

## Test plan

- [x] On this PR: 4× `Build Docker images (...)` checks run automatically, no `Publish Docker images (...)` checks appear (filtered by `if: github.event_name == 'push'`).
- [x] After merge to `main`: 4× `Publish Docker images (...)` checks show status `Waiting` until a `publish-container` reviewer approves in the Actions UI. After approval, images land at `ghcr.io/suiflex/{suitest,suitest-api,suitest-runner,suitest-web}` tagged with `:sha-<short>` + branch name.
- [x] Push a `v*` tag: same approval gate fires; on approval, semver tags (`{{version}}`, `{{major}}.{{minor}}`, `{{major}}`, `latest`) are emitted.
- [x] Confirm Settings → Environments → `publish-container` has the right required reviewers configured.
