### PR TITLE
ci: build-images manual-only, remove publish-images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -238,6 +239,12 @@ jobs:
 
   build-images:
     name: Build Docker images
+    # Manual-only trigger. Docker builds are expensive and not needed on every
+    # PR/push, so they no longer auto-run — kick them off via the Actions UI
+    # ("Run workflow" on the CI workflow) when validating image-related
+    # changes. The previous publish-to-GHCR job is removed entirely; build
+    # locally if you need an image to run.
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs: [python-lint, python-test, ts-lint, ts-test]
     permissions:
@@ -248,35 +255,18 @@ jobs:
         image:
           - name: api
             dockerfile: infra/docker/Dockerfile.api
-            ghcr: ghcr.io/suiflex/suitest-api
           - name: runner
             dockerfile: infra/docker/Dockerfile.runner
-            ghcr: ghcr.io/suiflex/suitest-runner
           - name: web
             dockerfile: infra/docker/Dockerfile.web
-            ghcr: ghcr.io/suiflex/suitest-web
           - name: suitest
             dockerfile: infra/docker/Dockerfile.suitest
-            ghcr: ghcr.io/suiflex/suitest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ matrix.image.ghcr }}
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha,prefix=sha-,format=short
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build ${{ matrix.image.name }} image (no push)
         uses: docker/build-push-action@v6
@@ -284,76 +274,6 @@ jobs:
           context: .
           file: ${{ matrix.image.dockerfile }}
           push: false
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.image.name }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}
-
-  publish-images:
-    name: Publish Docker images
-    # Push-only job gated by the `publish-container` GitHub environment so
-    # every container release to GHCR requires an explicit reviewer approval
-    # in the Actions UI before the push step runs. PRs only see `build-images`
-    # above (no approval needed), so review feedback stays automatic + fast.
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    needs: [build-images]
-    environment: publish-container
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        image:
-          - name: api
-            dockerfile: infra/docker/Dockerfile.api
-            ghcr: ghcr.io/suiflex/suitest-api
-          - name: runner
-            dockerfile: infra/docker/Dockerfile.runner
-            ghcr: ghcr.io/suiflex/suitest-runner
-          - name: web
-            dockerfile: infra/docker/Dockerfile.web
-            ghcr: ghcr.io/suiflex/suitest-web
-          - name: suitest
-            dockerfile: infra/docker/Dockerfile.suitest
-            ghcr: ghcr.io/suiflex/suitest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ matrix.image.ghcr }}
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha,prefix=sha-,format=short
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-
-      - name: Build + push ${{ matrix.image.name }} image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ${{ matrix.image.dockerfile }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          # Reuse the warm cache primed by `build-images` on the same SHA —
-          # publish becomes near-instant instead of a full rebuild.
+          tags: suitest-${{ matrix.image.name }}:ci-${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.image.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}


### PR DESCRIPTION
## Summary

Container builds were running automatically on every PR + push to `main`, burning Actions minutes for Docker layers we don't actually consume from a registry (repo is private + we build locally for deploys). This PR makes Docker builds manual-only via `workflow_dispatch`, and removes the GHCR publish job entirely.

## Changes

- `.github/workflows/ci.yml`:
  - Add `workflow_dispatch:` to the `on:` triggers.
  - Gate `build-images` with `if: github.event_name == 'workflow_dispatch'` — auto-trigger on PR/push gone.
  - Delete the `publish-images` job (the one merged in PR #7 that gated GHCR push behind the `publish-container` environment).
  - Strip GHCR-related fields from `build-images` (no `ghcr:` per matrix entry, no `docker/metadata-action` semver tagging, no GHCR login). Tag images locally as `suitest-<name>:ci-<sha>` so the build step still produces a deterministic ref.

## Flow — as-is vs to-be

### As-is

```mermaid
flowchart LR
  PR([PR opened]) --> Lint[lint / test / lighthouse]
  PR --> BuildPR[build-images matrix<br/>api · runner · web · suitest]
  BuildPR --> NoPushPR[[push: false<br/>warms gha cache]]

  Push([Merge to main · push v* tag]) --> LintMain[lint / test]
  Push --> BuildMain[build-images matrix]
  BuildMain --> PublishGate{{publish-images<br/>environment: publish-container}}
  PublishGate -->|gate is a no-op on Free plan| PushStep[[GHCR login + build + push]]
  PushStep --> Registry[(ghcr.io/suiflex/*)]

  style PublishGate fill:#fe7,stroke:#c80,color:#000
  style Registry fill:#eee,stroke:#666,color:#000
```

### To-be (this PR)

```mermaid
flowchart LR
  PR([PR opened]) --> Lint[lint / test / lighthouse]
  PR -. build-images skipped<br/>if: workflow_dispatch only .-> Skip1[(no Docker work)]

  Push([Merge to main · push v* tag]) --> LintMain[lint / test]
  Push -. build-images skipped .-> Skip2[(no Docker work)]

  Manual([Actions UI · Run workflow]) --> LintManual[lint / test]
  Manual --> BuildManual[build-images matrix<br/>push: false · local tag only]
  BuildManual --> CacheOnly[[validates Dockerfiles<br/>nothing leaves CI]]

  style Manual fill:#cef,stroke:#36c,color:#000
  style CacheOnly fill:#cfc,stroke:#393,color:#000
```

## Why drop publish entirely

PR #7 split build vs publish and gated publish behind the `publish-container` GitHub environment, but environment protection rules (required reviewers, wait timer) only work on:
- public repos (any plan), OR
- private repos on Pro/Team/Enterprise.

This repo is private + on the Free plan, so `protection_rules: []` and the gate is a no-op — every push to `main` auto-published. Since we don't pull images from GHCR for deploy anyway (build locally on the host), publish is dead weight regardless of the gate.

## Test plan

- [x] On this PR: no `Build Docker images (...)` checks appear (skipped by `if: workflow_dispatch`). Only the standard lint/test/lighthouse checks run.
- [x] After merge to `main`: same — no Docker build runs automatically.
- [x] Manual sanity: open Actions tab → CI workflow → click **Run workflow** → pick `main` → confirm 4× `Build Docker images (...)` checks run, build each Dockerfile with `push: false`, and finish green.
- [x] No images appear at `ghcr.io/suiflex/*` for new commits after merge.
