### PR TITLE
feat(mcp-npx): install command for registering the MCP server into IDE agents

### DIFF
--- a/packages/mcp-npx/README.md
+++ b/packages/mcp-npx/README.md
@@ -24,7 +24,38 @@ no LLM key required.
 
 ## IDE setup
 
-Add to your project's `.mcp.json` (Claude Code) or the equivalent MCP config:
+Fastest path — let the installer write the config for you:
+
+```bash
+npx -y @suiflex/suitest-mcp login                        # save API URL + key once (TTY)
+npx -y @suiflex/suitest-mcp install                      # pick a client (arrow keys + type to filter)
+npx -y @suiflex/suitest-mcp install --client claude-code # or target one directly
+npx -y @suiflex/suitest-mcp doctor                       # inspect every client's config target
+```
+
+`login` stores the credentials at `~/.config/suitest/credentials.json` (chmod
+600) and every `install` reuses them, writing the right `env` block into the
+chosen client. Supported targets:
+
+| `--client`        | Writes / delegates to |
+|-------------------|-----------------------|
+| `claude-code`     | `~/.claude.json` (`--scope project` → `./.mcp.json`) |
+| `claude-desktop`  | `claude_desktop_config.json` in the Claude support dir |
+| `cursor`          | `~/.cursor/mcp.json` |
+| `codex`           | delegates to `codex mcp add` |
+| `gemini-cli`      | delegates to `gemini mcp add` |
+| `vscode`          | delegates to `code --add-mcp` (GitHub Copilot in VS Code) |
+| `copilot-cli`     | `~/.copilot/mcp-config.json` |
+| `opencode`        | `opencode.jsonc` |
+| `antigravity`     | `~/.gemini/antigravity/mcp_config.json` |
+| `antigravity-cli` | `~/.gemini/config/mcp_config.json` |
+| `generic-json`    | prints a portable snippet, writes nothing |
+
+Flags: `--name` (entry name, default `suitest`), `--api-url` / `--api-key`
+(skip the saved creds), `--print`, `--dry-run`, `--force`.
+
+Prefer to wire it by hand? Add to your project's `.mcp.json` (Claude Code) or
+the equivalent MCP config:
 
 ```json
 {

--- a/packages/mcp-npx/bin/suitest-mcp.js
+++ b/packages/mcp-npx/bin/suitest-mcp.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * suitest-mcp — run the Suitest MCP server via npx.
+ * suitest-mcp — run the Suitest MCP server via npx, or install it into an IDE agent.
  *
  * The server itself is `suitest_lifecycle.mcp_server`, a stdlib-only Python
  * module bundled inside this npm package (synced from packages/lifecycle at
@@ -9,81 +9,58 @@
  * demand inside the target project's environment — nothing global.
  *
  * Usage:
- *   npx @suiflex/suitest-mcp            # start the stdio MCP server
- *   npx @suiflex/suitest-mcp mcp        # same (explicit subcommand)
+ *   npx @suiflex/suitest-mcp                    # start the stdio MCP server
+ *   npx @suiflex/suitest-mcp mcp                # same (explicit subcommand)
+ *   npx @suiflex/suitest-mcp install            # interactive: pick a client (TTY)
+ *   npx @suiflex/suitest-mcp install --client claude-code
+ *   npx @suiflex/suitest-mcp login              # save API URL + key once
+ *   npx @suiflex/suitest-mcp doctor             # check client config targets
  *   npx @suiflex/suitest-mcp --help
  */
 
 "use strict";
 
-const { spawnSync, spawn } = require("node:child_process");
+const { spawn } = require("node:child_process");
 const path = require("node:path");
 const fs = require("node:fs");
 
+const { findPython } = require("../lib/python.js");
+
 const PKG_ROOT = path.resolve(__dirname, "..");
 const PYTHON_DIR = path.join(PKG_ROOT, "python");
-const MIN_PY = [3, 11];
 
-function findPython() {
-  const candidates = process.env.SUITEST_PYTHON
-    ? [process.env.SUITEST_PYTHON]
-    : ["python3", "python"];
-  for (const cmd of candidates) {
-    const probe = spawnSync(cmd, [
-      "-c",
-      "import sys; print('%d.%d' % sys.version_info[:2])",
-    ]);
-    if (probe.status !== 0) continue;
-    const [maj, min] = String(probe.stdout).trim().split(".").map(Number);
-    if (maj > MIN_PY[0] || (maj === MIN_PY[0] && min >= MIN_PY[1])) {
-      return { cmd, version: `${maj}.${min}` };
-    }
-  }
-  return null;
+function printHelp() {
+  process.stdout.write(
+    [
+      "suitest-mcp — Suitest MCP server (stdio) + installer",
+      "",
+      "Usage:",
+      "  npx @suiflex/suitest-mcp                    start the MCP server (default)",
+      "  npx @suiflex/suitest-mcp mcp                same, explicit",
+      "  npx @suiflex/suitest-mcp install            interactive picker (TTY)",
+      "  npx @suiflex/suitest-mcp install --client <target>",
+      "  npx @suiflex/suitest-mcp login              save API URL + key once",
+      "  npx @suiflex/suitest-mcp doctor             check client config targets",
+      "  npx @suiflex/suitest-mcp --version          bundled server version",
+      "",
+      "Install flags: --client, --name, --scope global|project, --api-url,",
+      "               --api-key, --print, --dry-run, --force",
+      "",
+      "Requires Python >= 3.11 on PATH (override with SUITEST_PYTHON).",
+      "Docs: https://github.com/suiflex/suitest/blob/main/docs/MCP_PLUGINS.md",
+      "",
+    ].join("\n"),
+  );
 }
 
-function main() {
-  const args = process.argv.slice(2);
-  if (args.includes("--help") || args.includes("-h")) {
-    process.stdout.write(
-      [
-        "suitest-mcp — Suitest MCP server (stdio)",
-        "",
-        "Usage:",
-        "  npx @suiflex/suitest-mcp            start the MCP server (default)",
-        "  npx @suiflex/suitest-mcp mcp        same, explicit",
-        "  npx @suiflex/suitest-mcp --version  bundled server version",
-        "",
-        "Add to your IDE agent (e.g. .mcp.json):",
-        "  {",
-        '    "mcpServers": {',
-        '      "suitest": {',
-        '        "command": "npx",',
-        '        "args": ["-y", "@suiflex/suitest-mcp"],',
-        '        "env": { "SUITEST_API_URL": "...", "SUITEST_API_KEY": "..." }',
-        "      }",
-        "    }",
-        "  }",
-        "",
-        "Requires Python >= 3.11 on PATH (override with SUITEST_PYTHON).",
-        "Docs: https://github.com/suiflex/suitest/blob/main/docs/MCP_PLUGINS.md",
-        "",
-      ].join("\n"),
-    );
-    return 0;
-  }
-  if (args.includes("--version") || args.includes("-v")) {
-    const pkg = JSON.parse(
-      fs.readFileSync(path.join(PKG_ROOT, "package.json"), "utf8"),
-    );
-    process.stdout.write(`${pkg.name} ${pkg.version}\n`);
-    return 0;
-  }
-  const sub = args[0];
-  if (sub && sub !== "mcp") {
-    process.stderr.write(`unknown command: ${sub} (try --help)\n`);
-    return 2;
-  }
+function printVersion() {
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(PKG_ROOT, "package.json"), "utf8"),
+  );
+  process.stdout.write(`${pkg.name} ${pkg.version}\n`);
+}
+
+function startServer() {
   if (!fs.existsSync(path.join(PYTHON_DIR, "suitest_lifecycle"))) {
     process.stderr.write(
       "bundled python sources missing — this is a packaging bug; " +
@@ -119,5 +96,41 @@ function main() {
   return undefined;
 }
 
-const rc = main();
-if (rc !== undefined) process.exit(rc);
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes("--help") || args.includes("-h")) {
+    printHelp();
+    return 0;
+  }
+  if (args.includes("--version") || args.includes("-v")) {
+    printVersion();
+    return 0;
+  }
+
+  const sub = args[0];
+  const rest = args.slice(1);
+
+  if (sub === "install" || sub === "doctor" || sub === "login") {
+    const installer = require("../lib/install.js");
+    try {
+      if (sub === "install") await installer.handleInstall(rest);
+      else if (sub === "doctor") installer.handleDoctor(rest);
+      else await installer.handleLogin();
+      return 0;
+    } catch (err) {
+      process.stderr.write(`${err.message}\n`);
+      return 1;
+    }
+  }
+
+  if (sub && sub !== "mcp") {
+    process.stderr.write(`unknown command: ${sub} (try --help)\n`);
+    return 2;
+  }
+
+  return startServer();
+}
+
+main().then((rc) => {
+  if (rc !== undefined) process.exit(rc);
+});

--- a/packages/mcp-npx/lib/creds.js
+++ b/packages/mcp-npx/lib/creds.js
@@ -1,0 +1,154 @@
+"use strict";
+
+/**
+ * Credential resolution + persistence for `suitest-mcp`.
+ *
+ * The Suitest MCP server refuses to boot without SUITEST_API_URL +
+ * SUITEST_API_KEY (it verifies against /api/v1/api-keys/whoami). So the
+ * installer must put a working pair into each client's `env` block.
+ *
+ * Resolution order: explicit flags -> process env -> saved file -> interactive
+ * TTY prompt (which offers to save). Non-TTY with nothing set returns
+ * placeholders and warn=true so the caller can nag instead of silently
+ * writing a dead config.
+ */
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const readline = require("node:readline");
+
+const PLACEHOLDER = {
+  apiUrl: "http://localhost:4000",
+  apiKey: "sk_suitest_…",
+};
+
+// XDG-aware config dir, mirroring opencode_settings_path() in the jira ref.
+function configDir() {
+  if (process.env.SUITEST_CONFIG_DIR) return process.env.SUITEST_CONFIG_DIR;
+  if (process.env.XDG_CONFIG_HOME) {
+    return path.join(process.env.XDG_CONFIG_HOME, "suitest");
+  }
+  if (process.platform === "win32") {
+    const appdata =
+      process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming");
+    return path.join(appdata, "suitest");
+  }
+  return path.join(os.homedir(), ".config", "suitest");
+}
+
+function credsPath() {
+  return path.join(configDir(), "credentials.json");
+}
+
+function loadCreds() {
+  const p = credsPath();
+  if (!fs.existsSync(p)) return null;
+  try {
+    const raw = fs.readFileSync(p, "utf8").trim();
+    if (!raw) return null;
+    const obj = JSON.parse(raw);
+    if (obj && obj.apiUrl && obj.apiKey) {
+      return { apiUrl: String(obj.apiUrl), apiKey: String(obj.apiKey) };
+    }
+  } catch {
+    // corrupt file -> treat as absent, resolve() will re-prompt/warn.
+  }
+  return null;
+}
+
+function saveCreds({ apiUrl, apiKey }) {
+  const dir = configDir();
+  fs.mkdirSync(dir, { recursive: true });
+  const p = credsPath();
+  fs.writeFileSync(p, `${JSON.stringify({ apiUrl, apiKey }, null, 2)}\n`);
+  try {
+    fs.chmodSync(p, 0o600);
+  } catch {
+    // best effort (e.g. Windows) — the value is user-scoped anyway.
+  }
+  return p;
+}
+
+function ask(rl, question) {
+  return new Promise((resolve) => rl.question(question, (a) => resolve(a.trim())));
+}
+
+/**
+ * Interactive prompt for URL + key. Prefills from `defaults` so the user can
+ * just hit enter to keep an existing value. Returns null if aborted (empty
+ * required field).
+ */
+async function promptCreds(defaults = {}) {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  try {
+    const urlHint = defaults.apiUrl ? ` [${defaults.apiUrl}]` : "";
+    const keyHint = defaults.apiKey ? " [keep existing]" : "";
+    const apiUrl =
+      (await ask(rl, `SUITEST_API_URL${urlHint}: `)) || defaults.apiUrl || "";
+    const apiKey =
+      (await ask(rl, `SUITEST_API_KEY${keyHint}: `)) || defaults.apiKey || "";
+    if (!apiUrl || !apiKey) return null;
+    return { apiUrl, apiKey };
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Resolve credentials to embed in a client's `env` block.
+ * @returns {{apiUrl:string, apiKey:string, warn:boolean, source:string}}
+ */
+async function resolveCreds({
+  apiUrl,
+  apiKey,
+  interactive = true,
+  allowPrompt = true,
+} = {}) {
+  // 1. explicit flags
+  if (apiUrl && apiKey) {
+    return { apiUrl, apiKey, warn: false, source: "flags" };
+  }
+  // 2. process env
+  if (process.env.SUITEST_API_URL && process.env.SUITEST_API_KEY) {
+    return {
+      apiUrl: process.env.SUITEST_API_URL,
+      apiKey: process.env.SUITEST_API_KEY,
+      warn: false,
+      source: "env",
+    };
+  }
+  // 3. saved file
+  const saved = loadCreds();
+  if (saved) return { ...saved, warn: false, source: "saved" };
+
+  // 4. interactive prompt (TTY only)
+  if (interactive && allowPrompt && process.stdin.isTTY) {
+    process.stdout.write(
+      "No saved credentials. Enter them now (stored at " +
+        `${credsPath()}, chmod 600):\n`,
+    );
+    const entered = await promptCreds();
+    if (entered) {
+      saveCreds(entered);
+      process.stdout.write("Saved. Reused automatically next time.\n\n");
+      return { ...entered, warn: false, source: "prompted" };
+    }
+  }
+
+  // 5. give up -> placeholders + warn
+  return { ...PLACEHOLDER, warn: true, source: "placeholder" };
+}
+
+module.exports = {
+  PLACEHOLDER,
+  configDir,
+  credsPath,
+  loadCreds,
+  saveCreds,
+  promptCreds,
+  resolveCreds,
+};

--- a/packages/mcp-npx/lib/install.js
+++ b/packages/mcp-npx/lib/install.js
@@ -1,0 +1,549 @@
+"use strict";
+
+/**
+ * `suitest-mcp install` — register the Suitest MCP server into a supported
+ * IDE agent's config. Node/stdlib port of jira-commands' crates/jira/src/cli/mcp.rs.
+ *
+ * File-target clients get their JSON/JSONC config merged in place (with a .bak
+ * backup); CLIs that own an `mcp add` command are delegated to. Every entry
+ * carries the SUITEST_API_URL/KEY env the server needs to boot.
+ */
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const creds = require("./creds.js");
+const picker = require("./picker.js");
+const { findPython } = require("./python.js");
+
+const PKG = "@suiflex/suitest-mcp";
+const NPX_ARGS = ["-y", PKG];
+
+function homeConfig(envKey, ...segments) {
+  if (envKey && process.env[envKey]) return process.env[envKey];
+  return path.join(os.homedir(), ...segments);
+}
+
+function claudeDesktopPath() {
+  const home = os.homedir();
+  if (process.platform === "darwin") {
+    return path.join(
+      home,
+      "Library/Application Support/Claude/claude_desktop_config.json",
+    );
+  }
+  if (process.platform === "win32") {
+    const appdata = process.env.APPDATA || path.join(home, "AppData/Roaming");
+    return path.join(appdata, "Claude/claude_desktop_config.json");
+  }
+  const xdg = process.env.XDG_CONFIG_HOME || path.join(home, ".config");
+  return path.join(xdg, "Claude/claude_desktop_config.json");
+}
+
+function opencodePath() {
+  if (process.env.OPENCODE_CONFIG) return process.env.OPENCODE_CONFIG;
+  const home = os.homedir();
+  if (process.platform === "win32") {
+    const appdata = process.env.APPDATA || path.join(home, "AppData/Roaming");
+    return path.join(appdata, "opencode/opencode.jsonc");
+  }
+  const xdg = process.env.XDG_CONFIG_HOME || path.join(home, ".config");
+  return path.join(xdg, "opencode/opencode.jsonc");
+}
+
+// Client registry — same 11 targets as the jira reference.
+const CLIENTS = {
+  "claude-code": {
+    kind: "file",
+    label: "claude-code",
+    hint: "writes ~/.claude.json mcpServers",
+    key: "mcpServers",
+    targetPath: (scope) =>
+      scope === "project"
+        ? path.resolve(process.cwd(), ".mcp.json")
+        : homeConfig("CLAUDE_CODE_CONFIG", ".claude.json"),
+  },
+  "claude-desktop": {
+    kind: "file",
+    label: "claude-desktop",
+    hint: "writes claude_desktop_config.json in Claude support dir",
+    key: "mcpServers",
+    targetPath: () => process.env.CLAUDE_DESKTOP_CONFIG || claudeDesktopPath(),
+  },
+  cursor: {
+    kind: "file",
+    label: "cursor",
+    hint: "writes ~/.cursor/mcp.json",
+    key: "mcpServers",
+    targetPath: () => homeConfig("CURSOR_CONFIG", ".cursor/mcp.json"),
+  },
+  codex: {
+    kind: "delegated",
+    label: "codex",
+    hint: "delegates to `codex mcp add`",
+    program: "codex",
+    steps: (name, env, force) => {
+      const steps = [];
+      if (force) steps.push(["mcp", "remove", name]);
+      const envFlags = Object.entries(env).flatMap(([k, v]) => [
+        "--env",
+        `${k}=${v}`,
+      ]);
+      steps.push(["mcp", "add", name, ...envFlags, "--", "npx", ...NPX_ARGS]);
+      return steps;
+    },
+  },
+  "gemini-cli": {
+    kind: "delegated",
+    label: "gemini-cli",
+    hint: "delegates to `gemini mcp add`",
+    program: "gemini",
+    steps: (name, env, force) => {
+      const steps = [];
+      if (force) steps.push(["mcp", "remove", name]);
+      const envFlags = Object.entries(env).flatMap(([k, v]) => [
+        "-e",
+        `${k}=${v}`,
+      ]);
+      steps.push([
+        "mcp",
+        "add",
+        "-s",
+        "user",
+        ...envFlags,
+        name,
+        "npx",
+        ...NPX_ARGS,
+      ]);
+      return steps;
+    },
+  },
+  vscode: {
+    kind: "delegated",
+    label: "vscode",
+    hint: "delegates to `code --add-mcp` (GitHub Copilot in VS Code)",
+    program: "code",
+    steps: (name, env) => [
+      [
+        "--add-mcp",
+        JSON.stringify({
+          name,
+          type: "stdio",
+          command: "npx",
+          args: NPX_ARGS,
+          env,
+        }),
+      ],
+    ],
+  },
+  "copilot-cli": {
+    kind: "file",
+    label: "copilot-cli",
+    hint: "writes ~/.copilot/mcp-config.json (GitHub Copilot CLI)",
+    key: "mcpServers",
+    targetPath: () =>
+      homeConfig("COPILOT_CLI_CONFIG", ".copilot/mcp-config.json"),
+  },
+  opencode: {
+    kind: "file",
+    label: "opencode",
+    hint: "writes opencode.jsonc",
+    key: "mcp",
+    targetPath: () => opencodePath(),
+  },
+  antigravity: {
+    kind: "file",
+    label: "antigravity",
+    hint: "writes ~/.gemini/antigravity/mcp_config.json",
+    key: "mcpServers",
+    targetPath: () =>
+      homeConfig("ANTIGRAVITY_CONFIG", ".gemini/antigravity/mcp_config.json"),
+  },
+  "antigravity-cli": {
+    kind: "file",
+    label: "antigravity-cli",
+    hint: "writes ~/.gemini/config/mcp_config.json",
+    key: "mcpServers",
+    targetPath: () =>
+      homeConfig("ANTIGRAVITY_CLI_CONFIG", ".gemini/config/mcp_config.json"),
+  },
+  "generic-json": {
+    kind: "snippet",
+    label: "generic-json",
+    hint: "print snippet only, no file changes",
+  },
+};
+
+const CLIENT_ORDER = Object.keys(CLIENTS);
+
+// --- JSON entry shape per client (file targets) --------------------------
+
+function serverSpec(client, env) {
+  if (client === "opencode") {
+    const entry = {
+      type: "local",
+      command: ["npx", ...NPX_ARGS],
+      environment: env,
+      enabled: true,
+    };
+    return { entry, snippet: { mcp: { suitest: entry } } };
+  }
+  if (client === "copilot-cli") {
+    const entry = { type: "stdio", command: "npx", args: NPX_ARGS, env };
+    return { entry, snippet: { mcpServers: { suitest: entry } } };
+  }
+  const entry = { command: "npx", args: NPX_ARGS, env };
+  return { entry, snippet: { mcpServers: { suitest: entry } } };
+}
+
+// --- JSON/JSONC helpers (port of mcp.rs) ---------------------------------
+
+function stripJsonComments(input) {
+  let out = "";
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+    if (inString) {
+      out += ch;
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      out += ch;
+    } else if (ch === "/" && input[i + 1] === "/") {
+      i++;
+      while (i + 1 < input.length && input[i + 1] !== "\n") i++;
+    } else if (ch === "/" && input[i + 1] === "*") {
+      i += 2;
+      while (i + 1 < input.length && !(input[i] === "*" && input[i + 1] === "/")) {
+        if (input[i] === "\n") out += "\n";
+        i++;
+      }
+      i++;
+    } else {
+      out += ch;
+    }
+  }
+  return out;
+}
+
+function loadJsonObject(p) {
+  if (!fs.existsSync(p)) return {};
+  const raw = fs.readFileSync(p, "utf8");
+  if (!raw.trim()) return {};
+  const value = JSON.parse(stripJsonComments(raw));
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`Config file ${p} must contain a top-level JSON object`);
+  }
+  return value;
+}
+
+function ensureObjectPath(root, dottedKey) {
+  let current = root;
+  for (const key of dottedKey.split(".")) {
+    if (current[key] === undefined) current[key] = {};
+    if (
+      typeof current[key] !== "object" ||
+      current[key] === null ||
+      Array.isArray(current[key])
+    ) {
+      throw new Error(`Field '${key}' must be a JSON object`);
+    }
+    current = current[key];
+  }
+  return current;
+}
+
+function backupIfExists(p) {
+  if (!fs.existsSync(p)) return;
+  fs.copyFileSync(p, `${p}.bak`);
+}
+
+function writeJsonObject(p, root) {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, `${JSON.stringify(root, null, 2)}\n`);
+}
+
+function shellJoin(args) {
+  return args
+    .map((a) => (/^[\w\-/.:=@]+$/.test(a) ? a : `'${a.replace(/'/g, "'\\''")}'`))
+    .join(" ");
+}
+
+function deepEqual(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+// --- install one client ---------------------------------------------------
+
+function installClient(clientId, { name, scope, env, print, dryRun, force }) {
+  const client = CLIENTS[clientId];
+  if (!client) throw new Error(`unknown client: ${clientId}`);
+  const { entry, snippet } = serverSpec(clientId, env);
+
+  if (client.kind === "snippet") {
+    process.stdout.write(`${JSON.stringify(snippet, null, 2)}\n`);
+    return;
+  }
+
+  if (client.kind === "delegated") {
+    const steps = client.steps(name, env, force);
+    const preview = steps
+      .map((s) => `${client.program} ${shellJoin(s)}`)
+      .join(" && ");
+    if (print || dryRun) process.stdout.write(`${preview}\n`);
+    if (dryRun) {
+      process.stdout.write("Dry run, no client command executed.\n");
+      return;
+    }
+    for (const s of steps) {
+      const res = spawnSync(client.program, s, { stdio: "inherit" });
+      if (res.error && res.error.code === "ENOENT") {
+        throw new Error(
+          `${client.program} CLI not found on PATH — install it, then retry.`,
+        );
+      }
+      // `force` remove may fail if the entry is absent; ignore that one.
+      if (res.status !== 0 && !(force && s[1] === "remove")) {
+        throw new Error(`${client.program} exited with status ${res.status}`);
+      }
+    }
+    process.stdout.write(`Installed MCP entry '${name}' via ${client.label}\n`);
+    return;
+  }
+
+  // file target
+  const target = client.targetPath(scope);
+  const root = loadJsonObject(target);
+  const bag = ensureObjectPath(root, client.key);
+
+  if (bag[name] !== undefined) {
+    if (deepEqual(bag[name], entry)) {
+      process.stdout.write(
+        `MCP entry '${name}' already configured at ${target}\n`,
+      );
+      return;
+    }
+    if (!force) {
+      throw new Error(
+        `MCP entry '${name}' already exists at ${target}. Re-run with --force to overwrite.`,
+      );
+    }
+  }
+
+  bag[name] = entry;
+  if (print || dryRun) {
+    process.stdout.write(`${JSON.stringify(snippet, null, 2)}\n`);
+  }
+  if (dryRun) {
+    process.stdout.write(`Dry run, no file written. Target: ${target}\n`);
+    return;
+  }
+  backupIfExists(target);
+  writeJsonObject(target, root);
+  process.stdout.write(
+    `Installed MCP entry '${name}' for ${client.label} at ${target}\n`,
+  );
+}
+
+// --- doctor ---------------------------------------------------------------
+
+function commandExists(program) {
+  const probe = spawnSync(program, ["--version"], { stdio: "ignore" });
+  return !(probe.error && probe.error.code === "ENOENT");
+}
+
+function doctor(only) {
+  process.stdout.write("MCP doctor\n──────────\n");
+
+  const py = findPython();
+  process.stdout.write(
+    py
+      ? `[ok] Python ${py.version} on PATH (${py.cmd})\n`
+      : "[warn] Python >= 3.11 not found on PATH (set SUITEST_PYTHON)\n",
+  );
+
+  const saved = creds.loadCreds();
+  process.stdout.write(
+    saved
+      ? `[ok] Credentials saved at ${creds.credsPath()}\n`
+      : "[warn] No saved credentials — run `suitest-mcp login`\n",
+  );
+
+  const ids = only ? [only] : CLIENT_ORDER;
+  for (const id of ids) {
+    const client = CLIENTS[id];
+    if (client.kind === "delegated") {
+      process.stdout.write(
+        commandExists(client.program)
+          ? `[ok] ${client.label} CLI found: ${client.program}\n`
+          : `[warn] ${client.label} CLI missing: ${client.program}\n`,
+      );
+    } else if (client.kind === "file") {
+      const p = client.targetPath("global");
+      process.stdout.write(
+        fs.existsSync(p)
+          ? `[ok] ${client.label} config exists: ${p}\n`
+          : `[info] ${client.label} config will be created: ${p}\n`,
+      );
+    } else {
+      process.stdout.write(`[ok] ${client.label} available (print-only)\n`);
+    }
+  }
+}
+
+// --- interactive orchestration -------------------------------------------
+
+async function runInteractive(opts) {
+  process.stdout.write("suitest-mcp install — interactive setup\n");
+  process.stdout.write("─".repeat(38) + "\n\n");
+
+  const py = findPython();
+  process.stdout.write(
+    py
+      ? `[ok]   Python interpreter: ${py.cmd} (${py.version})\n`
+      : "[fail] Python >= 3.11 not found on PATH\n",
+  );
+  const saved = creds.loadCreds();
+  process.stdout.write(
+    saved
+      ? "[ok]   Credentials saved (reused automatically)\n"
+      : "[info] No saved credentials — you'll be asked once\n",
+  );
+  process.stdout.write("\n");
+
+  if (!py) {
+    throw new Error(
+      "Python >= 3.11 is required to run the server. Install from https://python.org, then retry.",
+    );
+  }
+
+  const items = CLIENT_ORDER.map((id) => ({
+    value: id,
+    label: CLIENTS[id].label,
+    hint: CLIENTS[id].hint,
+  }));
+  const clientId = await picker.select("Pick the MCP client to install into:", items);
+
+  const resolved = await creds.resolveCreds(opts);
+  const env = {
+    SUITEST_API_URL: resolved.apiUrl,
+    SUITEST_API_KEY: resolved.apiKey,
+  };
+  if (resolved.warn) {
+    process.stderr.write(
+      "[warn] Using placeholder credentials — edit the config or run `suitest-mcp login`.\n",
+    );
+  }
+  installClient(clientId, { ...opts, env });
+}
+
+// --- arg parsing + entrypoints -------------------------------------------
+
+function parseArgs(argv) {
+  const out = {
+    client: null,
+    name: "suitest",
+    scope: "global",
+    print: false,
+    dryRun: false,
+    force: false,
+    apiUrl: undefined,
+    apiKey: undefined,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case "--client":
+        out.client = argv[++i];
+        break;
+      case "--name":
+        out.name = argv[++i];
+        break;
+      case "--scope":
+        out.scope = argv[++i];
+        break;
+      case "--api-url":
+        out.apiUrl = argv[++i];
+        break;
+      case "--api-key":
+        out.apiKey = argv[++i];
+        break;
+      case "--print":
+        out.print = true;
+        break;
+      case "--dry-run":
+        out.dryRun = true;
+        break;
+      case "--force":
+        out.force = true;
+        break;
+      default:
+        throw new Error(`unknown flag: ${a}`);
+    }
+  }
+  return out;
+}
+
+async function handleInstall(argv) {
+  const opts = parseArgs(argv);
+  if (!opts.client) {
+    return runInteractive(opts);
+  }
+  if (!CLIENTS[opts.client]) {
+    throw new Error(
+      `unknown --client '${opts.client}'. Choose from: ${CLIENT_ORDER.join(", ")}`,
+    );
+  }
+  const resolved = await creds.resolveCreds(opts);
+  if (resolved.warn) {
+    process.stderr.write(
+      "[warn] No credentials — writing placeholders. Run `suitest-mcp login` or pass --api-url/--api-key.\n",
+    );
+  }
+  const env = {
+    SUITEST_API_URL: resolved.apiUrl,
+    SUITEST_API_KEY: resolved.apiKey,
+  };
+  installClient(opts.client, { ...opts, env });
+}
+
+async function handleLogin() {
+  if (!process.stdin.isTTY) {
+    throw new Error(
+      "login needs a TTY. Non-interactive? Pass --api-url/--api-key to install, or set SUITEST_API_URL/KEY.",
+    );
+  }
+  const existing = creds.loadCreds() || {};
+  const entered = await creds.promptCreds(existing);
+  if (!entered) {
+    throw new Error("login cancelled — both URL and key are required.");
+  }
+  const p = creds.saveCreds(entered);
+  process.stdout.write(`Saved credentials to ${p} (chmod 600).\n`);
+}
+
+function handleDoctor(argv) {
+  const opts = parseArgs(argv);
+  doctor(opts.client || null);
+}
+
+module.exports = {
+  CLIENTS,
+  CLIENT_ORDER,
+  serverSpec,
+  stripJsonComments,
+  loadJsonObject,
+  ensureObjectPath,
+  installClient,
+  parseArgs,
+  handleInstall,
+  handleLogin,
+  handleDoctor,
+};

--- a/packages/mcp-npx/lib/picker.js
+++ b/packages/mcp-npx/lib/picker.js
@@ -1,0 +1,121 @@
+"use strict";
+
+/**
+ * Minimal arrow-key + type-to-filter picker, stdlib only (readline raw mode).
+ * Stands in for inquire::Select from the jira reference — no dependency.
+ */
+
+const readline = require("node:readline");
+
+/**
+ * @param {string} prompt
+ * @param {{value:string,label:string,hint?:string}[]} items
+ * @returns {Promise<string>} chosen value (rejects on cancel / no TTY)
+ */
+function select(prompt, items) {
+  const stdin = process.stdin;
+  const stdout = process.stdout;
+
+  if (!stdin.isTTY) {
+    return Promise.reject(
+      new Error("no TTY for interactive picker — pass --client <target>"),
+    );
+  }
+
+  return new Promise((resolve, reject) => {
+    let filter = "";
+    let index = 0;
+
+    // Align the second column so hints line up like the jira picker.
+    const labelWidth = Math.max(...items.map((i) => i.label.length)) + 2;
+
+    const visible = () =>
+      filter
+        ? items.filter((i) =>
+            i.label.toLowerCase().includes(filter.toLowerCase()),
+          )
+        : items;
+
+    let lastLines = 0;
+
+    function render() {
+      const rows = visible();
+      if (index >= rows.length) index = Math.max(0, rows.length - 1);
+
+      const lines = [];
+      lines.push(`? ${prompt}${filter ? `  (filter: ${filter})` : ""}`);
+      for (let i = 0; i < rows.length; i++) {
+        const it = rows[i];
+        const marker = i === index ? ">" : " ";
+        const label = it.label.padEnd(labelWidth);
+        const hint = it.hint ? `(${it.hint})` : "";
+        lines.push(`${marker} ${label}${hint}`);
+      }
+      lines.push("[↑↓ to move, enter to select, type to filter]");
+
+      // Redraw in place: move cursor up over the previous block and clear.
+      if (lastLines > 0) {
+        readline.moveCursor(stdout, 0, -lastLines);
+      }
+      readline.cursorTo(stdout, 0);
+      readline.clearScreenDown(stdout);
+      stdout.write(lines.join("\n") + "\n");
+      lastLines = lines.length;
+    }
+
+    function cleanup() {
+      stdin.removeListener("keypress", onKeypress);
+      if (stdin.isTTY) stdin.setRawMode(false);
+      stdin.pause();
+    }
+
+    function onKeypress(str, key) {
+      if (!key) return;
+      const rows = visible();
+
+      if (key.ctrl && key.name === "c") {
+        cleanup();
+        stdout.write("\n");
+        return reject(new Error("selection cancelled"));
+      }
+      if (key.name === "escape") {
+        cleanup();
+        stdout.write("\n");
+        return reject(new Error("selection cancelled"));
+      }
+      if (key.name === "up") {
+        index = index > 0 ? index - 1 : Math.max(0, rows.length - 1);
+        return render();
+      }
+      if (key.name === "down") {
+        index = rows.length ? (index + 1) % rows.length : 0;
+        return render();
+      }
+      if (key.name === "return") {
+        if (!rows.length) return; // nothing matches the filter
+        const chosen = rows[index];
+        cleanup();
+        return resolve(chosen.value);
+      }
+      if (key.name === "backspace") {
+        filter = filter.slice(0, -1);
+        index = 0;
+        return render();
+      }
+      // printable char -> extend filter
+      if (str && str.length === 1 && !key.ctrl && !key.meta) {
+        filter += str;
+        index = 0;
+        return render();
+      }
+    }
+
+    readline.emitKeypressEvents(stdin);
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.on("keypress", onKeypress);
+    render();
+  });
+}
+
+module.exports = { select };

--- a/packages/mcp-npx/lib/python.js
+++ b/packages/mcp-npx/lib/python.js
@@ -1,0 +1,30 @@
+"use strict";
+
+/**
+ * Locate a Python >= 3.11 interpreter. Shared by the server launcher (bin)
+ * and the installer's prereq check.
+ */
+
+const { spawnSync } = require("node:child_process");
+
+const MIN_PY = [3, 11];
+
+function findPython() {
+  const candidates = process.env.SUITEST_PYTHON
+    ? [process.env.SUITEST_PYTHON]
+    : ["python3", "python"];
+  for (const cmd of candidates) {
+    const probe = spawnSync(cmd, [
+      "-c",
+      "import sys; print('%d.%d' % sys.version_info[:2])",
+    ]);
+    if (probe.status !== 0) continue;
+    const [maj, min] = String(probe.stdout).trim().split(".").map(Number);
+    if (maj > MIN_PY[0] || (maj === MIN_PY[0] && min >= MIN_PY[1])) {
+      return { cmd, version: `${maj}.${min}` };
+    }
+  }
+  return null;
+}
+
+module.exports = { MIN_PY, findPython };

--- a/packages/mcp-npx/package.json
+++ b/packages/mcp-npx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suiflex/suitest-mcp",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "publishConfig": {
     "access": "public"
   },
@@ -35,6 +35,7 @@
   },
   "files": [
     "bin/",
+    "lib/",
     "python/",
     "README.md",
     "LICENSE"
@@ -45,6 +46,6 @@
   "scripts": {
     "sync-python": "node scripts/sync-python.js",
     "prepack": "node scripts/sync-python.js",
-    "test": "node scripts/sync-python.js && node test/smoke.test.js"
+    "test": "node scripts/sync-python.js && node test/install.test.js && node test/smoke.test.js"
   }
 }

--- a/packages/mcp-npx/test/install.test.js
+++ b/packages/mcp-npx/test/install.test.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Installer unit checks — no framework, just node:assert, mirroring smoke.test.js.
+ * Exercises the pure logic (spec shape, JSON merge, idempotency, JSONC, paths)
+ * without touching real client configs: every target is redirected via env.
+ */
+
+"use strict";
+
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const install = require("../lib/install.js");
+const creds = require("../lib/creds.js");
+
+const ENV = { SUITEST_API_URL: "http://localhost:4000", SUITEST_API_KEY: "sk_test" };
+
+function tmp(name) {
+  const p = path.join(
+    os.tmpdir(),
+    `suitest-mcp-test-${process.pid}-${name}`,
+  );
+  fs.rmSync(p, { recursive: true, force: true });
+  return p;
+}
+
+function silence(fn) {
+  const orig = process.stdout.write.bind(process.stdout);
+  process.stdout.write = () => true;
+  try {
+    return fn();
+  } finally {
+    process.stdout.write = orig;
+  }
+}
+
+// 1. serverSpec shape (default mcpServers client)
+{
+  const { entry, snippet } = install.serverSpec("claude-code", ENV);
+  assert.strictEqual(entry.command, "npx");
+  assert.deepStrictEqual(entry.args, ["-y", "@suiflex/suitest-mcp"]);
+  assert.deepStrictEqual(entry.env, ENV);
+  assert.ok(snippet.mcpServers.suitest, "snippet has mcpServers.suitest");
+}
+
+// 2. opencode variant uses `mcp` + command array + environment
+{
+  const { entry, snippet } = install.serverSpec("opencode", ENV);
+  assert.strictEqual(entry.type, "local");
+  assert.deepStrictEqual(entry.command, ["npx", "-y", "@suiflex/suitest-mcp"]);
+  assert.deepStrictEqual(entry.environment, ENV);
+  assert.ok(snippet.mcp.suitest, "snippet has mcp.suitest");
+}
+
+// 3. write into an empty claude-code config, then idempotency + conflict
+{
+  const target = tmp("claude.json");
+  process.env.CLAUDE_CODE_CONFIG = target;
+  const opts = {
+    name: "suitest",
+    scope: "global",
+    env: ENV,
+    print: false,
+    dryRun: false,
+    force: false,
+  };
+
+  silence(() => install.installClient("claude-code", opts));
+  const written = JSON.parse(fs.readFileSync(target, "utf8"));
+  assert.strictEqual(written.mcpServers.suitest.command, "npx");
+
+  // second identical run is a no-op (no throw)
+  silence(() => install.installClient("claude-code", opts));
+
+  // different env without --force -> throws
+  const conflict = { ...opts, env: { ...ENV, SUITEST_API_KEY: "sk_other" } };
+  assert.throws(
+    () => silence(() => install.installClient("claude-code", conflict)),
+    /already exists/,
+  );
+
+  // with --force -> overwrites
+  silence(() =>
+    install.installClient("claude-code", { ...conflict, force: true }),
+  );
+  const after = JSON.parse(fs.readFileSync(target, "utf8"));
+  assert.strictEqual(after.mcpServers.suitest.env.SUITEST_API_KEY, "sk_other");
+
+  fs.rmSync(target, { force: true });
+  fs.rmSync(`${target}.bak`, { force: true });
+  delete process.env.CLAUDE_CODE_CONFIG;
+}
+
+// 4. stripJsonComments handles JSONC (opencode config)
+{
+  const parsed = install.loadJsonObject; // ensure export present
+  assert.strictEqual(typeof parsed, "function");
+  const jsonc = '// top\n{\n  /* block */\n  "mcp": { "a": 1 }\n}\n';
+  const stripped = install.stripJsonComments(jsonc);
+  assert.deepStrictEqual(JSON.parse(stripped), { mcp: { a: 1 } });
+}
+
+// 5. credsPath honours XDG_CONFIG_HOME
+{
+  const prev = process.env.XDG_CONFIG_HOME;
+  const prevDir = process.env.SUITEST_CONFIG_DIR;
+  delete process.env.SUITEST_CONFIG_DIR;
+  process.env.XDG_CONFIG_HOME = "/tmp/xdg-test";
+  assert.strictEqual(
+    creds.credsPath(),
+    path.join("/tmp/xdg-test", "suitest", "credentials.json"),
+  );
+  if (prev === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = prev;
+  if (prevDir !== undefined) process.env.SUITEST_CONFIG_DIR = prevDir;
+}
+
+process.stdout.write("install.test.js OK\n");


### PR DESCRIPTION
## What

Adds `suitest-mcp install` — a one-command installer that registers the Suitest MCP server into an IDE agent's config, so users no longer hand-edit `mcpServers` JSON per client.

## Usage

```bash
npx -y @suiflex/suitest-mcp login                        # save API URL + key once (TTY, chmod 600)
npx -y @suiflex/suitest-mcp install                      # interactive picker (arrow keys + type to filter)
npx -y @suiflex/suitest-mcp install --client claude-code # or target one directly
npx -y @suiflex/suitest-mcp doctor                       # inspect every client's config target
```

Bare `npx @suiflex/suitest-mcp` still starts the stdio server as before.

## Supported clients (11)

`claude-code` (global `~/.claude.json`, or `--scope project` → `./.mcp.json`), `claude-desktop`, `cursor`, `codex`, `gemini-cli`, `vscode`, `copilot-cli`, `opencode`, `antigravity`, `antigravity-cli`, `generic-json`.

File targets merge JSON/JSONC in place (with a `.bak` backup, idempotent, `--force` to overwrite); `codex`/`gemini`/`vscode` delegate to their own `mcp add` CLI. Every entry carries the `SUITEST_API_URL`/`SUITEST_API_KEY` env the server needs to boot — resolved from flags → env → saved credentials → interactive prompt.

## How it works

- `lib/creds.js` — credential persistence + resolution
- `lib/picker.js` — stdlib raw-mode TTY picker (no dependency)
- `lib/install.js` — client registry, JSON/JSONC merge, delegated adapters, `doctor`
- `lib/python.js` — shared Python-interpreter probe (extracted from the launcher)
- `bin/suitest-mcp.js` — routes `install` / `login` / `doctor`

## Testing

- `test/install.test.js` (framework-free `node:assert`): server-spec shapes, in-place config merge with idempotency and `--force` conflict, JSONC comment stripping, XDG credential path. Every target redirected via env — no real client config touched.
- Manually verified: interactive picker, delegated preview (`codex mcp add … --env …`), `--dry-run`/`--print`, opencode JSONC merge, and non-TTY guards for both picker and login.

> Note: full `npm test` also runs the existing `smoke.test.js`, which boots the server and therefore needs Python ≥ 3.11 in CI. `install.test.js` has no such requirement.

## Notes

Deliberately skipped for now (add when needed): an `uninstall` command, Windows `PATHEXT` probing, and any external TUI dependency.