### PR TITLE
chore(cla): add mulhamna to the CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -25,7 +25,7 @@ jobs:
           path-to-signatures: signatures/version1/cla.json
           path-to-document: https://github.com/suiflex/suitest/blob/main/CLA.md
           branch: cla-signatures
-          allowlist: badrus123,*[bot]
+          allowlist: badrus123,mulhamna,*[bot]
           custom-notsigned-comment: >
             Thanks for your contribution! Before we can merge, please read our
             [Contributor License Agreement](https://github.com/suiflex/suitest/blob/main/CLA.md)


### PR DESCRIPTION
## Why

The CLA Assistant workflow triggers on `pull_request_target`, which means GitHub always evaluates the workflow definition from the **base branch (`main`)** — never the PR head. So editing `cla.yml` inside a feature PR has no effect on that PR's own CLA check.

Adding the maintainer (`mulhamna`) to the allowlist on `main` lets their PRs pass the CLA gate without a per-PR signature comment. It also sidesteps the current `cla-signatures` branch-not-found error, since allowlisted authors skip signature recording entirely.

## Change

`allowlist: badrus123,*[bot]` → `allowlist: badrus123,mulhamna,*[bot]`

## After merge

Re-trigger the CLA check on open PRs (e.g. #9) by commenting `recheck` or pushing a new commit.