### PR TITLE
feat(mcp): reorder install login flow + Windows spawn fixes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in the repo.
+# Ordered by specificity: later matches win, so add narrower rules below.
+* @suiflex

--- a/packages/mcp-npx/lib/install.js
+++ b/packages/mcp-npx/lib/install.js
@@ -311,7 +311,10 @@ function installClient(clientId, { name, scope, env, print, dryRun, force }) {
       return;
     }
     for (const s of steps) {
-      const res = spawnSync(client.program, s, { stdio: "inherit" });
+      const res = spawnSync(client.program, s, {
+        stdio: "inherit",
+        windowsHide: true,
+      });
       if (res.error && res.error.code === "ENOENT") {
         throw new Error(
           `${client.program} CLI not found on PATH — install it, then retry.`,
@@ -319,7 +322,13 @@ function installClient(clientId, { name, scope, env, print, dryRun, force }) {
       }
       // `force` remove may fail if the entry is absent; ignore that one.
       if (res.status !== 0 && !(force && s[1] === "remove")) {
-        throw new Error(`${client.program} exited with status ${res.status}`);
+        throw new Error(
+          `${client.program} exited with status ${res.status}. ` +
+            "On Windows this can be an npm/child-tool job-object error " +
+            "(AssignProcessToJobObject 87) — try updating npm, or install a " +
+            "file-based client instead (claude-code / cursor / windsurf), which " +
+            "writes config directly without spawning a child CLI.",
+        );
       }
     }
     process.stdout.write(`Installed MCP entry '${name}' via ${client.label}\n`);

--- a/packages/mcp-npx/lib/install.js
+++ b/packages/mcp-npx/lib/install.js
@@ -432,14 +432,8 @@ async function runInteractive(opts) {
     );
   }
 
-  const items = CLIENT_ORDER.map((id) => ({
-    value: id,
-    label: CLIENTS[id].label,
-    hint: CLIENTS[id].hint,
-  }));
-  const clientId = await picker.select("Pick the MCP client to install into:", items);
-
-  const resolved = await creds.resolveCreds(opts);
+  // Login first, client last: (a) log in or not → (b) existing or new → (c) client.
+  const resolved = await interactiveLogin(opts);
   const env = {
     SUITEST_API_URL: resolved.apiUrl,
     SUITEST_API_KEY: resolved.apiKey,
@@ -449,7 +443,61 @@ async function runInteractive(opts) {
       "[warn] Using placeholder credentials — edit the config or run `suitest-mcp login`.\n",
     );
   }
+
+  const items = CLIENT_ORDER.map((id) => ({
+    value: id,
+    label: CLIENTS[id].label,
+    hint: CLIENTS[id].hint,
+  }));
+  const clientId = await picker.select("Pick the MCP client to install into:", items);
+
   installClient(clientId, { ...opts, env });
+}
+
+// Interactive credential step for `install`. Order: honor flags/env first (no
+// prompt), else ask "log in now?"; on yes, offer saved-vs-new; on skip, placeholder.
+// Returns the same shape as creds.resolveCreds ({apiUrl, apiKey, warn}).
+async function interactiveLogin(opts) {
+  // Non-interactive override: explicit flags or env win, no questions asked.
+  if (opts.apiUrl && opts.apiKey) {
+    return { apiUrl: opts.apiUrl, apiKey: opts.apiKey, warn: false };
+  }
+  if (process.env.SUITEST_API_URL && process.env.SUITEST_API_KEY) {
+    return {
+      apiUrl: process.env.SUITEST_API_URL,
+      apiKey: process.env.SUITEST_API_KEY,
+      warn: false,
+    };
+  }
+
+  const want = await picker.select("Set up Suitest login now?", [
+    { value: "yes", label: "Yes, log in", hint: "enter or reuse API URL + key" },
+    { value: "skip", label: "Skip", hint: "write placeholder, edit later" },
+  ]);
+  if (want === "skip") {
+    return { ...creds.PLACEHOLDER, warn: true };
+  }
+
+  const saved = creds.loadCreds();
+  let useExisting = false;
+  if (saved) {
+    const pick = await picker.select("Saved credentials found — use them?", [
+      { value: "existing", label: "Use existing", hint: saved.apiUrl },
+      { value: "new", label: "Enter new credentials" },
+    ]);
+    useExisting = pick === "existing";
+  }
+  if (useExisting) {
+    return { ...saved, warn: false };
+  }
+
+  const entered = await creds.promptCreds(saved || {});
+  if (!entered) {
+    throw new Error("login cancelled — both URL and key are required.");
+  }
+  creds.saveCreds(entered);
+  process.stdout.write(`Saved credentials to ${creds.credsPath()} (chmod 600).\n\n`);
+  return { ...entered, warn: false };
 }
 
 // --- arg parsing + entrypoints -------------------------------------------

--- a/packages/suitest-npx/lib/stack.js
+++ b/packages/suitest-npx/lib/stack.js
@@ -73,8 +73,13 @@ function spawnLogged(cmd, args, { env, logFile }) {
   const out = fs.openSync(logFile, "a");
   const child = spawn(cmd, args, {
     env,
-    detached: true,
+    // ponytail: detached only off-Windows — detached:true forces a job-object
+    // assign that fails with AssignProcessToJobObject (87) when the parent is
+    // already in a no-breakaway job (VS Code terminal / CI). unref() alone keeps
+    // the child alive after the parent exits.
+    detached: process.platform !== "win32",
     stdio: ["ignore", out, out],
+    windowsHide: true,
   });
   child.unref();
   fs.closeSync(out);


### PR DESCRIPTION
## Summary
- `suitest-mcp install` now drives login first: ask to log in, reuse saved creds or enter new, then pick the client — instead of picking the client blind and silently reusing saved creds.
- Fix the `AssignProcessToJobObject (87)` error our own detached spawn triggers on Windows.
- Clearer failure message when a delegated client CLI dies (esp. the Windows npm/child-tool job-object case), pointing users to file-based clients.
- Add a default CODEOWNERS.

## Changes
- **packages/mcp-npx/lib/install.js**
  - New `interactiveLogin(opts)`: flags/env short-circuit → "log in or skip" → "use saved or enter new" → prompt. `runInteractive` calls it before the client picker.
  - Delegated `spawnSync` gets `windowsHide: true`; non-ENOENT failure now explains the possible AssignProcessToJobObject (87) origin and suggests file-based clients (claude-code / cursor / windsurf).
- **packages/suitest-npx/lib/stack.js**
  - `spawnLogged` uses `detached: process.platform !== "win32"` + `windowsHide: true`. `unref()` alone keeps the child alive after the parent exits.
- **.github/CODEOWNERS** — `* @suiflex` default owner.

## Notes
- The literal `suitest-mcp install` path has no detached spawn of its own; a (87) there comes from the delegated child CLI or the npm/npx Windows wrapper, outside this repo. The actionable fix is the file-based-client hint; the detached fix covers `suitest up` / `onboard`.

## Test plan
- [x] `node --test test/install.test.js` (mcp-npx) — pass
- [x] `node --test test/stack.test.js` (suitest-npx) — pass
- [x] `node -c` syntax check both edited files
- [x] Manual macOS TTY: `install` shows login → existing/new → client order
- [ ] Manual Windows: `suitest up` no longer throws (87); child stays alive after parent exit