### PR TITLE
ci(mcp): VERSION file + release-please for mcp-npx

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,29 @@
+name: release-please
+
+# Version + changelog automation, scoped to packages/mcp-npx for now.
+# On every push to main, release-please opens/updates a release PR that bumps
+# packages/mcp-npx/package.json + VERSION from the conventional commits since the
+# last release. Merging that PR tags `mcp-v<version>`, which triggers the publish
+# job in release-mcp.yml.
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          # A PAT is required for the release tag to trigger release-mcp.yml:
+          # tags pushed with the default GITHUB_TOKEN do NOT re-trigger other
+          # workflows. Set RELEASE_PLEASE_TOKEN (repo/workflow scope) to enable
+          # auto-publish; without it the tag is still created but the npm/PyPI
+          # publish must be started manually (re-push the tag or run the workflow).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,3 @@
+{
+  "packages/mcp-npx": "0.1.5"
+}

--- a/packages/mcp-npx/VERSION
+++ b/packages/mcp-npx/VERSION
@@ -1,0 +1,1 @@
+0.1.5 # x-release-please-version

--- a/packages/mcp-npx/bin/suitest-mcp.js
+++ b/packages/mcp-npx/bin/suitest-mcp.js
@@ -89,11 +89,27 @@ function parseInitFlags(argv) {
   return out;
 }
 
+// VERSION is the release-please-maintained source of truth (package.json is kept
+// in sync for npm). The bare version is the first whitespace-delimited token; the
+// trailing `# x-release-please-version` marker is what lets release-please bump it.
+function readVersion() {
+  try {
+    const raw = fs.readFileSync(path.join(PKG_ROOT, "VERSION"), "utf8");
+    const v = raw.split(/\s+/)[0].trim();
+    if (v) return v;
+  } catch {
+    // VERSION absent (e.g. dev checkout mid-edit) — fall back to package.json.
+  }
+  return JSON.parse(
+    fs.readFileSync(path.join(PKG_ROOT, "package.json"), "utf8"),
+  ).version;
+}
+
 function printVersion() {
   const pkg = JSON.parse(
     fs.readFileSync(path.join(PKG_ROOT, "package.json"), "utf8"),
   );
-  process.stdout.write(`${pkg.name} ${pkg.version}\n`);
+  process.stdout.write(`${pkg.name} ${readVersion()}\n`);
 }
 
 // Resolve the bundled python + PYTHONPATH-augmented env, or emit the same

--- a/packages/mcp-npx/package.json
+++ b/packages/mcp-npx/package.json
@@ -37,6 +37,7 @@
     "bin/",
     "lib/",
     "python/",
+    "VERSION",
     "README.md",
     "LICENSE"
   ],

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "separate-pull-requests": true,
+  "include-component-in-tag": true,
+  "packages": {
+    "packages/mcp-npx": {
+      "release-type": "node",
+      "component": "mcp",
+      "package-name": "@suiflex/suitest-mcp",
+      "extra-files": ["VERSION"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- mcp-npx version now lives in a human-readable `VERSION` file (mirror), read by `--version`; `package.json` stays the version npm publishes.
- Add release-please (manifest mode, scoped to `packages/mcp-npx`) to bump both files from conventional commits and tag `mcp-v<version>`, which the existing `release-mcp.yml` consumes to publish.

## Changes
- **packages/mcp-npx/VERSION** — `0.1.5` with a `# x-release-please-version` marker so release-please can bump the bare file.
- **packages/mcp-npx/bin/suitest-mcp.js** — `readVersion()` reads VERSION (first token), falls back to package.json.
- **packages/mcp-npx/package.json** — add `VERSION` to published `files`.
- **release-please-config.json** / **.release-please-manifest.json** — manifest config, component `mcp`, `include-component-in-tag` → tag `mcp-v*`.
- **.github/workflows/release-please.yml** — opens/updates the release PR on push to main.

## How it flows
`commit → release-please PR (bump package.json + VERSION) → merge → tag mcp-vX.Y.Z → release-mcp.yml publishes npm + PyPI`

## Notes / follow-up
- **PAT required for auto-publish:** tags pushed with the default `GITHUB_TOKEN` do not re-trigger tag-push workflows. Set repo secret `RELEASE_PLEASE_TOKEN` (PAT, repo/workflow scope) to let the release tag trigger `release-mcp.yml`. Without it the tag is still created; publish is triggered manually. Workflow already falls back to `GITHUB_TOKEN`.
- Scoped to mcp-npx only for now; other packages can be added to `release-please-config.json` later.

## Test plan
- [x] `node packages/mcp-npx/bin/suitest-mcp.js --version` → `@suiflex/suitest-mcp 0.1.5`
- [x] `node -c` bin syntax; config + manifest JSON valid; workflow YAML valid
- [ ] After merge: confirm release-please opens a Release PR on next conventional commit
- [ ] Set `RELEASE_PLEASE_TOKEN` secret to enable auto-publish