### PR TITLE
ci: multi-package release-please + CI path gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,48 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Compute which areas a PR touches so downstream jobs only run when relevant.
+  # On push to main / tags the filter is bypassed (see each job's `if:`) — main is
+  # the integration point and always gets the full matrix.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      python: ${{ steps.filter.outputs.python }}
+      web: ${{ steps.filter.outputs.web }}
+      mcp: ${{ steps.filter.outputs.mcp }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            python:
+              - 'apps/api/**'
+              - 'apps/runner/**'
+              - 'packages/agent/**'
+              - 'packages/core/**'
+              - 'packages/db/**'
+              - 'packages/mcp/**'
+              - 'packages/shared/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.github/workflows/ci.yml'
+            web:
+              - 'apps/web/**'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/ci.yml'
+            mcp:
+              - 'packages/mcp-npx/**'
+              - 'packages/lifecycle/**'
+              - '.github/workflows/ci.yml'
+
   python-lint:
     name: Python lint (ruff + mypy)
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -58,6 +98,8 @@ jobs:
 
   python-test:
     name: Python tests (pytest)
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
 
     services:
@@ -120,6 +162,8 @@ jobs:
 
   ts-lint:
     name: TypeScript lint (tsc + eslint)
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -152,6 +196,8 @@ jobs:
 
   ts-test:
     name: TypeScript tests (vitest)
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -185,7 +231,8 @@ jobs:
     # `vite preview`, and runs Lighthouse against the three primary screens.
     # Assertions live in apps/web/lighthouserc.json.
     name: Web Lighthouse (soft fail)
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.web == 'true'
     continue-on-error: true
     runs-on: ubuntu-latest
     defaults:
@@ -286,6 +333,8 @@ jobs:
   # ------------------------------------------------------------------------
   mcp-package:
     name: MCP package (npx + uvx smoke)
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.mcp == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,10 +1,13 @@
 name: release-please
 
-# Version + changelog automation, scoped to packages/mcp-npx for now.
-# On every push to main, release-please opens/updates a release PR that bumps
-# packages/mcp-npx/package.json + VERSION from the conventional commits since the
-# last release. Merging that PR tags `mcp-v<version>`, which triggers the publish
-# job in release-mcp.yml.
+# Version + changelog automation for the three published npm packages:
+#   - packages/mcp-npx     → @suiflex/suitest-mcp  → tag mcp-v*      → release-mcp.yml
+#   - sdk/typescript       → @suiflex/suitest-sdk  → tag tssdk-v*    → release-ts-sdk.yml
+#   - packages/suitest-npx → @suiflex/suitest      → tag launcher-v* → release-launcher.yml
+# On every push to main, release-please opens/updates a separate release PR per
+# package (separate-pull-requests) that bumps its package.json (+ VERSION for mcp)
+# from the conventional commits since that package's last release. Merging a PR
+# tags `<component>-v<version>`, which triggers the matching publish workflow.
 on:
   push:
     branches: [main]

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,5 @@
 {
-  "packages/mcp-npx": "0.2.0"
+  "packages/mcp-npx": "0.2.0",
+  "sdk/typescript": "0.1.1",
+  "packages/suitest-npx": "0.1.7"
 }

--- a/docs-site/src/components/landing/Closing.astro
+++ b/docs-site/src/components/landing/Closing.astro
@@ -4,6 +4,9 @@ import bookIcon from "@phosphor-icons/core/assets/regular/book-open.svg?raw";
 
 const year = new Date().getFullYear();
 
+// Product Hunt launch badge (official embed markup — kept verbatim, self-contained inline styles).
+const productHuntBadge = `<div style="font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, sans-serif; border: 1px solid rgb(224, 224, 224); border-radius: 12px; padding: 20px; max-width: 500px; background: rgb(255, 255, 255); box-shadow: rgba(0, 0, 0, 0.05) 0px 2px 8px;"><div style="display: flex; align-items: center; gap: 12px; margin-bottom: 12px;"><img alt="Suitest" src="https://ph-files.imgix.net/db5194df-355f-4728-8d3c-bc73d46f109e.svg?auto=compress,format&amp;codec=mozjpeg&amp;cs=strip&amp;fit=crop&amp;h=80&amp;w=80" style="width: 64px; height: 64px; border-radius: 8px; object-fit: cover; flex-shrink: 0;"><div style="flex: 1 1 0%; min-width: 0px;"><h3 style="margin: 0px; font-size: 18px; font-weight: 600; color: rgb(26, 26, 26); line-height: 1.3; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">Suitest</h3><p style="margin: 4px 0px 0px; font-size: 14px; color: rgb(102, 102, 102); line-height: 1.4; overflow: hidden; text-overflow: ellipsis; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;">Free E2E AI testing &amp; MCP server. A TestSprite alternative.</p></div></div><a href="https://www.producthunt.com/products/suitest?embed=true&amp;utm_source=embed&amp;utm_medium=post_embed" target="_blank" rel="noopener" style="display: inline-flex; align-items: center; gap: 4px; margin-top: 12px; padding: 8px 16px; background: rgb(255, 97, 84); color: rgb(255, 255, 255); text-decoration: none; border-radius: 8px; font-size: 14px; font-weight: 600;">Check it out on Product Hunt →</a></div>`;
+
 const footCols = [
   {
     title: "Product",
@@ -77,6 +80,7 @@ const footCols = [
           Open-source, MCP-native testing platform. Manual test management,
           deterministic runs, optional AI.
         </p>
+        <div class="ph-badge" set:html={productHuntBadge} />
       </div>
 
       {
@@ -157,6 +161,9 @@ const footCols = [
     line-height: 1.65;
     color: var(--text-3);
     max-width: 34ch;
+  }
+  .ph-badge {
+    margin-top: 20px;
   }
   .foot-col h3 {
     margin: 0 0 14px;

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,16 @@
       "component": "mcp",
       "package-name": "@suiflex/suitest-mcp",
       "extra-files": ["VERSION"]
+    },
+    "sdk/typescript": {
+      "release-type": "node",
+      "component": "tssdk",
+      "package-name": "@suiflex/suitest-sdk"
+    },
+    "packages/suitest-npx": {
+      "release-type": "node",
+      "component": "launcher",
+      "package-name": "@suiflex/suitest"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Track all three published npm packages with release-please (not just mcp-npx), so ts-sdk and launcher stop relying on hand-cut tags.
- Stop running the full CI matrix on every PR — gate jobs by the paths a PR actually touches.
- Add the Product Hunt launch badge to the docs-site landing footer.

## Changes
- **release-please**: add `sdk/typescript` (component `tssdk`) and `packages/suitest-npx` (component `launcher`) to `release-please-config.json`; seed `.release-please-manifest.json` from current published versions (continues from existing `tssdk-v0.1.1` / `launcher-v0.1.7` tags). Both keep `release-type: node` — package.json is their version source of truth, so no VERSION mirror is needed (that is mcp-npx-specific: its bin reads `VERSION`). Refresh the workflow header comment.
- **CI**: add a `dorny/paths-filter` `changes` job that classifies the diff once into python/web/mcp; gate `python-lint`, `python-test`, `ts-lint`, `ts-test`, `web-lighthouse`, `mcp-package` with `needs: changes` + `if:`. Pushes to `main`/tags bypass the filter and run the full matrix.
- **docs-site**: render the official Product Hunt embed card in the landing footer brand column via `set:html`.

## Test plan
- [ ] release-please opens a separate release PR per package once qualifying commits land on `main`
- [ ] TS-only PR runs only `ts-lint`/`ts-test`/`web-lighthouse` (+`changes`); python & mcp jobs skip
- [ ] `packages/mcp-npx/**` PR runs `mcp-package`
- [ ] push to `main` runs the full matrix
- [ ] docs-site builds and the Product Hunt badge renders in the footer