### PR TITLE
fix: local-runtime + MCP client compatibility (heatmap, eval, Playwright, Codex/Copilot)

### DIFF
--- a/apps/api/src/suitest_api/routers/analytics.py
+++ b/apps/api/src/suitest_api/routers/analytics.py
@@ -184,13 +184,19 @@ async def analytics_flaky(
 @router.get("/analytics/heatmap", response_model=list[HeatmapCell])
 async def analytics_heatmap(
     project_id: str = Query(alias="projectId"),
+    days: int | None = Query(default=None, ge=1, le=365),
     period: str = Query(default="14d"),
     ctx: TenantContext = Depends(require_workspace_membership),
     session: AsyncSession = Depends(get_async_session),
 ) -> list[HeatmapCell]:
-    """Run-count grid (day x hour) over the window (docs/API.md §3.8)."""
+    """Run-count grid (day x hour) over the window (docs/API.md §3.8).
+
+    Accepts ``days=<n>`` (what the web client sends) or ``period=<n>d``; ``days``
+    wins when both are present.
+    """
     await _project_or_404(session, project_id, ctx.workspace_id)
-    since = datetime.now(tz=UTC) - _parse_period(period)
+    window = timedelta(days=days) if days is not None else _parse_period(period)
+    since = datetime.now(tz=UTC) - window
     cells = await RunRepo(session).heatmap_cells(project_id, since)
     return [HeatmapCell(day=day, hour=hour, count=count) for day, hour, count in cells]
 

--- a/apps/api/src/suitest_api/routers/eval_runs.py
+++ b/apps/api/src/suitest_api/routers/eval_runs.py
@@ -41,7 +41,33 @@ _ZERO_MODEL_ID = "deterministic-zero"
 
 
 def _fixtures_dir() -> Path:
-    return Path(os.environ.get("SUITEST_EVAL_FIXTURES_DIR", "eval/fixtures"))
+    """Resolve the golden eval fixtures dir independent of the process cwd.
+
+    The packaged deployment runs uvicorn with an arbitrary cwd, so the old
+    cwd-relative ``eval/fixtures`` default 400'd ("fixtures dir not found").
+    Resolve in order: explicit env override → cwd-relative → bundled package
+    data → repo checkout (walking up from this file). Falls back to the
+    cwd-relative default so the 400 message stays actionable.
+    """
+    env = os.environ.get("SUITEST_EVAL_FIXTURES_DIR")
+    if env:
+        return Path(env)
+
+    candidates = [Path("eval/fixtures").resolve()]
+    # Bundled as package data — real deployments ship fixtures inside the wheel.
+    try:
+        from importlib.resources import files
+
+        candidates.append(Path(str(files("suitest_api"))) / "eval_fixtures")
+    except (ModuleNotFoundError, TypeError, OSError):
+        pass
+    # Dev checkout: walk up from this module to a repo root holding eval/fixtures.
+    candidates.extend(parent / "eval" / "fixtures" for parent in Path(__file__).resolve().parents)
+
+    for candidate in candidates:
+        if candidate.is_dir():
+            return candidate
+    return Path("eval/fixtures")
 
 
 def _to_public(row: EvalRun) -> EvalRunPublic:

--- a/apps/api/tests/test_eval_fixtures_resolver.py
+++ b/apps/api/tests/test_eval_fixtures_resolver.py
@@ -1,0 +1,33 @@
+"""Unit tests for eval fixtures dir resolution (no DB, no harness).
+
+Regression for the packaged-deploy 400 — uvicorn runs with an arbitrary cwd, so
+the old cwd-relative ``eval/fixtures`` default raised "fixtures dir not found".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from suitest_api.routers.eval_runs import _fixtures_dir
+
+
+def test_env_override_wins(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("SUITEST_EVAL_FIXTURES_DIR", str(tmp_path))
+    assert _fixtures_dir() == tmp_path
+
+
+def test_resolves_cwd_relative(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("SUITEST_EVAL_FIXTURES_DIR", raising=False)
+    (tmp_path / "eval" / "fixtures").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+    assert _fixtures_dir() == (tmp_path / "eval" / "fixtures").resolve()
+
+
+def test_resolves_repo_checkout_when_cwd_has_none(monkeypatch, tmp_path: Path) -> None:
+    # cwd without eval/fixtures — must still resolve via the walk-up from __file__
+    # (this repo checkout ships apps/api under a root that has eval/fixtures).
+    monkeypatch.delenv("SUITEST_EVAL_FIXTURES_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+    resolved = _fixtures_dir()
+    assert resolved.is_dir()
+    assert resolved.name == "fixtures"

--- a/apps/api/tests/test_eval_fixtures_resolver.py
+++ b/apps/api/tests/test_eval_fixtures_resolver.py
@@ -8,22 +8,25 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from suitest_api.routers.eval_runs import _fixtures_dir
 
 
-def test_env_override_wins(monkeypatch, tmp_path: Path) -> None:
+def test_env_override_wins(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("SUITEST_EVAL_FIXTURES_DIR", str(tmp_path))
     assert _fixtures_dir() == tmp_path
 
 
-def test_resolves_cwd_relative(monkeypatch, tmp_path: Path) -> None:
+def test_resolves_cwd_relative(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.delenv("SUITEST_EVAL_FIXTURES_DIR", raising=False)
     (tmp_path / "eval" / "fixtures").mkdir(parents=True)
     monkeypatch.chdir(tmp_path)
     assert _fixtures_dir() == (tmp_path / "eval" / "fixtures").resolve()
 
 
-def test_resolves_repo_checkout_when_cwd_has_none(monkeypatch, tmp_path: Path) -> None:
+def test_resolves_repo_checkout_when_cwd_has_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     # cwd without eval/fixtures — must still resolve via the walk-up from __file__
     # (this repo checkout ships apps/api under a root that has eval/fixtures).
     monkeypatch.delenv("SUITEST_EVAL_FIXTURES_DIR", raising=False)

--- a/packages/db/src/suitest_db/repositories/runs.py
+++ b/packages/db/src/suitest_db/repositories/runs.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
-from sqlalchemy import extract, func, select
+from sqlalchemy import func, select
 from suitest_db.models.case import TestCase, TestStep
 from suitest_db.models.project import Project, Suite
 from suitest_db.models.run import Artifact, Run, RunStep
@@ -163,19 +163,22 @@ class RunRepo(AsyncRepository[Run, RunCreate, RunUpdate]):
     ) -> Sequence[tuple[datetime, int, int]]:
         """Run counts grouped by ``(day, hour)`` since ``since`` (docs/API.md §3.8).
 
-        Returns rows of ``(day_truncated, hour_of_day, count)``; the day is the
-        ``date_trunc('day', created_at)`` timestamp and hour is 0-23.
+        Returns rows of ``(day_truncated, hour_of_day, count)`` ascending. Buckets
+        in Python so the query stays engine-agnostic: ``date_trunc`` is
+        Postgres-only and raised ``no such function`` (500) on SQLite, the
+        LOCAL/ZERO default backend.
         """
-        day = func.date_trunc("day", Run.created_at).label("day")
-        hour = extract("hour", Run.created_at).label("hour")
-        stmt = (
-            select(day, hour, func.count(Run.id))
-            .where(Run.project_id == project_id, Run.created_at >= since)
-            .group_by(day, hour)
-            .order_by(day.asc(), hour.asc())
+        stmt = select(Run.created_at).where(Run.project_id == project_id, Run.created_at >= since)
+        created_ats = (await self.session.execute(stmt)).scalars().all()
+        counts: dict[tuple[datetime, int], int] = {}
+        for created in created_ats:
+            day = created.replace(hour=0, minute=0, second=0, microsecond=0)
+            key = (day, created.hour)
+            counts[key] = counts.get(key, 0) + 1
+        return sorted(
+            ((day, hour, count) for (day, hour), count in counts.items()),
+            key=lambda row: (row[0], row[1]),
         )
-        rows = (await self.session.execute(stmt)).all()
-        return [(d, int(h), int(count)) for d, h, count in rows]
 
     async def get_steps(self, run_id: str) -> Sequence[RunStep]:
         stmt = select(RunStep).where(RunStep.run_id == run_id).order_by(RunStep.step_order.asc())

--- a/packages/db/tests/test_sqlite_dialect.py
+++ b/packages/db/tests/test_sqlite_dialect.py
@@ -62,6 +62,63 @@ async def test_create_local_schema_builds_full_schema(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_heatmap_cells_on_sqlite(tmp_path: Path) -> None:
+    """Local mode: ``heatmap_cells`` must bucket by (day, hour) without PG-only SQL.
+
+    Regression for the analytics heatmap 500 — ``sqlite3.OperationalError: no
+    such function: date_trunc`` on the LOCAL/ZERO SQLite backend. The query now
+    buckets in Python so it is engine-agnostic.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+    from suitest_db.bootstrap import create_local_schema
+    from suitest_db.engine import make_engine
+    from suitest_db.ids import new_id
+    from suitest_db.models.project import Project
+    from suitest_db.models.run import Run
+    from suitest_db.models.workspace import Workspace
+    from suitest_db.repositories.runs import RunRepo
+    from suitest_db.settings import DbSettings
+    from suitest_shared.domain.enums import RunStatus, RunTrigger, Tier
+
+    settings = DbSettings(database_url=f"sqlite+aiosqlite:///{tmp_path / 'hm.db'}")
+    engine = make_engine(settings)
+    await create_local_schema(engine)
+
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        ws = Workspace(slug=f"ws-{new_id()}", name="WS")
+        session.add(ws)
+        await session.flush()
+        project = Project(workspace_id=ws.id, slug=f"p-{new_id()}", name="P")
+        session.add(project)
+        await session.flush()
+
+        base = datetime(2026, 7, 9, 21, 30, tzinfo=UTC)
+        # two runs in the same day+hour, one the next day at a different hour
+        for created in (base, base + timedelta(minutes=5), base + timedelta(days=1, hours=2)):
+            session.add(
+                Run(
+                    public_id=f"R-{new_id()}",
+                    project_id=project.id,
+                    name="Run",
+                    trigger=RunTrigger.MANUAL,
+                    status=RunStatus.PASS,
+                    tier_at_runtime=Tier.ZERO,
+                    created_at=created,
+                )
+            )
+        await session.flush()
+
+        cells = await RunRepo(session).heatmap_cells(project.id, base - timedelta(days=2))
+    await engine.dispose()
+
+    counts = {(day.date().isoformat(), hour): count for day, hour, count in cells}
+    assert counts == {("2026-07-09", 21): 2, ("2026-07-10", 23): 1}
+
+
+@pytest.mark.asyncio
 async def test_public_id_generated_on_sqlite(tmp_path: Path) -> None:
     """Local mode: the before_insert listener must not need the PG plpgsql function.
 

--- a/packages/lifecycle/src/suitest_lifecycle/blackbox/mcp.py
+++ b/packages/lifecycle/src/suitest_lifecycle/blackbox/mcp.py
@@ -13,13 +13,18 @@ enough for the no-config quick path.
 
 from __future__ import annotations
 
+import functools
 import json
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from suitest_lifecycle.blackbox.models import BlackboxUiConfig, DiscoveryResult
+from suitest_lifecycle.frontend_runtime import ensure_browser
 from suitest_lifecycle.models import Mode
 from suitest_lifecycle.paths import Paths, build_paths
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def _envelope(
@@ -607,7 +612,42 @@ def blackbox_publish_results(**kwargs: Any) -> dict[str, Any]:
     )
 
 
-BLACKBOX_TOOLS = {
+# Tools that drive a real browser (need the Playwright package + Chromium).
+# bootstrap_project opens a local HTTP wizard in the user's own browser, and the
+# graph/generate/publish/summarize tools only read saved JSON — none need
+# Playwright, so they are NOT gated.
+_BROWSER_DRIVING = frozenset(
+    {
+        "blackbox_discover_app",
+        "blackbox_detect_login",
+        "blackbox_perform_login",
+        "blackbox_crawl_routes",
+        "blackbox_analyze_page",
+        "blackbox_run_playwright_tests",
+    }
+)
+
+
+def _guard_browser(fn: Callable[..., dict[str, Any]]) -> Callable[..., dict[str, Any]]:
+    """Provision Playwright + Chromium before a browser tool runs; on failure
+    return a clear envelope instead of letting a raw ImportError crash the tool
+    (the "sometimes produces no output" symptom)."""
+
+    @functools.wraps(fn)
+    def wrapper(**kwargs: Any) -> dict[str, Any]:
+        status = ensure_browser()
+        if not status.ready:
+            return _envelope(
+                False,
+                f"browser runtime unavailable: {status.detail}",
+                errors=[status.detail],
+            )
+        return fn(**kwargs)
+
+    return wrapper
+
+
+_RAW_BLACKBOX_TOOLS = {
     "blackbox_publish_results": blackbox_publish_results,
     "bootstrap_project": bootstrap_project,
     "blackbox_discover_app": blackbox_discover_app,
@@ -622,4 +662,9 @@ BLACKBOX_TOOLS = {
     "blackbox_summarize_findings": blackbox_summarize_findings,
 }
 
-__all__ = ["BLACKBOX_TOOLS", *BLACKBOX_TOOLS.keys()]
+BLACKBOX_TOOLS = {
+    name: (_guard_browser(fn) if name in _BROWSER_DRIVING else fn)
+    for name, fn in _RAW_BLACKBOX_TOOLS.items()
+}
+
+__all__ = ["BLACKBOX_TOOLS", *_RAW_BLACKBOX_TOOLS.keys()]

--- a/packages/lifecycle/src/suitest_lifecycle/frontend_runtime.py
+++ b/packages/lifecycle/src/suitest_lifecycle/frontend_runtime.py
@@ -1,15 +1,21 @@
 """Frontend execution runtime — Suitest owns the browser, not the user.
 
 Like TestSprite (which bundles its own browser-driving agent), Suitest ships the
-Playwright runtime and auto-provisions the Chromium binary on first use. The
-person testing their app only runs their app — they never `pip install playwright`
-or `playwright install` themselves.
+Playwright runtime and auto-provisions BOTH the Playwright package and the
+Chromium binary on first use. The person testing their app only runs their app —
+they never ``pip install playwright`` or ``playwright install`` themselves.
 
-``ensure_browser`` is idempotent and fast when the browser is already cached.
+``ensure_browser`` is idempotent and fast when everything is already cached: it
+installs the ``playwright`` package into the running interpreter (or its venv)
+when missing, then provisions Chromium. It degrades to a clear, actionable
+message instead of letting a raw ``ModuleNotFoundError`` crash the tool.
 """
 
 from __future__ import annotations
 
+import contextlib
+import importlib
+import site
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -27,6 +33,78 @@ def _playwright_importable() -> bool:
     except ImportError:
         return False
     return True
+
+
+def _pip_install_variants(pkg: str) -> list[list[str]]:
+    """pip argv variants to try in order, adapting to the interpreter.
+
+    - Inside a venv (``sys.prefix != sys.base_prefix``): install into the venv
+      site — no ``--user`` (disallowed in venvs), no PEP-668 marker to fight.
+    - System/Homebrew/distro interpreter: prefer ``--user`` (contained to the
+      user site, importable by this interpreter AND the subprocesses that run
+      the generated tests), with a ``--break-system-packages`` fallback for
+      PEP-668 "externally-managed" environments (Homebrew, Debian).
+    """
+    base = [sys.executable, "-m", "pip", "install", "--upgrade", pkg]
+    in_venv = sys.prefix != sys.base_prefix
+    if in_venv:
+        return [base]
+    return [[*base, "--user"], [*base, "--user", "--break-system-packages"]]
+
+
+def _ensure_pip() -> None:
+    """Best-effort: bootstrap pip via ensurepip when the interpreter lacks it
+    (minimal venvs / stripped pythons ship without pip)."""
+    try:
+        import pip  # noqa: F401
+
+        return
+    except ImportError:
+        pass
+    with contextlib.suppress(subprocess.TimeoutExpired, OSError):
+        subprocess.run(
+            [sys.executable, "-m", "ensurepip", "--upgrade"],
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+
+
+def _make_importable_in_process() -> None:
+    """Surface a just-installed package to the RUNNING interpreter without a
+    restart. A server started before the user-site dir existed never got it on
+    ``sys.path`` (``site`` only adds user-site at startup, and only if it
+    exists) — add it now and drop import caches."""
+    usersite = site.getusersitepackages()
+    if isinstance(usersite, str):
+        site.addsitedir(usersite)
+    importlib.invalidate_caches()
+
+
+def _install_playwright_package(timeout_sec: int) -> BrowserStatus:
+    _ensure_pip()
+    detail = "pip unavailable"
+    for argv in _pip_install_variants("playwright"):
+        try:
+            proc = subprocess.run(argv, capture_output=True, text=True, timeout=timeout_sec)
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            detail = str(exc)
+            continue
+        if proc.returncode == 0:
+            _make_importable_in_process()
+            if _playwright_importable():
+                return BrowserStatus(True, "playwright package installed on demand")
+            detail = "pip reported success but playwright is still not importable"
+            continue
+        tail = (proc.stderr or proc.stdout or "").strip().splitlines()[-3:]
+        detail = " | ".join(tail) if tail else f"pip exited {proc.returncode}"
+    return BrowserStatus(
+        False,
+        "could not auto-install the playwright package "
+        f"(interpreter: {sys.executable}): {detail}. "
+        "Install it manually: "
+        f"'{sys.executable} -m pip install playwright'",
+    )
 
 
 def _chromium_present() -> bool:
@@ -47,18 +125,7 @@ def _chromium_present() -> bool:
         return False
 
 
-def ensure_browser(*, auto_install: bool = True, timeout_sec: int = 600) -> BrowserStatus:
-    """Ensure Playwright + Chromium are usable; install the browser if missing."""
-    if not _playwright_importable():
-        return BrowserStatus(
-            False,
-            "playwright not installed in the Suitest environment "
-            "(install the 'frontend' extra: pip install 'suiflex-suitest-lifecycle[frontend]')",
-        )
-    if _chromium_present():
-        return BrowserStatus(True, "chromium already installed")
-    if not auto_install:
-        return BrowserStatus(False, "chromium not installed (auto-install disabled)")
+def _install_chromium(timeout_sec: int) -> BrowserStatus:
     try:
         proc = subprocess.run(
             [sys.executable, "-m", "playwright", "install", "chromium"],
@@ -67,11 +134,34 @@ def ensure_browser(*, auto_install: bool = True, timeout_sec: int = 600) -> Brow
             timeout=timeout_sec,
         )
     except (subprocess.TimeoutExpired, OSError) as exc:
-        return BrowserStatus(False, f"playwright install failed: {exc}")
+        return BrowserStatus(False, f"playwright install chromium failed: {exc}")
     if proc.returncode != 0:
         tail = (proc.stderr or proc.stdout or "").strip().splitlines()[-3:]
         return BrowserStatus(False, "playwright install chromium failed: " + " | ".join(tail))
     return BrowserStatus(True, "chromium installed on demand")
+
+
+def ensure_browser(*, auto_install: bool = True, timeout_sec: int = 600) -> BrowserStatus:
+    """Ensure the Playwright package + Chromium are usable in this interpreter.
+
+    Idempotent: no-op fast path when both are already present. Installs whatever
+    is missing when ``auto_install`` is set; otherwise reports what's missing.
+    """
+    if not _playwright_importable():
+        if not auto_install:
+            return BrowserStatus(
+                False,
+                "playwright package not installed and auto-install disabled "
+                f"(run: {sys.executable} -m pip install playwright)",
+            )
+        status = _install_playwright_package(timeout_sec)
+        if not status.ready:
+            return status
+    if _chromium_present():
+        return BrowserStatus(True, "ready")
+    if not auto_install:
+        return BrowserStatus(False, "chromium not installed (auto-install disabled)")
+    return _install_chromium(timeout_sec)
 
 
 __all__ = ["BrowserStatus", "ensure_browser"]

--- a/packages/lifecycle/src/suitest_lifecycle/mcp_server.py
+++ b/packages/lifecycle/src/suitest_lifecycle/mcp_server.py
@@ -198,6 +198,19 @@ def handle(message: dict[str, object]) -> dict[str, object] | None:
         return None  # notification, no response
     if method == "tools/list":
         return _ok(req_id, {"tools": [_tool_schema(n) for n in TOOLS]})
+    # Standard utility/discovery methods that strict clients (Codex, GitHub
+    # Copilot CLI) send on connect and as health checks. We expose no
+    # resources/prompts, but MUST answer these instead of returning -32601:
+    # a JSON-RPC error to ``ping`` makes those clients mark the server broken
+    # (works in Cursor/Claude Code/Antigravity only because they never ping).
+    if method == "ping":
+        return _ok(req_id, {})
+    if method == "resources/list":
+        return _ok(req_id, {"resources": []})
+    if method == "resources/templates/list":
+        return _ok(req_id, {"resourceTemplates": []})
+    if method == "prompts/list":
+        return _ok(req_id, {"prompts": []})
     if method == "tools/call":
         params = message.get("params") or {}
         if not isinstance(params, dict):

--- a/packages/lifecycle/tests/test_frontend_runtime.py
+++ b/packages/lifecycle/tests/test_frontend_runtime.py
@@ -1,0 +1,67 @@
+"""Unit tests for on-demand Playwright provisioning + the browser-tool guard.
+
+Hermetic: no real pip, no browser. We assert the argv-selection logic (the
+money path: venv vs system, PEP-668 fallback) and that a browser tool degrades
+to a clean envelope instead of crashing when provisioning fails.
+"""
+
+from __future__ import annotations
+
+import suitest_lifecycle.frontend_runtime as fr
+from suitest_lifecycle.blackbox import mcp as bbmcp
+from suitest_lifecycle.frontend_runtime import BrowserStatus
+
+
+def test_pip_variants_in_venv_installs_into_venv(monkeypatch) -> None:
+    # venv => prefix differs from base_prefix; no --user, no PEP-668 fight.
+    monkeypatch.setattr(fr.sys, "prefix", "/tmp/venv")
+    monkeypatch.setattr(fr.sys, "base_prefix", "/usr")
+    variants = fr._pip_install_variants("playwright")
+    assert len(variants) == 1
+    assert "--user" not in variants[0]
+    assert "--break-system-packages" not in variants[0]
+    assert variants[0][-1] == "playwright"
+
+
+def test_pip_variants_system_has_user_then_break_system(monkeypatch) -> None:
+    # Non-venv => --user first, then --break-system-packages for PEP-668.
+    monkeypatch.setattr(fr.sys, "prefix", "/usr")
+    monkeypatch.setattr(fr.sys, "base_prefix", "/usr")
+    variants = fr._pip_install_variants("playwright")
+    assert len(variants) == 2
+    assert "--user" in variants[0] and "--break-system-packages" not in variants[0]
+    assert "--user" in variants[1] and "--break-system-packages" in variants[1]
+
+
+def test_ensure_browser_no_autoinstall_reports_missing(monkeypatch) -> None:
+    monkeypatch.setattr(fr, "_playwright_importable", lambda: False)
+    status = fr.ensure_browser(auto_install=False)
+    assert status.ready is False
+    assert "playwright" in status.detail.lower()
+
+
+def test_browser_tool_degrades_gracefully(monkeypatch) -> None:
+    # The core regression: a browser tool must NOT raise ModuleNotFoundError.
+    # When provisioning fails it returns success=False with the reason.
+    monkeypatch.setattr(
+        bbmcp, "ensure_browser", lambda **_: BrowserStatus(False, "no pip, offline")
+    )
+    guarded = bbmcp.BLACKBOX_TOOLS["blackbox_discover_app"]
+    out = guarded(url="https://example.test")
+    assert out["success"] is False
+    assert "browser runtime unavailable" in out["summary"]
+    assert out["errors"] == ["no pip, offline"]
+
+
+def test_nonbrowser_tool_is_not_gated() -> None:
+    # summarize reads saved JSON only — it must not be wrapped by the guard.
+    assert (
+        bbmcp.BLACKBOX_TOOLS["blackbox_summarize_findings"]
+        is (bbmcp._RAW_BLACKBOX_TOOLS["blackbox_summarize_findings"])
+    )
+
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/packages/lifecycle/tests/test_mcp_server.py
+++ b/packages/lifecycle/tests/test_mcp_server.py
@@ -80,3 +80,27 @@ def test_serve_starts_with_valid_key(monkeypatch: pytest.MonkeyPatch) -> None:
     mcp_server.serve(stdin=io.StringIO(line), stdout=out)
     assert seen == ["http://localhost:4000/api/v1/api-keys/whoami"]
     assert '"protocolVersion"' in out.getvalue()
+
+
+def test_handle_answers_standard_probes() -> None:
+    """Codex + GitHub Copilot CLI probe ping/resources/prompts on connect and
+    health-check via ``ping``. Answering these (not -32601) is what keeps those
+    clients from marking the server broken — the regression this guards."""
+    cases = [
+        ("ping", None),
+        ("resources/list", "resources"),
+        ("resources/templates/list", "resourceTemplates"),
+        ("prompts/list", "prompts"),
+    ]
+    for method, empty_key in cases:
+        resp = mcp_server.handle({"jsonrpc": "2.0", "id": 1, "method": method})
+        assert resp is not None
+        assert "error" not in resp, f"{method} returned {resp.get('error')}"
+        if empty_key is not None:
+            assert resp["result"][empty_key] == []
+
+
+def test_handle_unknown_method_still_errors() -> None:
+    resp = mcp_server.handle({"jsonrpc": "2.0", "id": 9, "method": "does/not/exist"})
+    assert resp is not None
+    assert resp["error"]["code"] == -32601

--- a/packages/mcp-npx/bin/suitest-mcp.js
+++ b/packages/mcp-npx/bin/suitest-mcp.js
@@ -125,8 +125,12 @@ function preparePython() {
   const py = findPython();
   if (!py) {
     process.stderr.write(
-      "suitest-mcp needs Python >= 3.11 on PATH (or set SUITEST_PYTHON " +
-        "to an interpreter). Install from https://python.org and retry.\n",
+      "suitest-mcp needs Python >= 3.11 and could not find or provision one.\n" +
+        "Fix any one of:\n" +
+        "  • install uv (https://docs.astral.sh/uv/) — suitest auto-provisions " +
+        "Python through it, no manual Python install needed;\n" +
+        "  • install Python >= 3.11 from https://python.org so `python3` is on PATH;\n" +
+        "  • set SUITEST_PYTHON to an existing interpreter path.\n",
     );
     return null;
   }

--- a/packages/mcp-npx/lib/python.js
+++ b/packages/mcp-npx/lib/python.js
@@ -3,28 +3,60 @@
 /**
  * Locate a Python >= 3.11 interpreter. Shared by the server launcher (bin)
  * and the installer's prereq check.
+ *
+ * Resolution order:
+ *   1. $SUITEST_PYTHON, then `python3` / `python` on PATH.
+ *   2. Fallback: a `uv`-managed Python. If the client has no system Python but
+ *      has `uv` (a single static binary), we provision one automatically so
+ *      "test my app" works without the user installing Python by hand.
  */
 
 const { spawnSync } = require("node:child_process");
 
 const MIN_PY = [3, 11];
 
+function probeVersion(cmd, args = []) {
+  const probe = spawnSync(cmd, [
+    ...args,
+    "-c",
+    "import sys; print('%d.%d' % sys.version_info[:2])",
+  ]);
+  if (probe.status !== 0) return null;
+  const [maj, min] = String(probe.stdout).trim().split(".").map(Number);
+  if (Number.isNaN(maj) || Number.isNaN(min)) return null;
+  if (maj > MIN_PY[0] || (maj === MIN_PY[0] && min >= MIN_PY[1])) {
+    return `${maj}.${min}`;
+  }
+  return null;
+}
+
+// Provision/locate a uv-managed interpreter. Returns an absolute python path or
+// null when uv is absent or the install fails (offline, etc.).
+function findUvPython() {
+  const uv = spawnSync("uv", ["--version"]);
+  if (uv.status !== 0) return null;
+
+  const target = `${MIN_PY[0]}.${Math.max(MIN_PY[1], 12)}`; // 3.12
+  // Install is idempotent and fast when the interpreter is already present.
+  spawnSync("uv", ["python", "install", target], { stdio: "ignore" });
+
+  const found = spawnSync("uv", ["python", "find", target], { encoding: "utf8" });
+  if (found.status !== 0) return null;
+  const path = String(found.stdout).trim().split("\n")[0].trim();
+  if (!path) return null;
+  const version = probeVersion(path);
+  return version ? { cmd: path, version, viaUv: true } : null;
+}
+
 function findPython() {
   const candidates = process.env.SUITEST_PYTHON
     ? [process.env.SUITEST_PYTHON]
     : ["python3", "python"];
   for (const cmd of candidates) {
-    const probe = spawnSync(cmd, [
-      "-c",
-      "import sys; print('%d.%d' % sys.version_info[:2])",
-    ]);
-    if (probe.status !== 0) continue;
-    const [maj, min] = String(probe.stdout).trim().split(".").map(Number);
-    if (maj > MIN_PY[0] || (maj === MIN_PY[0] && min >= MIN_PY[1])) {
-      return { cmd, version: `${maj}.${min}` };
-    }
+    const version = probeVersion(cmd);
+    if (version) return { cmd, version };
   }
-  return null;
+  return findUvPython();
 }
 
-module.exports = { MIN_PY, findPython };
+module.exports = { MIN_PY, findPython, findUvPython, probeVersion };

--- a/packages/shared/openapi.json
+++ b/packages/shared/openapi.json
@@ -10349,7 +10349,7 @@
     },
     "/api/v1/analytics/heatmap": {
       "get": {
-        "description": "Run-count grid (day x hour) over the window (docs/API.md \u00a73.8).",
+        "description": "Run-count grid (day x hour) over the window (docs/API.md \u00a73.8).\n\nAccepts ``days=<n>`` (what the web client sends) or ``period=<n>d``; ``days``\nwins when both are present.",
         "operationId": "analytics_heatmap_api_v1_analytics_heatmap_get",
         "parameters": [
           {
@@ -10359,6 +10359,24 @@
             "schema": {
               "title": "Projectid",
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "days",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 365,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Days"
             }
           },
           {

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -150,11 +150,17 @@ async def seeded_case(database_url: str, nginx_test_page_url: str) -> dict[str, 
             "{}",
         )
         await conn.execute(
-            "INSERT INTO test_cases (id, suite_id, public_id, name, source, status, priority, order_in_suite) "
-            "VALUES ($1, $2, $3, $4, 'MANUAL', 'ACTIVE', 'P2', 0)",
+            # workspace_id + title are NOT NULL columns filled by ORM defaults /
+            # a before_insert listener; this raw seed bypasses the ORM, so both
+            # must be supplied explicitly (title's default is Python-side, not a
+            # DB server_default).
+            "INSERT INTO test_cases (id, suite_id, workspace_id, public_id, name, title, source, "
+            "status, priority, order_in_suite) VALUES ($1, $2, $3, $4, $5, $6, 'MANUAL', 'ACTIVE', 'P2', 0)",
             case_id,
             suite_id,
+            workspace_id,
             f"TC-E2E-{suffix.upper()}",
+            "Smoke flow",
             "Smoke flow",
         )
         for idx, step in enumerate(steps_payload, start=1):


### PR DESCRIPTION
Three independent fixes found while running the blackbox flow against a local (SQLite) install. One commit each.

## 1. `fix(mcp)`: auto-provision Playwright on demand for blackbox tools
Blackbox tools imported `playwright` directly but never installed it, so a runtime without the package crashed with a raw `No module named 'playwright'` (surfacing as "tool crashed" / no output). `ensure_browser()` now installs the package into the running interpreter (venv-aware; `--user`/`--break-system-packages` fallback for PEP-668; `ensurepip` bootstrap), makes it importable in-process, then provisions Chromium. Browser tools are gated so a provisioning failure returns a clear envelope instead of crashing. The npx launcher also falls back to a `uv`-managed Python when no system Python ≥3.11 is present.

## 2. `fix(api)`: heatmap + eval fixtures on the local runtime
- **Heatmap 500** — `RunRepo.heatmap_cells` used `date_trunc()` (Postgres-only → `no such function` on SQLite). Now buckets by `(day, hour)` in Python (engine-agnostic). Handler also accepts `days=<n>` (what the web client sends) alongside `period=<n>d`.
- **Eval 400** — `_fixtures_dir()` resolved `eval/fixtures` relative to the process cwd, but uvicorn runs with an arbitrary cwd and fixtures aren't shipped in the wheel. Now resolves via env → cwd → bundled package data → repo checkout.

## 3. `fix(mcp)`: answer `ping`/`resources`/`prompts` so Codex and Copilot connect
The stdio server returned JSON-RPC `-32601` for everything except `initialize`/`tools/list`/`tools/call` — including `ping`. Codex and GitHub Copilot CLI health-check via `ping`, so the error made them mark the server broken (Cursor / Claude Code / Antigravity never ping). `handle()` now answers `ping` and the list probes.

## Tests
- New SQLite heatmap regression (`test_sqlite_dialect.py`), eval resolver unit tests, Playwright provisioning tests, MCP protocol probe tests.
- Ruff clean. `frontend_runtime.py` mypy-clean.
- Postgres-backed API suites not run locally (no Docker); covered by the new SQLite test + live verification against the running instance.

## Notes / follow-ups (not in this PR)
- Bundle eval fixtures into the `suitest_api` wheel so eval works in every packaged install (currently relies on the resolver finding a repo checkout).
- Wire blackbox test failures → auto-filed defects (today the MCP flow publishes cases/runs but never writes defects).