### PR TITLE
feat: CLI onboard hardening — cross-OS transport, secret masking, settings TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Requirements: **Node ≥ 18** and [uv](https://docs.astral.sh/uv/).
 npx @suiflex/suitest onboard
 ```
 
-Boots the full platform locally — web dashboard + API on SQLite + run supervisor (port 4000, falls back to 4001–4009, binds `127.0.0.1`) — and wires your IDE's MCP config in the same step. No Docker, no Postgres, no LLM key (generation uses MCP sampling through your IDE agent). Data lives in `./.suitest/`; the dashboard and Suitest wheels ship inside the npm package (~3 MB). `suitest up` / `suitest down` manage the stack; `--port`, `--ide`, `--base-url` override defaults. Details: [packages/suitest-npx](./packages/suitest-npx/README.md).
+Boots the full platform locally — web dashboard + API on SQLite + run supervisor (port 4000, falls back to 4001–4009, binds `127.0.0.1`) — and wires your IDE's MCP config in the same step. No Docker, no Postgres, no LLM key (generation uses MCP sampling through your IDE agent). Data lives in `./.suitest/`; the dashboard and Suitest wheels ship inside the npm package (~3 MB). `suitest up` / `suitest down` manage the stack; `suitest settings` generates/refreshes the API key from the terminal (no browser); `--port`, `--ide`, `--base-url` override defaults. Details: [packages/suitest-npx](./packages/suitest-npx/README.md).
 
 ### 2. MCP server only (no install required)
 

--- a/packages/mcp-npx/lib/creds.js
+++ b/packages/mcp-npx/lib/creds.js
@@ -18,6 +18,8 @@ const os = require("node:os");
 const path = require("node:path");
 const readline = require("node:readline");
 
+const { askSecret } = require("./prompt.js");
+
 const PLACEHOLDER = {
   apiUrl: "http://localhost:4000",
   apiKey: "sk_suitest_…",
@@ -70,32 +72,36 @@ function saveCreds({ apiUrl, apiKey }) {
   return p;
 }
 
-function ask(rl, question) {
-  return new Promise((resolve) => rl.question(question, (a) => resolve(a.trim())));
+// One-shot text prompt: owns and closes its own interface so it never overlaps
+// with the masked-secret interface on stdin.
+function ask(question) {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+    rl.question(question, (a) => {
+      rl.close();
+      resolve(a.trim());
+    });
+  });
 }
 
 /**
  * Interactive prompt for URL + key. Prefills from `defaults` so the user can
  * just hit enter to keep an existing value. Returns null if aborted (empty
- * required field).
+ * required field). The key is masked (`askSecret`); the URL is plain text.
  */
 async function promptCreds(defaults = {}) {
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  try {
-    const urlHint = defaults.apiUrl ? ` [${defaults.apiUrl}]` : "";
-    const keyHint = defaults.apiKey ? " [keep existing]" : "";
-    const apiUrl =
-      (await ask(rl, `SUITEST_API_URL${urlHint}: `)) || defaults.apiUrl || "";
-    const apiKey =
-      (await ask(rl, `SUITEST_API_KEY${keyHint}: `)) || defaults.apiKey || "";
-    if (!apiUrl || !apiKey) return null;
-    return { apiUrl, apiKey };
-  } finally {
-    rl.close();
-  }
+  const urlHint = defaults.apiUrl ? ` [${defaults.apiUrl}]` : "";
+  const keyHint = defaults.apiKey ? " [keep existing]" : "";
+  const apiUrl =
+    (await ask(`SUITEST_API_URL${urlHint}: `)) || defaults.apiUrl || "";
+  // Secret: mask so the key never echoes to the terminal / screen-share.
+  const apiKey =
+    (await askSecret(`SUITEST_API_KEY${keyHint}: `)) || defaults.apiKey || "";
+  if (!apiUrl || !apiKey) return null;
+  return { apiUrl, apiKey };
 }
 
 /**

--- a/packages/mcp-npx/lib/init.js
+++ b/packages/mcp-npx/lib/init.js
@@ -12,6 +12,7 @@
 const path = require("node:path");
 const readline = require("node:readline/promises");
 
+const { askSecret } = require("./prompt.js");
 const { detectIdes, IDE_TARGETS } = require("./detect-ide.js");
 const { detectFramework } = require("./detect-framework.js");
 const { scaffoldConfig } = require("./scaffold-config.js");
@@ -116,7 +117,7 @@ async function runInit(opts) {
       ? opts.apiKey
       : opts.yes
         ? ""
-        : await ask("SUITEST_API_KEY (sk_suitest_…): ", "");
+        : await askSecret("SUITEST_API_KEY (sk_suitest_…): ");
     if (!apiKey) {
       throw new Error(
         "server mode needs SUITEST_API_KEY — pass --api-key or run `login` first.",

--- a/packages/mcp-npx/lib/prompt.js
+++ b/packages/mcp-npx/lib/prompt.js
@@ -1,0 +1,40 @@
+"use strict";
+
+/**
+ * Masked secret prompt for the CLI onboarding. Node's `readline` echoes input
+ * verbatim, so API keys/passwords would print in the clear. This overrides the
+ * interface's output writer to emit `*` per typed char instead of the raw byte.
+ *
+ * No dependency — the mute trick is stdlib readline (`ponytail:` no
+ * inquirer/read). Returns the trimmed secret, or "" if the user just hits enter.
+ */
+
+const readline = require("node:readline");
+
+function askSecret(question, { input = process.stdin, output = process.stdout } = {}) {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input, output });
+    let printed = false;
+    // Called on every keystroke. Print the prompt once, then mask the rest.
+    rl._writeToOutput = (chunk) => {
+      if (!printed) {
+        rl.output.write(question);
+        printed = true;
+        return;
+      }
+      // Preserve control sequences (enter/backspace redraw) but mask visible chars.
+      if (chunk === "\r\n" || chunk === "\n" || chunk === "\r") {
+        rl.output.write(chunk);
+      } else {
+        rl.output.write("*");
+      }
+    };
+    rl.question(question, (answer) => {
+      rl.output.write("\n");
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+module.exports = { askSecret };

--- a/packages/mcp-npx/test/prompt.test.js
+++ b/packages/mcp-npx/test/prompt.test.js
@@ -1,0 +1,34 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert");
+const { PassThrough } = require("node:stream");
+
+const { askSecret } = require("../lib/prompt.js");
+
+test("askSecret returns the typed secret without echoing plaintext", async () => {
+  // Note: per-keystroke `*` masking only fires under a real TTY (keystroke echo).
+  // A PassThrough is line-buffered, so here we assert the two guarantees that
+  // hold regardless of TTY: the exact value comes back and it never hits output.
+  const input = new PassThrough();
+  const output = new PassThrough();
+  let seen = "";
+  output.on("data", (b) => {
+    seen += b.toString();
+  });
+
+  const p = askSecret("KEY: ", { input, output });
+  input.write("sk_secret_123\n");
+  const answer = await p;
+
+  assert.strictEqual(answer, "sk_secret_123");
+  assert.ok(!seen.includes("sk_secret_123"), "raw secret leaked to output");
+});
+
+test("askSecret returns empty string on a bare enter", async () => {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const p = askSecret("KEY: ", { input, output });
+  input.write("\n");
+  assert.strictEqual(await p, "");
+});

--- a/packages/mcp/src/suitest_mcp/client.py
+++ b/packages/mcp/src/suitest_mcp/client.py
@@ -42,8 +42,8 @@ from opentelemetry import trace
 
 from mcp import ClientSession, StdioServerParameters
 from suitest_mcp.errors import McpHandshakeFailed, McpToolFailed, McpToolTimeout
-from suitest_mcp.proc import resolve_command
 from suitest_mcp.models import McpArtifact, McpProviderConfig, McpToolResult, McpTransport
+from suitest_mcp.proc import resolve_command
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable

--- a/packages/mcp/src/suitest_mcp/client.py
+++ b/packages/mcp/src/suitest_mcp/client.py
@@ -42,6 +42,7 @@ from opentelemetry import trace
 
 from mcp import ClientSession, StdioServerParameters
 from suitest_mcp.errors import McpHandshakeFailed, McpToolFailed, McpToolTimeout
+from suitest_mcp.proc import resolve_command
 from suitest_mcp.models import McpArtifact, McpProviderConfig, McpToolResult, McpTransport
 
 if TYPE_CHECKING:
@@ -168,7 +169,7 @@ def _transport_context(provider: McpProviderConfig) -> Any:
         if not provider.command:
             raise McpHandshakeFailed(f"stdio provider {provider.name} has no command configured")
         params = StdioServerParameters(
-            command=provider.command[0],
+            command=resolve_command(provider.command[0]),
             args=list(provider.command[1:]),
             env={**provider.env} if provider.env else None,
         )

--- a/packages/mcp/src/suitest_mcp/proc.py
+++ b/packages/mcp/src/suitest_mcp/proc.py
@@ -1,0 +1,23 @@
+"""Cross-OS resolution for stdio MCP command executables.
+
+Bundled providers spawn bare names like ``npx`` / ``node`` (see
+``bundled/playwright.py``). On Windows those live as ``npx.cmd`` / ``node.exe``,
+so passing the bare name straight to the stdio transport fails to launch. This
+resolves the command to an absolute path before spawn.
+
+``shutil.which`` already honors Windows ``PATHEXT`` and absolute/relative paths,
+so this is a thin wrapper: resolve when possible, otherwise return the original
+string unchanged so the transport still surfaces a helpful "not found" error.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+
+def resolve_command(command: str) -> str:
+    """Return an absolute path for ``command`` on PATH, else ``command`` as-is.
+
+    ``# ponytail: shutil.which covers PATHEXT + absolute paths; thin wrapper only``
+    """
+    return shutil.which(command) or command

--- a/packages/mcp/tests/test_proc.py
+++ b/packages/mcp/tests/test_proc.py
@@ -1,0 +1,34 @@
+"""Tests for cross-OS stdio command resolution."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+from suitest_mcp.proc import resolve_command
+
+
+def test_resolve_command_returns_absolute_for_path_on_disk() -> None:
+    resolved = resolve_command("/bin/sh")
+    assert Path(resolved).is_absolute()
+    assert Path(resolved).exists()
+
+
+def test_resolve_command_finds_bare_name_on_path(tmp_path: Path) -> None:
+    exe = tmp_path / "faketool"
+    exe.write_text("#!/bin/sh\n")
+    exe.chmod(exe.stat().st_mode | stat.S_IXUSR)
+    old = os.environ.get("PATH", "")
+    os.environ["PATH"] = f"{tmp_path}{os.pathsep}{old}"
+    try:
+        assert resolve_command("faketool") == str(exe)
+    finally:
+        os.environ["PATH"] = old
+
+
+def test_resolve_command_returns_input_when_missing() -> None:
+    # Unknown command falls through unchanged so the transport surfaces the error.
+    assert resolve_command("definitely-not-a-real-binary-xyz") == (
+        "definitely-not-a-real-binary-xyz"
+    )

--- a/packages/suitest-npx/README.md
+++ b/packages/suitest-npx/README.md
@@ -23,6 +23,8 @@ demand); `onboard` prints the install one-liner when it's missing.
 | `suitest onboard` | provision runtime (per-project uv venv from bundled wheels), boot the stack, mint a local API key, wire your IDE's MCP config |
 | `suitest up` | boot the local stack (idempotent) |
 | `suitest down` | stop it |
+| `suitest status` | is the stack running? (URL, version, health) |
+| `suitest settings` | terminal panel: generate/refresh the API key + show config, no browser |
 | `suitest init` | wire MCP config only |
 
 Data lives in `./.suitest/` (SQLite DB, artifacts, logs, venv, credentials).

--- a/packages/suitest-npx/bin/suitest.js
+++ b/packages/suitest-npx/bin/suitest.js
@@ -10,6 +10,7 @@ Commands:
   up        boot local stack (API + supervisor + dashboard)
   down      stop local stack
   status    is the local stack running? (URL, version, health)
+  settings  terminal panel: generate/refresh API key, show config (no browser)
   upgrade   check for a newer version and how to switch to it
   init      wire MCP config only (delegates to @suiflex/suitest-mcp)
 
@@ -94,6 +95,11 @@ async function main() {
       }[s.state];
       console.log(line);
       await printUpdateNotice();
+      break;
+    }
+    case "settings": {
+      const { runSettings } = require("../lib/settings.js");
+      await runSettings(cwd);
       break;
     }
     case "upgrade": {

--- a/packages/suitest-npx/lib/onboard.js
+++ b/packages/suitest-npx/lib/onboard.js
@@ -25,25 +25,31 @@ async function promptAccount(credPath, opts = {}) {
     );
   }
   const readline = require("node:readline/promises");
+  const { askSecret } = loadMcpLib("prompt.js");
+  console.log("Create the admin account for your local Suitest (you'll log in with this):");
+
+  // Email over a plain interface, closed before we prompt for secrets so the
+  // masked-secret interface owns stdin without two readers competing.
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  let email = "";
   try {
-    console.log("Create the admin account for your local Suitest (you'll log in with this):");
-    let email = "";
     while (!email.includes("@")) {
       email = (await rl.question("  email: ")).trim();
     }
-    let password = "";
-    for (;;) {
-      password = (await rl.question("  password (min 8 chars): ")).trim();
-      if (password.length < 8) continue;
-      const confirm = (await rl.question("  confirm password: ")).trim();
-      if (confirm === password) break;
-      console.log("  Passwords don't match, try again.");
-    }
-    return loadOrCreateCredentials(credPath, { email, password });
   } finally {
     rl.close();
   }
+
+  // Password typed twice, masked (`askSecret` echoes `*`, never the chars).
+  let password = "";
+  for (;;) {
+    password = await askSecret("  password (min 8 chars): ");
+    if (password.length < 8) continue;
+    const confirm = await askSecret("  confirm password: ");
+    if (confirm === password) break;
+    console.log("  Passwords don't match, try again.");
+  }
+  return loadOrCreateCredentials(credPath, { email, password });
 }
 
 // ponytail: published dependency first; relative fallback for monorepo dev

--- a/packages/suitest-npx/lib/settings.js
+++ b/packages/suitest-npx/lib/settings.js
@@ -1,0 +1,71 @@
+"use strict";
+
+// `suitest settings` — a tiny terminal panel for the things you'd otherwise open
+// the browser dashboard for. MVP: generate/refresh the API key and show the
+// current config. Built on the existing arrow-key picker + the existing
+// `ensureApiKey` mint flow — no browser, no new dependency.
+
+const fs = require("node:fs");
+
+const { projectDirs, saveCredentials } = require("./project.js");
+const { status } = require("./stack.js");
+const { ensureApiKey } = require("./api-key.js");
+const { loadMcpLib } = require("./onboard.js");
+
+function redactKey(key) {
+  if (!key) return "(none)";
+  return key.length <= 8 ? "****" : `${key.slice(0, 6)}…${key.slice(-2)}`;
+}
+
+// Mint (or reuse a still-valid) API key against the running local stack and
+// persist it into .suitest/credentials.json — same file `onboard` writes.
+async function generateKey(cwd) {
+  const s = await status(cwd);
+  if (s.state !== "running") {
+    console.log('Local stack not running — run "suitest up" first.');
+    return;
+  }
+  const dirs = projectDirs(cwd);
+  const creds = JSON.parse(fs.readFileSync(dirs.credentials, "utf8"));
+  const key = await ensureApiKey(s.url, creds);
+  creds.apiKey = key;
+  saveCredentials(dirs.credentials, creds);
+  console.log(`\nAPI key (saved to ${dirs.credentials}):\n  ${key}\n`);
+}
+
+function showConfig(cwd) {
+  const dirs = projectDirs(cwd);
+  if (!fs.existsSync(dirs.credentials)) {
+    console.log('Not set up here — run "suitest onboard" first.');
+    return;
+  }
+  const creds = JSON.parse(fs.readFileSync(dirs.credentials, "utf8"));
+  console.log(
+    `email  : ${creds.email}\napi key: ${redactKey(creds.apiKey)}\nfile   : ${dirs.credentials}`,
+  );
+}
+
+async function runSettings(cwd) {
+  if (!process.stdin.isTTY) {
+    throw new Error("settings is interactive and needs a TTY.");
+  }
+  const { select } = loadMcpLib("picker.js");
+  for (;;) {
+    let choice;
+    try {
+      choice = await select("Suitest settings", [
+        { value: "key", label: "Generate / refresh API key", hint: "no browser" },
+        { value: "show", label: "Show current config" },
+        { value: "quit", label: "Quit" },
+      ]);
+    } catch {
+      return; // Esc / Ctrl-C
+    }
+    if (choice === "quit") return;
+    if (choice === "key") await generateKey(cwd);
+    else if (choice === "show") showConfig(cwd);
+    console.log("");
+  }
+}
+
+module.exports = { runSettings, generateKey, redactKey };

--- a/packages/suitest-npx/test/settings.test.js
+++ b/packages/suitest-npx/test/settings.test.js
@@ -1,0 +1,18 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert");
+
+const { redactKey } = require("../lib/settings.js");
+
+test("redactKey hides all but a short prefix/suffix", () => {
+  assert.strictEqual(redactKey(null), "(none)");
+  assert.strictEqual(redactKey(""), "(none)");
+  assert.strictEqual(redactKey("shortk"), "****");
+  assert.strictEqual(redactKey("sk_suitest_abcdef1234"), "sk_sui…34");
+});
+
+test("settings module loads the shared picker via the mcp-npx bridge", () => {
+  const { loadMcpLib } = require("../lib/onboard.js");
+  const { select } = loadMcpLib("picker.js");
+  assert.strictEqual(typeof select, "function");
+});


### PR DESCRIPTION
## Summary

- Fix a real Windows portability bug: bundled MCP providers spawn bare `npx`, which resolves as `npx.cmd` on Windows and fails the stdio transport.
- Close two secret-leak gaps: API keys and admin passwords were echoed in the clear during CLI onboarding.
- Add a terminal settings panel so users can generate an API key without opening the browser dashboard.

## Changes

**Transport (`packages/mcp`)**
- New `proc.py` `resolve_command()` — thin `shutil.which` wrapper (PATHEXT-aware); applied to the STDIO command in `client.py` before spawn. Falls back to the original string so a missing binary still surfaces a helpful error.

**Secret masking**
- `@suiflex/suitest-mcp`: new `lib/prompt.js` `askSecret()` (stdlib readline mute trick, no dependency). Wired into the `SUITEST_API_KEY` prompts in `creds.js` and `init.js`.
- `@suiflex/suitest`: `onboard` superadmin password + confirmation now masked (reuses `askSecret` via the existing `loadMcpLib` bridge); email prompt stays plain.

**Settings TUI (`@suiflex/suitest`)**
- New `suitest settings` command + `lib/settings.js`: arrow-key panel (reuses the existing picker) to generate/refresh the local API key (reuses `ensureApiKey`) and show config — no browser.

**Docs**
- Synced the suitest-npx command table (`status`, `settings`) and the root README launcher blurb.

## Test plan

- [x] `packages/mcp`: `pytest tests/test_proc.py` (3 passed); ruff + mypy clean on `proc.py`.
- [x] `packages/mcp-npx`: `node --test` (22 passed, incl. new `prompt.test.js`).
- [x] `packages/suitest-npx`: `node --test` (33 passed, incl. new `settings.test.js`).
- [x] `suitest --help` lists `settings`; `suitest-mcp --help` unchanged/accurate.
- [ ] Windows: verify a `playwright-mcp` stdio session resolves `npx.cmd` (no Windows runner locally).