### PR TITLE
feat: choosable dashboard port, dark/light toggle, fixed Connect-IDE modal

### DIFF
--- a/apps/web/e2e/golden-path.spec.ts
+++ b/apps/web/e2e/golden-path.spec.ts
@@ -75,6 +75,21 @@ const RUNS_SUMMARY = {
 const EMPTY_PAGE = { items: [], meta: { nextCursor: null, limit: 20 } };
 const EMPTY_ITEMS = { items: [] };
 
+// A workspace must have at least one project or `_app` beforeLoad can't seed an
+// active project, and /cases short-circuits to the NoProjectBootstrap empty
+// state (no "Test Cases" heading). Mirror ME's workspace (ws_1).
+const PROJECT = {
+  id: "prj_demo",
+  name: "Demo",
+  slug: "demo",
+  workspace_id: "ws_1",
+  description: null,
+  gating_suite_id: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+const PROJECTS_PAGE = { items: [PROJECT], meta: { nextCursor: null, limit: 20 } };
+
 /** The new case returned by POST /test-cases (mocked). */
 const CREATED_CASE = {
   id: "case_new",
@@ -209,7 +224,10 @@ function buildBaseRouteTable(overrides: RouteEntry[] = []): RouteEntry[] {
     { match: (u) => u.includes("/api/v1/integrations"), handler: (r) => fulfillJson(r, EMPTY_ITEMS) },
     { match: (u) => u.includes("/api/v1/traceability"), handler: (r) => fulfillJson(r, { items: [] }) },
     { match: (u) => u.includes("/api/v1/requirements"), handler: (r) => fulfillJson(r, EMPTY_ITEMS) },
-    { match: (u) => u.includes("/api/v1/projects"), handler: (r) => fulfillJson(r, EMPTY_ITEMS) },
+    // Single-project detail (useProject) before the list; the list must be
+    // non-empty so beforeLoad seeds an active project (see PROJECT above).
+    { match: (u) => /\/api\/v1\/projects\/[^/]+/.test(u), handler: (r) => fulfillJson(r, PROJECT) },
+    { match: (u) => u.includes("/api/v1/projects"), handler: (r) => fulfillJson(r, PROJECTS_PAGE) },
     { match: (u) => u.includes("/api/v1/workspaces"), handler: (r) => fulfillJson(r, EMPTY_ITEMS) },
   ];
 }
@@ -265,9 +283,10 @@ test("test_login_and_create_manual_case_then_run_pass", async ({ page }) => {
         await fulfillJson(route, QUEUED_RUN, 202);
       },
     },
-    // GET /runs/RUN-GP1 → PASS run (the detail page fetches this)
+    // GET /runs/run_gp → PASS run. The detail page fetches by internal id
+    // (run_gp), not the public_id (RUN-GP1) — see cases.tsx navigate().
     {
-      match: (u, m) => u.includes("/api/v1/runs/RUN-GP1") && m === "GET",
+      match: (u, m) => u.includes("/api/v1/runs/run_gp") && m === "GET",
       handler: (r) => fulfillJson(r, PASS_RUN),
     },
     // GET /test-cases/TC-101 → existing case with one step
@@ -305,6 +324,13 @@ test("test_login_and_create_manual_case_then_run_pass", async ({ page }) => {
   // The right pane should load the case detail panel
   await expect(page.getByTestId("case-detail")).toBeVisible({ timeout: 10_000 });
 
+  // The case detail is tabbed; the step editor lives under the "Steps" tab
+  // (Radix unmounts inactive tab content), so open it before asserting.
+  await page.getByTestId("case-tab-steps").click();
+
+  // The editor sits inside a collapsed "Edit steps" <details>; expand it.
+  await page.getByText("Edit steps").click();
+
   // Verify the step editor is visible
   await expect(page.getByTestId("step-editor")).toBeVisible({ timeout: 8_000 });
 
@@ -326,13 +352,14 @@ test("test_login_and_create_manual_case_then_run_pass", async ({ page }) => {
   await expect(saveBtn).toBeVisible();
   await saveBtn.click();
 
-  // Click "Run now" — this fires POST /runs and navigates to /runs/RUN-GP1
+  // Click "Run now" — this fires POST /runs and navigates to /runs/run_gp
+  // (the app navigates by internal run id, not the public_id).
   const runNowBtn = page.getByTestId("case-run-now");
   await expect(runNowBtn).toBeEnabled({ timeout: 8_000 });
   await runNowBtn.click();
 
   // Should land on the run detail page
-  await page.waitForURL(/\/runs\/RUN-GP1/, { timeout: 15_000 });
+  await page.waitForURL(/\/runs\/run_gp/, { timeout: 15_000 });
 
   // The run summary card should render with PASS status
   await expect(page.getByTestId("run-summary-card")).toBeVisible({ timeout: 10_000 });

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -6,19 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0a0a0a" />
     <title>Suitest</title>
-    <script>
-      // Apply the persisted theme before paint to avoid a flash. Keep in sync
-      // with src/lib/theme.ts (localStorage key + class names).
-      (function () {
-        try {
-          var t = localStorage.getItem("suitest.theme");
-          if (t !== "dark" && t !== "light") t = "dark";
-          var r = document.documentElement;
-          r.classList.remove("dark", "light");
-          r.classList.add(t);
-        } catch (e) {}
-      })();
-    </script>
   </head>
   <body class="bg-base text-fg-1 antialiased">
     <div id="root"></div>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -6,6 +6,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0a0a0a" />
     <title>Suitest</title>
+    <script>
+      // Apply the persisted theme before paint to avoid a flash. Keep in sync
+      // with src/lib/theme.ts (localStorage key + class names).
+      (function () {
+        try {
+          var t = localStorage.getItem("suitest.theme");
+          if (t !== "dark" && t !== "light") t = "dark";
+          var r = document.documentElement;
+          r.classList.remove("dark", "light");
+          r.classList.add(t);
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body class="bg-base text-fg-1 antialiased">
     <div id="root"></div>

--- a/apps/web/src/components/mcp/ConnectIdeDialog.test.tsx
+++ b/apps/web/src/components/mcp/ConnectIdeDialog.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  IDE_CLIENTS,
+  claudeCmd,
+  installCmd,
+  mcpJson,
+} from "@/components/mcp/connect-ide-commands";
+
+describe("ConnectIdeDialog commands", () => {
+  it("uses the npx package, not the stale python entry point", () => {
+    expect(claudeCmd()).toContain("npx -y @suiflex/suitest-mcp");
+    expect(claudeCmd()).not.toContain("python -m suitest_lifecycle.mcp_server");
+
+    const json = mcpJson();
+    expect(json).toContain('"command": "npx"');
+    expect(json).toContain('"@suiflex/suitest-mcp"');
+    expect(json).not.toContain("suitest_lifecycle.mcp_server");
+  });
+
+  it("generates per-IDE installer commands with the right --client target", () => {
+    expect(installCmd(IDE_CLIENTS.claude)).toBe(
+      "npx -y @suiflex/suitest-mcp install --client claude-code",
+    );
+    expect(installCmd(IDE_CLIENTS.cursor)).toBe(
+      "npx -y @suiflex/suitest-mcp install --client cursor",
+    );
+    expect(installCmd(IDE_CLIENTS.windsurf)).toBe(
+      "npx -y @suiflex/suitest-mcp install --client windsurf",
+    );
+  });
+});

--- a/apps/web/src/components/mcp/ConnectIdeDialog.tsx
+++ b/apps/web/src/components/mcp/ConnectIdeDialog.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { AlertTriangle, Cpu, KeyRound } from "lucide-react";
+import { AlertTriangle, Cpu, KeyRound, Zap } from "lucide-react";
 import { useState } from "react";
 
 import { CopyButton } from "@/components/shared/CopyButton";
@@ -13,6 +13,18 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  IDE_CLIENTS,
+  KEY_PLACEHOLDER,
+  NPM_PKG,
+  SERVER_CMD,
+  START_PROMPT,
+  apiUrl,
+  claudeCmd,
+  installCmd,
+  mcpJson,
+  type IdeTab,
+} from "@/components/mcp/connect-ide-commands";
 
 /**
  * "Connect Suitest to your AI IDE" — the outward MCP setup flow (Cursor /
@@ -20,10 +32,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
  * Keys (a key is a persistent, workspace-scoped credential); this dialog is a
  * copy-paste wiring guide that references the key by placeholder.
  */
-
-const SERVER_CMD = "python -m suitest_lifecycle.mcp_server";
-const START_PROMPT = "Hey, generate and run tests for this project with Suitest.";
-const KEY_PLACEHOLDER = "<your-api-key>";
 
 /** The lifecycle tools the connected agent can call. */
 const TOOLS = [
@@ -38,35 +46,6 @@ const TOOLS = [
   "runs",
 ] as const;
 
-function apiUrl(): string {
-  if (typeof window !== "undefined" && window.location?.origin) return window.location.origin;
-  return "http://localhost:4000";
-}
-
-function claudeCmd(): string {
-  return [
-    "claude mcp add suitest \\",
-    `  --env SUITEST_API_KEY=${KEY_PLACEHOLDER} \\`,
-    `  --env SUITEST_API_URL=${apiUrl()} \\`,
-    "  -- python -m suitest_lifecycle.mcp_server",
-  ].join("\n");
-}
-
-function mcpJson(): string {
-  return `{
-  "mcpServers": {
-    "suitest": {
-      "command": "python",
-      "args": ["-m", "suitest_lifecycle.mcp_server"],
-      "env": {
-        "SUITEST_API_KEY": "${KEY_PLACEHOLDER}",
-        "SUITEST_API_URL": "${apiUrl()}"
-      }
-    }
-  }
-}`;
-}
-
 function CodeBlock({ code }: { code: string }): React.ReactElement {
   return (
     <div className="relative">
@@ -77,6 +56,49 @@ function CodeBlock({ code }: { code: string }): React.ReactElement {
         <CopyButton value={code} label="Copy to clipboard" />
       </div>
     </div>
+  );
+}
+
+/** The recommended one-command path: the installer writes the IDE config. */
+function FastestBlock({
+  command,
+  picker,
+}: {
+  command: string;
+  picker?: boolean;
+}): React.ReactElement {
+  return (
+    <div className="mb-3">
+      <p className="mb-1.5 flex items-center gap-1.5 text-[11px] font-medium tracking-wide text-accent uppercase">
+        <Zap className="h-3 w-3" aria-hidden="true" />
+        Fastest — one command
+      </p>
+      <CodeBlock code={command} />
+      <p className="mt-1.5 text-[11px] text-fg-4">
+        {picker
+          ? "Interactive picker — choose your client; it writes the config."
+          : "Writes the IDE's MCP config for you."}{" "}
+        Run{" "}
+        <code className="rounded bg-bg-elev-2 px-1 font-mono text-[10.5px]">
+          npx -y {NPM_PKG} login
+        </code>{" "}
+        first to save your key.
+      </p>
+    </div>
+  );
+}
+
+/** Secondary manual path for users who prefer to edit config by hand. */
+function ManualBlock({ code, label }: { code: string; label?: string }): React.ReactElement {
+  return (
+    <details className="group">
+      <summary className="cursor-pointer list-none text-[11px] font-medium text-fg-4 hover:text-fg-2">
+        {label ?? "Prefer to wire it manually?"}
+      </summary>
+      <div className="mt-2">
+        <CodeBlock code={code} />
+      </div>
+    </details>
   );
 }
 
@@ -181,28 +203,20 @@ export function ConnectIdeDialog(): React.ReactElement {
 
           <StepShell n={2} title="Run the Suitest MCP server">
             <p className="mb-2 text-[12px] text-fg-3">
-              Local stdio server exposing the lifecycle tools — ships with the{" "}
-              <code className="rounded bg-bg-elev-2 px-1 font-mono text-[11px]">
-                suiflex-suitest-lifecycle
-              </code>{" "}
-              package.
+              Local stdio server exposing the lifecycle tools — runs straight from the{" "}
+              <code className="rounded bg-bg-elev-2 px-1 font-mono text-[11px]">{NPM_PKG}</code>{" "}
+              npm package, nothing to install. Most IDEs run this for you (step 3); this is the
+              raw command.
             </p>
             <CodeBlock code={SERVER_CMD} />
             <div className="mt-2 flex items-start gap-1.5 rounded-md border border-amber/25 bg-amber/[0.06] px-2.5 py-2 text-[11.5px] text-amber">
               <AlertTriangle className="mt-[1px] h-3.5 w-3.5 shrink-0" aria-hidden="true" />
               <span className="text-fg-2">
-                The <code className="font-mono text-[11px] text-fg-1">command</code> must be a
-                Python that has{" "}
-                <code className="font-mono text-[11px] text-fg-1">suiflex-suitest-lifecycle</code>{" "}
-                installed. Either{" "}
-                <code className="font-mono text-[11px] text-fg-1">
-                  pip install suiflex-suitest-lifecycle
-                </code>
-                , or point it at the Suitest repo&apos;s venv, e.g.{" "}
-                <code className="font-mono text-[11px] text-fg-1">
-                  /path/to/suitest/.venv/bin/python
-                </code>{" "}
-                — not bare <code className="font-mono text-[11px] text-fg-1">python</code>.
+                Requires <code className="font-mono text-[11px] text-fg-1">Node ≥ 18</code>. Python
+                is auto-provisioned via{" "}
+                <code className="font-mono text-[11px] text-fg-1">uv</code> — or point{" "}
+                <code className="font-mono text-[11px] text-fg-1">SUITEST_PYTHON</code> at an
+                existing interpreter.
               </span>
             </div>
           </StepShell>
@@ -225,38 +239,33 @@ export function ConnectIdeDialog(): React.ReactElement {
                   Claude Code
                 </TabsTrigger>
                 <TabsTrigger value="cursor">Cursor</TabsTrigger>
+                <TabsTrigger value="windsurf">Windsurf</TabsTrigger>
                 <TabsTrigger value="other">Other IDEs</TabsTrigger>
               </TabsList>
 
-              <TabsContent value="claude">
-                <p className="mb-2 text-[12px] text-fg-3">From your project directory, run:</p>
-                <CodeBlock code={claudeCmd()} />
-              </TabsContent>
-
-              <TabsContent value="cursor">
-                <p className="mb-2 text-[12px] text-fg-3">
-                  Add to{" "}
-                  <code className="rounded bg-bg-elev-2 px-1 font-mono text-[11px]">
-                    ~/.cursor/mcp.json
-                  </code>
-                  :
-                </p>
-                <CodeBlock code={mcpJson()} />
-              </TabsContent>
+              {(["claude", "cursor", "windsurf"] as IdeTab[]).map((tab) => (
+                <TabsContent key={tab} value={tab}>
+                  <FastestBlock command={installCmd(IDE_CLIENTS[tab])} />
+                  <ManualBlock code={tab === "claude" ? claudeCmd() : mcpJson()} />
+                </TabsContent>
+              ))}
 
               <TabsContent value="other">
-                <p className="mb-2 text-[12px] text-fg-3">
-                  Any MCP client accepts this server block:
-                </p>
-                <CodeBlock code={mcpJson()} />
+                <FastestBlock command={`npx -y ${NPM_PKG} install`} picker />
+                <ManualBlock code={mcpJson()} label="Or paste this server block into any MCP client:" />
               </TabsContent>
             </Tabs>
             <p className="mt-2 text-[11px] text-fg-4">
-              Replace{" "}
+              Manual configs use{" "}
               <code className="rounded bg-bg-elev-2 px-1 font-mono text-[10.5px]">
                 {KEY_PLACEHOLDER}
               </code>{" "}
-              with a key from Settings → API Keys.
+              — replace it with a key from Settings → API Keys. The one-command install prompts
+              for the key (or reuses{" "}
+              <code className="rounded bg-bg-elev-2 px-1 font-mono text-[10.5px]">
+                npx -y {NPM_PKG} login
+              </code>
+              ).
             </p>
           </StepShell>
 

--- a/apps/web/src/components/mcp/connect-ide-commands.ts
+++ b/apps/web/src/components/mcp/connect-ide-commands.ts
@@ -1,0 +1,51 @@
+/**
+ * Command strings for the Connect-IDE dialog, kept out of the component file so
+ * they can be unit-tested and imported without tripping react-refresh's
+ * "only export components" rule.
+ */
+export const NPM_PKG = "@suiflex/suitest-mcp";
+export const SERVER_CMD = `npx -y ${NPM_PKG}`;
+export const START_PROMPT = "Hey, generate and run tests for this project with Suitest.";
+export const KEY_PLACEHOLDER = "<your-api-key>";
+
+/** Tab id → the installer's `--client` target (matches the npx installer). */
+export const IDE_CLIENTS = {
+  claude: "claude-code",
+  cursor: "cursor",
+  windsurf: "windsurf",
+} as const;
+export type IdeTab = keyof typeof IDE_CLIENTS;
+
+export function apiUrl(): string {
+  if (typeof window !== "undefined" && window.location?.origin) return window.location.origin;
+  return "http://localhost:4000";
+}
+
+/** One-command install: the npx installer writes the IDE's MCP config for you. */
+export function installCmd(client: string): string {
+  return `npx -y ${NPM_PKG} install --client ${client}`;
+}
+
+export function claudeCmd(): string {
+  return [
+    "claude mcp add suitest \\",
+    `  --env SUITEST_API_KEY=${KEY_PLACEHOLDER} \\`,
+    `  --env SUITEST_API_URL=${apiUrl()} \\`,
+    `  -- npx -y ${NPM_PKG}`,
+  ].join("\n");
+}
+
+export function mcpJson(): string {
+  return `{
+  "mcpServers": {
+    "suitest": {
+      "command": "npx",
+      "args": ["-y", "${NPM_PKG}"],
+      "env": {
+        "SUITEST_API_KEY": "${KEY_PLACEHOLDER}",
+        "SUITEST_API_URL": "${apiUrl()}"
+      }
+    }
+  }
+}`;
+}

--- a/apps/web/src/components/shell/ThemeToggle.tsx
+++ b/apps/web/src/components/shell/ThemeToggle.tsx
@@ -1,0 +1,34 @@
+import { Moon, Sun } from "lucide-react";
+import { useState } from "react";
+
+import { getTheme, setTheme, type Theme } from "@/lib/theme";
+
+/**
+ * Topbar dark/light toggle. Flips the persisted theme (localStorage via
+ * `@/lib/theme`) which re-points the design tokens under `html.light` /
+ * `html.dark`. Seeded from `getTheme()` so it reflects the value the inline
+ * boot script already applied.
+ */
+export function ThemeToggle(): React.ReactElement {
+  const [theme, setThemeState] = useState<Theme>(() => getTheme());
+  const next: Theme = theme === "dark" ? "light" : "dark";
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        setTheme(next);
+        setThemeState(next);
+      }}
+      aria-label={`Switch to ${next} theme`}
+      className="flex h-7 w-7 items-center justify-center rounded-md text-fg-3 hover:bg-bg-elev-2 hover:text-fg-1"
+      data-testid="theme-toggle"
+    >
+      {theme === "dark" ? (
+        <Sun className="h-4 w-4" aria-hidden="true" />
+      ) : (
+        <Moon className="h-4 w-4" aria-hidden="true" />
+      )}
+    </button>
+  );
+}

--- a/apps/web/src/components/shell/Topbar.tsx
+++ b/apps/web/src/components/shell/Topbar.tsx
@@ -18,6 +18,7 @@ import {
 import { useCallback, useEffect, useState } from "react";
 
 import { LanguageSwitcher } from "@/components/shell/LanguageSwitcher";
+import { ThemeToggle } from "@/components/shell/ThemeToggle";
 import { TierBadge } from "@/components/shared/TierBadge";
 import { Button } from "@/components/ui/button";
 import {
@@ -146,6 +147,9 @@ export function Topbar({
 
         {/* Language switcher (M4-12) */}
         <LanguageSwitcher />
+
+        {/* Dark / light theme toggle */}
+        <ThemeToggle />
 
         {/* Help icon */}
         <a

--- a/apps/web/src/lib/theme.test.ts
+++ b/apps/web/src/lib/theme.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { applyTheme, getTheme, setTheme } from "@/lib/theme";
+
+const STORAGE_KEY = "suitest.theme";
+
+describe("theme", () => {
+  beforeEach(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    document.documentElement.classList.remove("dark", "light");
+  });
+
+  afterEach(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    document.documentElement.classList.remove("dark", "light");
+  });
+
+  it("defaults to dark when nothing is stored", () => {
+    expect(getTheme()).toBe("dark");
+  });
+
+  it("reads a stored theme", () => {
+    localStorage.setItem(STORAGE_KEY, "light");
+    expect(getTheme()).toBe("light");
+  });
+
+  it("ignores a garbage stored value", () => {
+    localStorage.setItem(STORAGE_KEY, "neon");
+    expect(getTheme()).toBe("dark");
+  });
+
+  it("setTheme persists and swaps the html class", () => {
+    setTheme("light");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("light");
+    expect(document.documentElement.classList.contains("light")).toBe(true);
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+
+    setTheme("dark");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.classList.contains("light")).toBe(false);
+  });
+
+  it("applyTheme swaps class without touching storage", () => {
+    applyTheme("light");
+    expect(document.documentElement.classList.contains("light")).toBe(true);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/theme.ts
+++ b/apps/web/src/lib/theme.ts
@@ -1,0 +1,37 @@
+/**
+ * Dark / light theme, persisted in localStorage — mirrors the plain-storage
+ * pattern of `src/i18n.ts` (no zustand). The theme is applied by toggling a
+ * `dark` / `light` class on `<html>`; the design tokens in `globals.css`
+ * re-point under `html.light`, so switching the class re-themes the whole app.
+ *
+ * An inline script in `index.html` reads the same key pre-paint (no flash);
+ * this module keeps it in sync on user toggles.
+ */
+export type Theme = "dark" | "light";
+
+const STORAGE_KEY = "suitest.theme";
+
+// Bare `localStorage` with a typeof guard — the same persistence pattern as
+// src/i18n.ts (proven under the jsdom test env).
+export function getTheme(): Theme {
+  if (typeof localStorage !== "undefined") {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "dark" || stored === "light") return stored;
+  }
+  return "dark";
+}
+
+export function applyTheme(theme: Theme): void {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  root.classList.remove("dark", "light");
+  root.classList.add(theme);
+}
+
+/** Switch the active theme and persist it so the choice survives reloads. */
+export function setTheme(theme: Theme): void {
+  if (typeof localStorage !== "undefined") {
+    localStorage.setItem(STORAGE_KEY, theme);
+  }
+  applyTheme(theme);
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -7,6 +7,7 @@ import { createRoot } from "react-dom/client";
 // component mounts (the <RouterProvider /> below renders title-translated
 // pages on first paint). Must precede the routeTree import.
 import "./i18n";
+import { applyTheme, getTheme } from "./lib/theme";
 import { routeTree } from "./routeTree.gen";
 import "@fontsource/geist-sans/400.css";
 import "@fontsource/geist-sans/500.css";
@@ -31,6 +32,11 @@ declare module "@tanstack/react-router" {
     router: typeof router;
   }
 }
+
+// Apply the persisted theme before the first render (index.html defaults to
+// `dark`; correct it here for a stored `light`). Runs as a module so it doesn't
+// affect Vite's page build target the way an inline classic script would.
+applyTheme(getTheme());
 
 const rootEl = document.getElementById("root");
 if (!rootEl) throw new Error("#root element missing in index.html");

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -106,6 +106,47 @@
   background-attachment: fixed;
 }
 
+/* ----------------------------------------------------------------------------
+   Light theme — overrides the same primitive color tokens under `html.light`.
+   Utilities compile to `var(--color-*)` and the shadcn aliases are `var()`
+   references, so re-pointing the primitives here re-themes the whole app with
+   zero component changes. `html.light` (0,1,1) outranks `:root` (0,1,0).
+   The theme class is set by src/lib/theme.ts + the inline boot script in
+   index.html. Dark stays the default (the @theme / :root values above).
+   -------------------------------------------------------------------------- */
+html.light {
+  color-scheme: light;
+  background-image: none;
+
+  --color-bg-base: #ffffff;
+  --color-bg-elev-1: #f7f8fa;
+  --color-bg-elev-2: #eef0f3;
+  --color-bg-elev-3: #e6e9ed;
+  --color-bg-hover: #eaecef;
+  --color-bg-code: #f3f4f6;
+
+  --color-border-subtle: #eceef1;
+  --color-border: #dce0e5;
+  --color-border-strong: #c3c8d0;
+
+  --color-fg-1: #14171c;
+  --color-fg-2: #2f343b;
+  --color-fg-3: #5b616b;
+  --color-fg-4: #838a94;
+  --color-fg-5: #aab0b8;
+
+  --color-accent: #1f9d57;
+  --color-accent-hover: #18884a;
+  --color-accent-fg: #ffffff;
+
+  --color-red: #d64535;
+  --color-amber: #b5750a;
+  --color-blue: #2f6fd0;
+  --color-violet: #6f52c9;
+
+  --color-destructive-foreground: #ffffff;
+}
+
 html {
   scroll-behavior: smooth;
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -27,6 +27,12 @@ export default defineConfig({
     },
   },
   preview: { port: 3000 },
+  // Pin the dep pre-bundler to the same modern target as the build. Vite's
+  // default optimizer target ("chrome87"/"es2020"…) can trip esbuild into a
+  // spurious "Transforming destructuring … is not supported yet" on some deps
+  // (e.g. sonner), which crashes the dev server. es2022 supports destructuring
+  // natively, so nothing is down-transformed.
+  optimizeDeps: { esbuildOptions: { target: "es2022" } },
   build: {
     outDir: "dist",
     sourcemap: true,

--- a/packages/suitest-npx/lib/onboard.js
+++ b/packages/suitest-npx/lib/onboard.js
@@ -72,10 +72,34 @@ async function prepare(cwd) {
   return { dirs, webDist, python };
 }
 
+// Resolve the dashboard port for onboard: an explicit --port wins; otherwise,
+// interactively, offer the previously-used port (or 4000) as the default.
+async function resolvePort(dirs, opts) {
+  if (opts.port) return opts.port;
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return undefined;
+  const { loadConfig } = require("./project.js");
+  const current = loadConfig(dirs.config).port || 4000;
+  const readline = require("node:readline/promises");
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = (await rl.question(`Dashboard port [${current}]: `)).trim();
+    if (!answer) return current;
+    if (/^\d+$/.test(answer)) {
+      const n = Number(answer);
+      if (n >= 1024 && n <= 65535) return n;
+    }
+    console.log(`  Ignoring invalid port "${answer}" — using ${current}.`);
+    return current;
+  } finally {
+    rl.close();
+  }
+}
+
 async function onboard(cwd, opts = {}) {
   const { dirs, webDist, python } = await prepare(cwd);
   await promptAccount(dirs.credentials, opts);
-  const running = await up(cwd, { webDist, python, port: opts.port });
+  const port = await resolvePort(dirs, opts);
+  const running = await up(cwd, { webDist, python, port });
   const creds = JSON.parse(fs.readFileSync(dirs.credentials, "utf8"));
   const apiUrl = `http://127.0.0.1:${running.port}`;
 

--- a/packages/suitest-npx/lib/settings.js
+++ b/packages/suitest-npx/lib/settings.js
@@ -6,15 +6,55 @@
 // `ensureApiKey` mint flow — no browser, no new dependency.
 
 const fs = require("node:fs");
+const readline = require("node:readline");
 
-const { projectDirs, saveCredentials } = require("./project.js");
+const { projectDirs, saveCredentials, loadConfig, saveConfig } = require("./project.js");
 const { status } = require("./stack.js");
 const { ensureApiKey } = require("./api-key.js");
 const { loadMcpLib } = require("./onboard.js");
 
+const DEFAULT_PORT = 4000;
+
 function redactKey(key) {
   if (!key) return "(none)";
   return key.length <= 8 ? "****" : `${key.slice(0, 6)}…${key.slice(-2)}`;
+}
+
+// Parse a user-typed port. Returns an int in [1024, 65535] or null (invalid),
+// so the caller can re-prompt without a TTY dependency in tests.
+function parsePort(str) {
+  if (!/^\d+$/.test(String(str).trim())) return null;
+  const n = Number(String(str).trim());
+  return n >= 1024 && n <= 65535 ? n : null;
+}
+
+// One-shot plain-text prompt (owns/closes its own interface).
+function askText(question, fallback = "") {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(question, (a) => {
+      rl.close();
+      resolve(a.trim() || fallback);
+    });
+  });
+}
+
+async function setPort(cwd) {
+  const dirs = projectDirs(cwd);
+  const config = loadConfig(dirs.config);
+  const current = config.port || DEFAULT_PORT;
+  const answer = await askText(`Dashboard port [${current}]: `, String(current));
+  const port = parsePort(answer);
+  if (port === null) {
+    console.log("Invalid port — must be an integer 1024–65535. Unchanged.");
+    return;
+  }
+  saveConfig(dirs.config, { ...config, port });
+  console.log(`Dashboard port set to ${port} (saved to ${dirs.config}).`);
+  const s = await status(cwd);
+  if (s.state === "running") {
+    console.log("Restart to apply: suitest down && suitest up");
+  }
 }
 
 // Mint (or reuse a still-valid) API key against the running local stack and
@@ -40,8 +80,10 @@ function showConfig(cwd) {
     return;
   }
   const creds = JSON.parse(fs.readFileSync(dirs.credentials, "utf8"));
+  const port = loadConfig(dirs.config).port || DEFAULT_PORT;
   console.log(
-    `email  : ${creds.email}\napi key: ${redactKey(creds.apiKey)}\nfile   : ${dirs.credentials}`,
+    `email  : ${creds.email}\napi key: ${redactKey(creds.apiKey)}\n` +
+      `port   : ${port}\nfile   : ${dirs.credentials}`,
   );
 }
 
@@ -55,6 +97,7 @@ async function runSettings(cwd) {
     try {
       choice = await select("Suitest settings", [
         { value: "key", label: "Generate / refresh API key", hint: "no browser" },
+        { value: "port", label: "Set dashboard port", hint: "applies on next up" },
         { value: "show", label: "Show current config" },
         { value: "quit", label: "Quit" },
       ]);
@@ -63,9 +106,10 @@ async function runSettings(cwd) {
     }
     if (choice === "quit") return;
     if (choice === "key") await generateKey(cwd);
+    else if (choice === "port") await setPort(cwd);
     else if (choice === "show") showConfig(cwd);
     console.log("");
   }
 }
 
-module.exports = { runSettings, generateKey, redactKey };
+module.exports = { runSettings, generateKey, redactKey, parsePort };

--- a/packages/suitest-npx/test/settings.test.js
+++ b/packages/suitest-npx/test/settings.test.js
@@ -2,7 +2,20 @@
 const { test } = require("node:test");
 const assert = require("node:assert");
 
-const { redactKey } = require("../lib/settings.js");
+const { redactKey, parsePort } = require("../lib/settings.js");
+
+test("parsePort accepts 1024-65535 and rejects everything else", () => {
+  assert.strictEqual(parsePort("4000"), 4000);
+  assert.strictEqual(parsePort(" 8080 "), 8080);
+  assert.strictEqual(parsePort("1024"), 1024);
+  assert.strictEqual(parsePort("65535"), 65535);
+  assert.strictEqual(parsePort("1023"), null); // below range
+  assert.strictEqual(parsePort("65536"), null); // above range
+  assert.strictEqual(parsePort("80"), null);
+  assert.strictEqual(parsePort("abc"), null);
+  assert.strictEqual(parsePort("40a0"), null);
+  assert.strictEqual(parsePort(""), null);
+});
 
 test("redactKey hides all but a short prefix/suffix", () => {
   assert.strictEqual(redactKey(null), "(none)");


### PR DESCRIPTION
## Summary

- The local dashboard was effectively pinned to :4000; make the port choosable from the terminal.
- The dashboard was dark-only; add a light theme and a topbar toggle.
- The "Connect Suitest to your AI IDE" modal showed a stale `python -m suitest_lifecycle.mcp_server` command; point it at the npx package and generate the exact per-IDE install command.

## Changes

**#1 Dashboard port (`packages/suitest-npx`)**
- `settings.js`: new "Set dashboard port" action — validates 1024–65535, persists `config.port`, warns to restart when the stack is running; `showConfig` now prints the port.
- `onboard.js`: interactive port prompt when `--port` is not passed (non-interactive keeps `--port`/default).
- Reuses the existing `loadConfig`/`saveConfig` + the `up()` precedence (`--port` > `config.port` > 4000).

**#2 Light theme (`apps/web`)**
- `globals.css`: light palette overriding the primitive tokens under `html.light` (utilities resolve `var(--color-*)`, so no component changes).
- `lib/theme.ts`: localStorage-backed theme (mirrors `i18n.ts`); `index.html` inline pre-paint script (no flash); `ThemeToggle.tsx` in the topbar.

**#3 Connect-IDE modal (`apps/web`)**
- `ConnectIdeDialog.tsx`: replace the python entry point with `npx -y @suiflex/suitest-mcp`; step 3 is now a per-IDE generator (Claude Code / Cursor / Windsurf / Other) leading with `install --client <id>` and a manual config fallback.
- Command strings extracted to `connect-ide-commands.ts` (unit-tested, avoids react-refresh warnings).

## Test plan

- [x] `packages/suitest-npx`: `node --test` (34 passed, incl. new `parsePort` cases).
- [x] `apps/web`: `tsc --noEmit` clean; `eslint --max-warnings=0` clean; `ConnectIdeDialog.test.tsx` passes.
- [ ] `theme.test.ts` runs under CI Node 22 (jsdom localStorage); could not run on local Node 26 where the experimental global `localStorage` shadows jsdom — same limitation as the existing `use-active-workspace.test.ts`.
- [ ] Manual: toggle theme (persists, no flash); `suitest settings` → set port → `suitest up` boots on it; Connect-IDE tabs show the correct `npx` commands.