### PR TITLE
feat(cli): consent-based uv preflight with auto-install for onboard

### DIFF
--- a/packages/suitest-npx/bin/suitest.js
+++ b/packages/suitest-npx/bin/suitest.js
@@ -74,7 +74,7 @@ async function main() {
     case "up": {
       const { prepare } = require("../lib/onboard.js");
       const { up } = require("../lib/stack.js");
-      const { webDist, python } = await prepare(cwd);
+      const { webDist, python } = await prepare(cwd, opts);
       await up(cwd, { webDist, python, port: opts.port });
       await printUpdateNotice();
       break;

--- a/packages/suitest-npx/lib/onboard.js
+++ b/packages/suitest-npx/lib/onboard.js
@@ -5,7 +5,8 @@ const path = require("node:path");
 
 const { ensureProjectDirs, loadOrCreateCredentials } = require("./project.js");
 const { ensureWebDist, ensureWheels } = require("./assets.js");
-const { requireUv, ensureVenv } = require("./venv.js");
+const { ensureVenv } = require("./venv.js");
+const { preflight } = require("./preflight.js");
 const { up } = require("./stack.js");
 
 // First run → the user MUST set the superadmin account; nothing is auto-generated
@@ -63,8 +64,8 @@ function loadMcpLib(mod) {
 }
 
 // Prepare = every up() prerequisite: uv, assets, venv. Used by onboard AND `suitest up`.
-async function prepare(cwd) {
-  requireUv();
+async function prepare(cwd, opts = {}) {
+  await preflight(opts);
   const dirs = ensureProjectDirs(cwd);
   const webDist = await ensureWebDist();
   const wheels = await ensureWheels();

--- a/packages/suitest-npx/lib/preflight.js
+++ b/packages/suitest-npx/lib/preflight.js
@@ -1,0 +1,122 @@
+"use strict";
+
+// Consent-based prerequisite check for onboard/up. The only real system
+// prerequisite is `uv` (it downloads Python 3.12 and installs the wheels itself).
+// When `uv` is missing we print a short report and — on a TTY, with consent —
+// run the correct per-OS installer, then refresh PATH in-process so onboarding
+// continues in the same terminal instead of dying with an error.
+
+const os = require("node:os");
+const path = require("node:path");
+const fs = require("node:fs");
+const readline = require("node:readline/promises");
+const { spawnSync } = require("node:child_process");
+
+const { uvInstallCommand, uvInstallHint } = require("./venv.js");
+
+// ponytail: stdlib spawn probe, no lookpath dep — matches requireUv in venv.js.
+function checkTool(cmd, args = ["--version"]) {
+  const probe = spawnSync(cmd, args, { stdio: "ignore" });
+  return !probe.error && probe.status === 0;
+}
+
+// uv's default install targets. A just-installed uv is written here but is NOT
+// on the current process PATH — we add these so `execFileSync("uv", …)` resolves
+// without asking the user to open a fresh terminal.
+function uvBinCandidates(platform = process.platform, env = process.env) {
+  const home = os.homedir();
+  const dirs =
+    platform === "win32"
+      ? [env.UV_INSTALL_DIR, path.join(home, ".local", "bin")]
+      : [
+          env.UV_INSTALL_DIR,
+          env.XDG_BIN_HOME,
+          path.join(home, ".local", "bin"),
+          path.join(home, ".cargo", "bin"),
+        ];
+  return dirs.filter((d) => d && fs.existsSync(d));
+}
+
+function refreshUvPath(platform = process.platform, env = process.env) {
+  const sep = platform === "win32" ? ";" : ":";
+  const add = uvBinCandidates(platform, env);
+  if (add.length === 0) return;
+  env.PATH = [...add, env.PATH || ""].join(sep);
+}
+
+// { file, args } for spawnSync + the tool the installer pipe needs.
+function installerFor(platform = process.platform) {
+  const command = uvInstallCommand(platform);
+  return platform === "win32"
+    ? { file: "cmd", args: ["/c", command], prereq: "powershell" }
+    : { file: "sh", args: ["-c", command], prereq: "curl" };
+}
+
+async function askYesNo(question, { defaultYes = true } = {}) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = (await rl.question(question + " ")).trim().toLowerCase();
+    if (!answer) return defaultYes;
+    return answer === "y" || answer === "yes";
+  } finally {
+    rl.close();
+  }
+}
+
+function installUv(platform = process.platform) {
+  const { file, args, prereq } = installerFor(platform);
+  if (!checkTool(prereq, platform === "win32" ? ["-Command", "$PSVersionTable"] : ["--version"])) {
+    throw new Error(
+      `Can't auto-install uv: \`${prereq}\` is missing too. Install uv manually:\n` +
+        uvInstallHint(platform),
+    );
+  }
+  console.log("Installing uv...");
+  const run = spawnSync(file, args, { stdio: "inherit" });
+  if (run.error || run.status !== 0) {
+    throw new Error("uv install failed. Install it manually:\n" + uvInstallHint(platform));
+  }
+  refreshUvPath(platform);
+}
+
+const isTTY = () => Boolean(process.stdin.isTTY && process.stdout.isTTY);
+
+// Report present/missing prerequisites, then (with consent) install uv.
+async function preflight(opts = {}, platform = process.platform) {
+  if (checkTool("uv")) return; // happy path: quiet, no noise.
+
+  const installer = installerFor(platform);
+  const prereqOk = checkTool(
+    installer.prereq,
+    platform === "win32" ? ["-Command", "$PSVersionTable"] : ["--version"],
+  );
+  console.log("Checking prerequisites:");
+  console.log("  uv (python runtime manager) ... not found");
+  console.log(`  ${installer.prereq} (installer)        ... ${prereqOk ? "ok" : "not found"}`);
+
+  // Explicit non-interactive consent (--yes) may proceed; otherwise no TTY = no
+  // way to ask for consent, so fall back to the manual hint (CI stays deterministic).
+  if (!isTTY() && !opts.yes) {
+    throw new Error(uvInstallHint(platform));
+  }
+  if (!opts.yes) {
+    const consent = await askYesNo("Install uv now? [Y/n]", { defaultYes: true });
+    if (!consent) throw new Error(uvInstallHint(platform));
+  }
+
+  installUv(platform);
+  if (!checkTool("uv")) {
+    // Installed but still not resolvable — PATH couldn't be picked up in-process.
+    throw new Error(uvInstallHint(platform));
+  }
+}
+
+module.exports = {
+  checkTool,
+  uvBinCandidates,
+  refreshUvPath,
+  installerFor,
+  askYesNo,
+  installUv,
+  preflight,
+};

--- a/packages/suitest-npx/lib/venv.js
+++ b/packages/suitest-npx/lib/venv.js
@@ -6,14 +6,19 @@ const { execFileSync, spawnSync } = require("node:child_process");
 
 const pkg = require("../package.json");
 
+// The raw per-OS install command — single source of truth shared by the manual
+// hint below and the interactive auto-installer in preflight.js.
+function uvInstallCommand(platform = process.platform) {
+  return platform === "win32"
+    ? 'powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"'
+    : "curl -LsSf https://astral.sh/uv/install.sh | sh";
+}
+
 function uvInstallHint(platform = process.platform) {
-  const cmd =
-    platform === "win32"
-      ? '  powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"'
-      : "  curl -LsSf https://astral.sh/uv/install.sh | sh";
   return (
     "`uv` not found. Install it first:\n" +
-    cmd +
+    "  " +
+    uvInstallCommand(platform) +
     "\nThen close this terminal, open a new one, and run the command again\n" +
     "(a fresh terminal picks up the updated PATH)."
   );
@@ -64,4 +69,4 @@ function ensureVenv(venvDir, wheelsDir) {
   return python;
 }
 
-module.exports = { requireUv, uvInstallHint, ensureVenv, venvPython };
+module.exports = { requireUv, uvInstallCommand, uvInstallHint, ensureVenv, venvPython };

--- a/packages/suitest-npx/test/preflight.test.js
+++ b/packages/suitest-npx/test/preflight.test.js
@@ -1,0 +1,59 @@
+"use strict";
+const { test } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  checkTool,
+  uvBinCandidates,
+  refreshUvPath,
+  installerFor,
+  preflight,
+} = require("../lib/preflight.js");
+
+function tmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "suitest-preflight-"));
+}
+
+test("checkTool returns false for a nonexistent binary", () => {
+  assert.strictEqual(checkTool("definitely-not-a-real-binary-xyz"), false);
+});
+
+test("installerFor is platform-specific with a prereq", () => {
+  const unix = installerFor("darwin");
+  assert.strictEqual(unix.file, "sh");
+  assert.strictEqual(unix.prereq, "curl");
+  assert.match(unix.args.join(" "), /astral\.sh\/uv\/install\.sh/);
+
+  const win = installerFor("win32");
+  assert.strictEqual(win.prereq, "powershell");
+  assert.match(win.args.join(" "), /install\.ps1/);
+});
+
+test("uvBinCandidates filters to existing dirs only", () => {
+  const dir = tmp();
+  const cands = uvBinCandidates("linux", { UV_INSTALL_DIR: dir, XDG_BIN_HOME: "/no/such/dir/x" });
+  assert.ok(cands.includes(dir));
+  assert.ok(!cands.includes("/no/such/dir/x"));
+});
+
+test("refreshUvPath prepends an existing candidate dir to PATH", () => {
+  const dir = tmp();
+  const env = { UV_INSTALL_DIR: dir, PATH: "/usr/bin" };
+  refreshUvPath("linux", env);
+  assert.ok(env.PATH.startsWith(dir + ":"));
+  assert.ok(env.PATH.includes("/usr/bin"));
+});
+
+test("preflight throws the manual hint when non-TTY and uv missing", async () => {
+  const prev = process.env.PATH;
+  process.env.PATH = tmp(); // empty dir: no uv, no curl
+  try {
+    // Non-interactive (node --test has no TTY) and no --yes → must fall back to the hint.
+    await assert.rejects(() => preflight({}, "linux"), /astral\.sh\/uv/);
+  } finally {
+    process.env.PATH = prev;
+  }
+});


### PR DESCRIPTION
## Summary

- `suitest onboard` / `up` hard-failed with a wall-of-text error the moment `uv` was missing, leaving new users stuck.
- `uv` is the only real system prerequisite — it bootstraps Python 3.12 and installs the wheels itself; Node is guaranteed (npm ran the CLI).
- Add a consent-based preflight: report what's missing, ask before installing, run the correct per-OS installer, and continue onboarding in the same terminal. Nothing installs silently.

## Changes

- **`lib/venv.js`** — extract `uvInstallCommand(platform)` as the single per-OS source of truth, reused by the hint and the auto-installer. No behavior change.
- **`lib/preflight.js`** (new) — `preflight(opts)`: probe `uv` + installer prereq (curl/powershell), print a compact report only when something is missing, then on a TTY ask `Install uv now? [Y/n]`, run the installer (`curl|sh` on Unix, `powershell irm|iex` on Windows), and refresh PATH in-process (`~/.local/bin`, `~/.cargo/bin`, `UV_INSTALL_DIR`, `XDG_BIN_HOME`) so `execFileSync("uv", …)` resolves without a fresh terminal.
- **`lib/onboard.js`** — `prepare(cwd, opts)` calls `await preflight(opts)` in place of the bare `requireUv()`.
- **`bin/suitest.js`** — `up` case forwards `opts` so `--yes` works there too.
- **`test/preflight.test.js`** (new) — probing, per-OS `installerFor`, `uvBinCandidates` filtering, in-process PATH refresh, non-TTY fallback to the manual hint.

## Behavior

- **TTY + consent (Y / enter)** → installer runs, PATH refreshed, onboarding continues in the same terminal.
- **Declined (n)** → prints the existing manual install hint.
- **Non-TTY (CI)** → falls back to the manual hint (deterministic); `--yes` provides explicit non-interactive consent.
- Missing `curl`/`powershell` → precise "installer prereq missing" message instead of a mystery pipe failure.

## Test plan

- [x] `cd packages/suitest-npx && node --test "test/*.test.js"` — 39 pass (34 existing + 5 new).
- [x] Existing `venv.test.js` stays green (no `requireUv` signature change).
- [x] Manual (macOS): shadow PATH to hide `uv`, run `suitest onboard`, confirm report + `[Y/n]`, choose Yes → install runs, onboarding continues; choose No → manual hint prints.
- [x] Manual (Windows): confirm `powershell` installer path.