### PR TITLE
fix(mcp): guard cross-client protocol compatibility

### DIFF
--- a/docs-site/src/content/docs/docs/help/troubleshooting.md
+++ b/docs-site/src/content/docs/docs/help/troubleshooting.md
@@ -20,6 +20,19 @@ printf '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}\n{"jsonrpc":"
 
 You should see a `serverInfo` response followed by the tool list. If this works but the IDE shows nothing, the problem is the IDE config, not the server.
 
+### Codex shows `Auth: Unsupported`
+
+This is expected for Suitest. Codex uses the `Auth` column for authentication
+handled by remote HTTP/OAuth MCP transports; Suitest runs locally over stdio
+and receives `SUITEST_API_KEY` through its process environment. If the Suitest
+row is `enabled` and its tools are listed, the connection is working. Use
+`codex mcp get suitest` to confirm the transport, command, and masked env names.
+
+Claude Code can show a project-scoped server as `Pending approval` until you
+approve the project's `.mcp.json`. Antigravity needs a refresh from Settings,
+Customizations after its `mcp_config.json` changes. Neither state indicates a
+Suitest protocol error.
+
 ### "needs Python >= 3.11" or "failed to start python"
 
 The npm package is only a launcher; the server is bundled Python. Install Python 3.11+ or point the launcher at a specific interpreter:

--- a/packages/mcp-npx/test/install.test.js
+++ b/packages/mcp-npx/test/install.test.js
@@ -54,7 +54,48 @@ function silence(fn) {
   assert.ok(snippet.mcp.suitest, "snippet has mcp.suitest");
 }
 
-// 3. write into an empty claude-code config, then idempotency + conflict
+// 3. Codex delegates the exact stdio command and env expected by its CLI.
+{
+  const steps = install.CLIENTS.codex.steps("suitest", ENV, false);
+  assert.deepStrictEqual(steps, [
+    [
+      "mcp",
+      "add",
+      "suitest",
+      "--env",
+      "SUITEST_API_URL=http://localhost:4000",
+      "--env",
+      "SUITEST_API_KEY=sk_test",
+      "--",
+      "npx",
+      "-y",
+      "@suiflex/suitest-mcp",
+    ],
+  ]);
+}
+
+// 4. Antigravity uses the same portable mcpServers stdio shape as Claude.
+{
+  const antigravity = install.serverSpec("antigravity", ENV);
+  const claude = install.serverSpec("claude-code", ENV);
+  assert.deepStrictEqual(antigravity, claude);
+
+  const target = tmp("antigravity.json");
+  process.env.ANTIGRAVITY_CONFIG = target;
+  silence(() => install.installClient("antigravity", {
+    name: "suitest",
+    scope: "global",
+    env: ENV,
+    print: false,
+    dryRun: false,
+    force: false,
+  }));
+  assert.deepStrictEqual(JSON.parse(fs.readFileSync(target, "utf8")), antigravity.snippet);
+  fs.rmSync(target, { force: true });
+  delete process.env.ANTIGRAVITY_CONFIG;
+}
+
+// 5. write into an empty claude-code config, then idempotency + conflict
 {
   const target = tmp("claude.json");
   process.env.CLAUDE_CODE_CONFIG = target;
@@ -93,7 +134,7 @@ function silence(fn) {
   delete process.env.CLAUDE_CODE_CONFIG;
 }
 
-// 4. stripJsonComments handles JSONC (opencode config)
+// 6. stripJsonComments handles JSONC (opencode config)
 {
   const parsed = install.loadJsonObject; // ensure export present
   assert.strictEqual(typeof parsed, "function");
@@ -102,7 +143,7 @@ function silence(fn) {
   assert.deepStrictEqual(JSON.parse(stripped), { mcp: { a: 1 } });
 }
 
-// 5. credsPath honours XDG_CONFIG_HOME
+// 7. credsPath honours XDG_CONFIG_HOME
 {
   const prev = process.env.XDG_CONFIG_HOME;
   const prevDir = process.env.SUITEST_CONFIG_DIR;

--- a/packages/mcp-npx/test/smoke.test.js
+++ b/packages/mcp-npx/test/smoke.test.js
@@ -3,9 +3,9 @@
  * Package smoke test — proves the published artifact actually boots.
  *
  * Spawns the real bin (exactly what `npx @suiflex/suitest-mcp` runs), performs a
- * JSON-RPC `initialize` handshake plus `tools/list` over stdio, and asserts
- * the Suitest tool surface is present. No network, no target app: this is a
- * boot-process test, not an e2e run.
+ * JSON-RPC `initialize` handshake, the discovery probes used by strict MCP
+ * clients (including Codex), and `tools/list` over stdio. No network, no
+ * target app: this is a boot-process test, not an e2e run.
  */
 
 "use strict";
@@ -58,6 +58,12 @@ function boot(apiUrl) {
 
   let buffer = "";
   const responses = [];
+  const probes = [
+    [2, "ping", null],
+    [3, "resources/list", "resources"],
+    [4, "resources/templates/list", "resourceTemplates"],
+    [5, "prompts/list", "prompts"],
+  ];
 
   child.stdout.on("data", (chunk) => {
     buffer += chunk.toString();
@@ -97,10 +103,24 @@ function boot(apiUrl) {
         child.kill();
         fail(`initialize: unexpected serverInfo: ${JSON.stringify(msg).slice(0, 200)}`);
       }
-      send({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+      send({ jsonrpc: "2.0", method: "notifications/initialized" });
+      send({ jsonrpc: "2.0", id: probes[0][0], method: probes[0][1] });
       return;
     }
-    if (msg.id === 2) {
+    const probeIndex = probes.findIndex(([id]) => id === msg.id);
+    if (probeIndex >= 0) {
+      const [, method, emptyKey] = probes[probeIndex];
+      if (msg.error || (emptyKey && !Array.isArray(msg.result && msg.result[emptyKey]))) {
+        clearTimeout(timer);
+        child.kill();
+        fail(`${method}: unexpected response: ${JSON.stringify(msg).slice(0, 200)}`);
+      }
+      const next = probes[probeIndex + 1];
+      if (next) send({ jsonrpc: "2.0", id: next[0], method: next[1] });
+      else send({ jsonrpc: "2.0", id: 6, method: "tools/list" });
+      return;
+    }
+    if (msg.id === 6) {
       clearTimeout(timer);
       const tools = ((msg.result && msg.result.tools) || []).map((t) => t.name);
       const missing = EXPECTED_TOOLS.filter((t) => !tools.includes(t));
@@ -109,7 +129,7 @@ function boot(apiUrl) {
         fail(`tools/list missing: ${missing.join(", ")} (got ${tools.length} tools)`);
       }
       process.stdout.write(
-        `SMOKE OK: initialize + tools/list (${tools.length} tools, ` +
+        `SMOKE OK: initialize + client probes + tools/list (${tools.length} tools, ` +
           `incl. ${EXPECTED_TOOLS.length} checked)\n`,
       );
       process.exit(0);


### PR DESCRIPTION
## What changed

- exercise the strict MCP discovery probes used by Codex before `tools/list`
- lock the generated Codex, Antigravity, and Claude stdio configuration shapes
- document why Codex reports `Auth: Unsupported` for a healthy stdio server

## Why

Codex probes `ping`, resources, templates, and prompts during connection health
checks. The server already handles those methods; this change makes the
published-package smoke test cover that behavior so a regression cannot ship
unnoticed. It also distinguishes client approval/refresh states from protocol
failures.

## Impact

Suitest MCP compatibility with Codex, Antigravity, and Claude is now
continuously checked without adding dependencies or changing the runtime
protocol.

## Validation

- `npm --prefix packages/mcp-npx test` — 22/22 passing
- published `@suiflex/suitest-mcp@0.3.0` handshake — 22 tools
- `git diff --check`
