### PR TITLE
fix(mcp): ship lifecycle 0.1.5 in bundled package

### DIFF
--- a/packages/mcp-npx/README.md
+++ b/packages/mcp-npx/README.md
@@ -133,6 +133,10 @@ This package bundles the `suitest_lifecycle` Python module (stdlib-only) and a
 thin Node launcher that starts it as a stdio MCP server. No pip install, no
 virtualenv, no daemon.
 
+The lifecycle sources are copied from `packages/lifecycle` during `prepack`, so
+lifecycle changes ship in a new `@suiflex/suitest-mcp` patch release. The
+standalone PyPI package keeps its own version.
+
 ## License
 
 Apache-2.0 — see [LICENSE](./LICENSE).


### PR DESCRIPTION
## Summary
- document that the MCP npm package bundles lifecycle sources during prepack
- trigger the MCP patch release so the merged lifecycle 0.1.5 changes are published

## Verification
- npm --prefix packages/mcp-npx test (22 passed)