### PR TITLE
chore(lifecycle): sync workspace lock version

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2581,7 +2581,7 @@ wheels = [
 
 [[package]]
 name = "suiflex-suitest-lifecycle"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "packages/lifecycle" }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- align the lifecycle entry in uv.lock with the published package version 0.1.5
- keep workspace installs reproducible after the lifecycle version bump

This is lock metadata only and does not trigger another MCP release.