### PR TITLE
chore(ci): add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      uv-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      actions-all:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Enable automated weekly dependency update PRs so version drift and security floors get surfaced early instead of by hand.

## Changes
- Add `.github/dependabot.yml` with three ecosystems, all at repo root:
  - `npm` — covers the pnpm workspace (single root lockfile).
  - `uv` — covers the `uv.lock` Python deps.
  - `github-actions` — covers all workflow action pins.
- Group minor/patch bumps per ecosystem (actions grouped fully) to reduce PR noise.
- Skipped Docker: only `Dockerfile.mcp-prototype` exists; add when a real image ships.

## Test plan
- [ ] Dependabot tab shows the three ecosystems parsed without config errors.
- [ ] First weekly run opens grouped PRs (or none if all current).