### PR TITLE
ci(release): use npm trusted publishing

### DIFF
--- a/.github/workflows/release-launcher.yml
+++ b/.github/workflows/release-launcher.yml
@@ -6,9 +6,8 @@ name: release-launcher
 # The package ships the built assets inside the tarball (~3 MB): the web
 # dashboard build + all workspace wheels, produced by
 # scripts/build-bundle-assets.sh and copied in by the package's prepack
-# (scripts/sync-assets.js). Requires the NPM_TOKEN secret (same automation
-# token as release-mcp). On PRs touching the launcher, everything up to the
-# publish runs as validation; publish only fires on the tag.
+# (scripts/sync-assets.js). npm uses OIDC Trusted Publishing, so no NPM_TOKEN
+# secret is maintained. On PRs, everything up to the publish runs as validation.
 
 on:
   push:
@@ -18,13 +17,20 @@ on:
       - "packages/suitest-npx/**"
       - "scripts/build-bundle-assets.sh"
       - ".github/workflows/release-launcher.yml"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing launcher release tag to publish to npm
+        required: true
+        type: string
 
 permissions:
-  contents: write  # create GitHub Release on tag
+  contents: write # create GitHub Release on tag
 
 jobs:
   npm:
     name: "@suiflex/suitest → npm"
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -57,24 +63,92 @@ jobs:
           npm pack --dry-run
           npm publish --dry-run --access public
 
+  publish-npm:
+    name: "@suiflex/suitest → npm"
+    if: github.event_name == 'push'
+    needs: [npm]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.5.2
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+          registry-url: "https://registry.npmjs.org"
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@11.5.2
+      - name: Install web deps
+        run: pnpm install --frozen-lockfile
+      - name: Build bundle assets (web dist + wheels)
+        run: ./scripts/build-bundle-assets.sh
       - name: Tag matches package version
-        if: startsWith(github.ref, 'refs/tags/launcher-v')
         working-directory: packages/suitest-npx
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#launcher-v}"
           PKG_VERSION="$(node -p "require('./package.json').version")"
           [ "$TAG_VERSION" = "$PKG_VERSION" ] || {
-            echo "tag $TAG_VERSION != package.json $PKG_VERSION" >&2; exit 1; }
-
-      - name: Publish
-        if: startsWith(github.ref, 'refs/tags/launcher-v')
+            echo "tag $GITHUB_REF_NAME != package.json $PKG_VERSION" >&2; exit 1; }
+      - name: Publish to npm
         working-directory: packages/suitest-npx
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: GitHub Release
-        if: startsWith(github.ref, 'refs/tags/launcher-v')
         run: gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes
         env:
           GH_TOKEN: ${{ github.token }}
+
+  recover-npm:
+    name: "Recover @suiflex/suitest npm publish"
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.5.2
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+          registry-url: "https://registry.npmjs.org"
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@11.5.2
+      - name: Install web deps
+        run: pnpm install --frozen-lockfile
+      - name: Build bundle assets (web dist + wheels)
+        run: ./scripts/build-bundle-assets.sh
+      - name: Unit tests
+        working-directory: packages/suitest-npx
+        run: npm test
+      - name: Tag matches package version
+        working-directory: packages/suitest-npx
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          TAG_VERSION="${RELEASE_TAG#launcher-v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          [ "$TAG_VERSION" = "$PKG_VERSION" ] || {
+            echo "tag $RELEASE_TAG != package.json $PKG_VERSION" >&2; exit 1; }
+      - name: Publish to npm
+        working-directory: packages/suitest-npx
+        run: npm publish --access public

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -4,9 +4,8 @@ name: release-mcp
 #   - @suiflex/suitest-mcp        → npm  (npx -y @suiflex/suitest-mcp)
 #   - suiflex-suitest-lifecycle   → PyPI (uvx --from suiflex-suitest-lifecycle suitest-mcp)
 #
-# Requires an NPM_TOKEN secret (npm automation token) and a PYPI_TOKEN secret
-# (PyPI API token). On PRs touching the packages, the build + smoke + dry-run
-# steps run to validate; publish only fires on the tag.
+# npm uses OIDC Trusted Publishing; no long-lived NPM_TOKEN is required. PyPI
+# still uses PYPI_TOKEN. On PRs, the build + smoke + dry-run steps validate.
 
 on:
   push:
@@ -16,6 +15,12 @@ on:
       - "packages/mcp-npx/**"
       - "packages/lifecycle/**"
       - ".github/workflows/release-mcp.yml"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing mcp release tag to publish to npm
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -23,6 +28,7 @@ permissions:
 jobs:
   npm:
     name: "@suiflex/suitest-mcp → npm"
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -45,14 +51,72 @@ jobs:
           npm pack --dry-run
           npm publish --dry-run --access public
 
-      - name: Publish
-        if: startsWith(github.ref, 'refs/tags/mcp-v')
+  publish-npm:
+    name: "@suiflex/suitest-mcp → npm"
+    if: github.event_name == 'push'
+    needs: [npm]
+    runs-on: ubuntu-latest
+    # OIDC Trusted Publishing: npm trusts this repository, workflow, and the
+    # `release` environment, so GitHub mints a short-lived token per publish.
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    defaults:
+      run:
+        working-directory: packages/mcp-npx
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@11.5.2
+      - name: Tag matches package version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#mcp-v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          [ "$TAG_VERSION" = "$PKG_VERSION" ] || {
+            echo "tag $GITHUB_REF_NAME != package.json $PKG_VERSION" >&2; exit 1; }
+      - name: Publish to npm
         run: npm publish --access public
+
+  recover-npm:
+    name: "Recover @suiflex/suitest-mcp npm publish"
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    defaults:
+      run:
+        working-directory: packages/mcp-npx
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@11.5.2
+      - name: Tag matches package version
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          TAG_VERSION="${RELEASE_TAG#mcp-v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          [ "$TAG_VERSION" = "$PKG_VERSION" ] || {
+            echo "tag $RELEASE_TAG != package.json $PKG_VERSION" >&2; exit 1; }
+      - name: Publish to npm
+        run: npm publish --access public
 
   pypi:
     name: "suiflex-suitest-lifecycle → PyPI"
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/release-ts-sdk.yml
+++ b/.github/workflows/release-ts-sdk.yml
@@ -1,8 +1,7 @@
 name: release-ts-sdk
 
-# M4-6: build + publish @suiflex/suitest-sdk to npm on a `tssdk-v*` tag. Requires an
-# NPM_TOKEN secret with publish rights (npm automation token). On PRs the build
-# + typecheck run to validate the package; publish only fires on the tag.
+# M4-6: build + publish @suiflex/suitest-sdk to npm on a `tssdk-v*` tag through
+# OIDC Trusted Publishing. On PRs, the build + typecheck validate the package.
 
 on:
   push:
@@ -11,12 +10,19 @@ on:
     paths:
       - "sdk/typescript/**"
       - ".github/workflows/release-ts-sdk.yml"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing TypeScript SDK release tag to publish to npm
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 jobs:
   build:
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -32,12 +38,73 @@ jobs:
       - run: npm run build
       - name: Validate package contents (publish dry-run)
         # `npm pack --dry-run` + `npm publish --dry-run` prove the tarball builds
-        # and would be accepted by the registry before NPM_TOKEN exists.
+        # and would be accepted by the registry before an OIDC publish run.
         run: |
           npm pack --dry-run
           npm publish --dry-run --access public
-      - name: Publish
-        if: startsWith(github.ref, 'refs/tags/tssdk-v')
+
+  publish-npm:
+    name: "@suiflex/suitest-sdk → npm"
+    if: github.event_name == 'push'
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    defaults:
+      run:
+        working-directory: sdk/typescript
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+      # Node 20 ships npm 10; trusted publishing requires npm >= 11.5.1.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@11.5.2
+      - run: npm install --no-audit --no-fund
+      - run: npm run build
+      - name: Tag matches package version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#tssdk-v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          [ "$TAG_VERSION" = "$PKG_VERSION" ] || {
+            echo "tag $GITHUB_REF_NAME != package.json $PKG_VERSION" >&2; exit 1; }
+      - name: Publish to npm
         run: npm publish --access public
+
+  recover-npm:
+    name: "Recover @suiflex/suitest-sdk npm publish"
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    defaults:
+      run:
+        working-directory: sdk/typescript
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@11.5.2
+      - run: npm install --no-audit --no-fund
+      - run: npm run build
+      - name: Tag matches package version
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          TAG_VERSION="${RELEASE_TAG#tssdk-v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          [ "$TAG_VERSION" = "$PKG_VERSION" ] || {
+            echo "tag $RELEASE_TAG != package.json $PKG_VERSION" >&2; exit 1; }
+      - name: Publish to npm
+        run: npm publish --access public

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -232,7 +232,7 @@ CLOUD tier works with ≥ 5 providers tested: anthropic, openai, gemini, groq, o
 #### SDK + CLI
 
 - [~] **M4-5** `suitest-py` SDK published to PyPI (generated from OpenAPI) (code-complete — [`sdk/python`](../sdk/python) typed httpx client tracking the OpenAPI schema + Apache-2 + `release-python-sdk.yml` Trusted-Publishing workflow now runs a `twine check` publish dry-run on every PR (proves wheel + sdist metadata would be accepted); **PyPI publish pending** — needs project + OIDC publisher configured)
-- [~] **M4-6** `@suiflex/suitest-sdk` TS SDK published to npm (code-complete — [`sdk/typescript`](../sdk/typescript) dependency-free fetch client, strict tsc green + `release-ts-sdk.yml` npm-publish workflow now runs `npm pack` + `npm publish --dry-run` on every PR (proves the tarball would be accepted); **npm publish pending** — needs NPM_TOKEN secret)
+- [~] **M4-6** `@suiflex/suitest-sdk` TS SDK published to npm (code-complete — [`sdk/typescript`](../sdk/typescript) dependency-free fetch client, strict tsc green + `release-ts-sdk.yml` runs `npm pack` + `npm publish --dry-run` on every PR; tag publish and manual recovery use npm OIDC Trusted Publishing through the `release` environment, with no long-lived npm token; **first npm publish pending**)
 - [x] **M4-7** `suitest` CLI: `suitest run`, `suitest cases list`, `suitest mcp ls` (shipped — [`cli`](../cli) argparse front-end over suiflex-suitest-sdk; run/cases-list/mcp-ls against the real API, env-driven connection, non-zero exit on error/failed run)
 
 #### Eval + observability


### PR DESCRIPTION
## Summary

- Replace long-lived npm publish tokens with GitHub OIDC trusted publishing.
- Add safe npm-only recovery paths for releases whose publish step fails.

## Changes

- Publish all three npm packages through the `release` environment with a short-lived OIDC token.
- Add tag-version checks and manual recovery dispatches for MCP, TypeScript SDK, and launcher packages.
- Keep MCP PyPI publishing and launcher GitHub Release creation out of recovery runs.
- Update the M4-6 roadmap entry for OIDC publishing.

## Test plan

- [x] Parse all modified GitHub Actions workflows with Ruby YAML.
- [x] Run Prettier checks for the modified workflows.
- [x] Run `apps/web/node_modules/.bin/tsc -p sdk/typescript/tsconfig.json --noEmit`.
- [x] Run `git diff --check`.
- [x] Confirm no `secrets.NPM_TOKEN` or `NODE_AUTH_TOKEN` remains in npm release workflows.

Milestone: M4-6
