### PR TITLE
feat: detect nuxt/sveltekit/vue and trim evidence video blank frames

### DIFF
--- a/docs-site/src/content/docs/docs/guides/getting-started.md
+++ b/docs-site/src/content/docs/docs/guides/getting-started.md
@@ -30,8 +30,8 @@ npx -y @suiflex/suitest-mcp init
 ```
 
 `init` detects your IDE (Claude Code or Cursor from project markers; pass
-`--ide windsurf` for Windsurf) and your framework (Next.js, Vite, Express,
-Django), then asks one question: local or server. Pick **local** for now; it
+`--ide windsurf` for Windsurf) and your framework (Next.js, Nuxt, SvelteKit,
+Vite, Vue, Express, Django), then asks one question: local or server. Pick **local** for now; it
 needs no API key.
 
 It writes two files:

--- a/docs-site/src/content/docs/docs/install/mcp-server.md
+++ b/docs-site/src/content/docs/docs/install/mcp-server.md
@@ -47,8 +47,9 @@ npx -y @suiflex/suitest-mcp init
    `.claude/` directory means Claude Code, a `.cursor/` directory means Cursor.
    Windsurf keeps its MCP config in your home directory, so it has no project
    marker: select it explicitly with `--ide windsurf`.
-2. **Detects your app framework.** Next.js, Vite, and Express are read from
-   `package.json` dependencies; a `manage.py` file means Django. Detection
+2. **Detects your app framework.** Next.js, Nuxt, SvelteKit, Vite, Vue (CLI),
+   and Express are read from `package.json` dependencies; a `manage.py` file
+   means Django. Detection
    seeds the test mode (`frontend` or `backend`) and the app `baseUrl`. If
    nothing is detected, `init` asks for a base URL (default
    `http://localhost:3000`).

--- a/packages/lifecycle/src/suitest_lifecycle/exporters/frontend.py
+++ b/packages/lifecycle/src/suitest_lifecycle/exporters/frontend.py
@@ -20,7 +20,9 @@ _HEADER = """import asyncio
 import glob
 import json
 import os
+import re
 import shutil
+import subprocess
 import uuid
 
 from playwright.async_api import async_playwright, expect
@@ -54,6 +56,41 @@ _N = [0]
 def _begin(step_type, description):
     _N[0] += 1
     _cur.update(index=_N[0], type=step_type, description=description)
+
+
+def _trim_leading_blank(src):
+    # Playwright starts recording at about:blank (white) and keeps rolling
+    # through the app's first-load spinner before content paints. Detect the
+    # first real visual change (scene change) and drop everything before it.
+    # ffmpeg is optional: if it's absent, detection fails, or there's nothing to
+    # trim, the original video is kept untouched.
+    # ponytail: re-encode is O(video length); fine for short evidence clips. If
+    #           clips ever get long, switch to -c copy with keyframe snapping.
+    if shutil.which("ffmpeg") is None:
+        return src
+    try:
+        probe = subprocess.run(
+            ["ffmpeg", "-i", src, "-vf", "select='gt(scene,0.02)',showinfo",
+             "-an", "-f", "null", "-"],
+            capture_output=True, text=True, timeout=30,
+        )
+        m = re.search(r"pts_time:(\\d+\\.?\\d*)", probe.stderr)
+        if not m:
+            return src
+        start = max(float(m.group(1)) - 0.15, 0.0)
+        if start < 0.2:  # nothing meaningful to trim
+            return src
+        out = src[:-5] + ".trim.webm"
+        r = subprocess.run(
+            ["ffmpeg", "-y", "-ss", "%.3f" % start, "-i", src,
+             "-c:v", "libvpx-vp9", "-an", out],
+            capture_output=True, text=True, timeout=120,
+        )
+        if r.returncode == 0 and os.path.exists(out) and os.path.getsize(out) > 0:
+            os.replace(out, src)  # overwrite same name -> result.json unchanged
+    except Exception:
+        pass
+    return src
 
 
 async def _shot(page):
@@ -164,6 +201,9 @@ async def run_test():
             except Exception:
                 pass
         vids = sorted(glob.glob(os.path.join(_VIDEO_DIR, "*.webm")))
+        _video = vids[-1] if vids else None
+        if _video:
+            _video = _trim_leading_blank(_video)
         with open(_RESULT, "w", encoding="utf-8") as fh:
             json.dump(
                 {
@@ -171,7 +211,7 @@ async def run_test():
                     "status": status,
                     "error": error,
                     "steps": STEPS,
-                    "video": vids[-1] if vids else None,
+                    "video": _video,
                     # Per-step screenshots already include the final state.
                     # A second "final" PNG doubled the last frame for no UI value.
                     "screenshot": None,

--- a/packages/lifecycle/tests/test_frontend_video_trim.py
+++ b/packages/lifecycle/tests/test_frontend_video_trim.py
@@ -1,0 +1,23 @@
+"""The generated frontend test must inline the ffmpeg leading-blank trimmer.
+
+The helper lives inside a template string (generated TCxxx.py files are
+standalone — no runtime import of suitest_lifecycle), so it can't be imported
+and exercised directly. We assert the rendered template wires it correctly:
+graceful ffmpeg guard, and the trim applied to the collected video path.
+"""
+
+from __future__ import annotations
+
+from suitest_lifecycle.exporters.frontend import _HEADER, _RUNNER
+
+
+def test_header_defines_trimmer_with_optional_ffmpeg_guard() -> None:
+    assert "def _trim_leading_blank(src):" in _HEADER
+    # ffmpeg is optional — absence must be a no-op, not a crash.
+    assert 'shutil.which("ffmpeg") is None' in _HEADER
+    assert "return src" in _HEADER
+
+
+def test_runner_trims_the_collected_video() -> None:
+    assert "_video = _trim_leading_blank(_video)" in _RUNNER
+    assert '"video": _video,' in _RUNNER

--- a/packages/mcp-npx/lib/detect-framework.js
+++ b/packages/mcp-npx/lib/detect-framework.js
@@ -9,10 +9,15 @@
 const fs = require("node:fs");
 const path = require("node:path");
 
-// Order = priority. `next` before `express`: a Next app often ships both.
+// Order = priority. Meta-frameworks (nuxt, sveltekit) before `vite`: they ship
+// vite as a dep, but their own dev-server port must win. `next` before
+// `express`: a Next app often ships both.
 const FRAMEWORKS = [
   { id: "nextjs", dep: "next", mode: "frontend", baseUrl: "http://localhost:3000" },
+  { id: "nuxt", dep: "nuxt", mode: "frontend", baseUrl: "http://localhost:3000" },
+  { id: "sveltekit", dep: "@sveltejs/kit", mode: "frontend", baseUrl: "http://localhost:5173" },
   { id: "vite", dep: "vite", mode: "frontend", baseUrl: "http://localhost:5173" },
+  { id: "vue", dep: "@vue/cli-service", mode: "frontend", baseUrl: "http://localhost:8080" },
   { id: "express", dep: "express", mode: "backend", baseUrl: "http://localhost:3000" },
 ];
 

--- a/packages/mcp-npx/test/detect-framework.test.js
+++ b/packages/mcp-npx/test/detect-framework.test.js
@@ -34,6 +34,42 @@ test("vite -> frontend :5173", () => {
   assert.strictEqual(detectFramework(dir).baseUrl, "http://localhost:5173");
 });
 
+test("nuxt -> frontend :3000", () => {
+  const dir = projectWith({
+    "package.json": JSON.stringify({ dependencies: { nuxt: "^3" } }),
+  });
+  assert.deepStrictEqual(detectFramework(dir), {
+    framework: "nuxt",
+    mode: "frontend",
+    baseUrl: "http://localhost:3000",
+  });
+});
+
+test("sveltekit -> frontend :5173", () => {
+  const dir = projectWith({
+    "package.json": JSON.stringify({ devDependencies: { "@sveltejs/kit": "^2" } }),
+  });
+  assert.deepStrictEqual(detectFramework(dir), {
+    framework: "sveltekit",
+    mode: "frontend",
+    baseUrl: "http://localhost:5173",
+  });
+});
+
+test("vue cli -> frontend :8080", () => {
+  const dir = projectWith({
+    "package.json": JSON.stringify({ devDependencies: { "@vue/cli-service": "^5" } }),
+  });
+  assert.strictEqual(detectFramework(dir).baseUrl, "http://localhost:8080");
+});
+
+test("nuxt beats vite when both present", () => {
+  const dir = projectWith({
+    "package.json": JSON.stringify({ dependencies: { nuxt: "^3", vite: "^6" } }),
+  });
+  assert.strictEqual(detectFramework(dir).framework, "nuxt");
+});
+
 test("express -> backend :3000", () => {
   const dir = projectWith({
     "package.json": JSON.stringify({ dependencies: { express: "^4" } }),


### PR DESCRIPTION
## Summary
- `init` now auto-detects Nuxt, SvelteKit, and Vue (CLI) apps, so their mode/`baseUrl` are seeded without a manual `--base-url` — closing the "only React (Next/Vite) is supported" gap.
- Evidence videos no longer open with a wall of white/loading frames: an optional ffmpeg pass trims the leading blank that Playwright records before the app paints (worst on dev servers that compile on first request).

## Changes
- **init (`packages/mcp-npx/lib/detect-framework.js`)** — add `nuxt` (:3000), `sveltekit` (:5173), `vue`/@vue/cli-service (:8080); meta-frameworks ordered before `vite` so their own dev port wins. Vite-based Vue/Svelte still resolve via the existing `vite` row.
- **export (`packages/lifecycle/src/suitest_lifecycle/exporters/frontend.py`)** — inline `_trim_leading_blank()` in generated tests: scene-detect the first real frame and cut everything before it. ffmpeg optional; absent/failed/nothing-to-trim keeps the original video, filename unchanged so `result.json.video` stays valid.
- **tests** — 4 new framework-detection cases (incl. nuxt-beats-vite ordering); a render test asserting the trimmer + ffmpeg guard + call site are wired.
- **docs** — list the new frameworks in the init guides.

## Test plan
- [x] `node --test test/detect-framework.test.js` → 9/9 green
- [x] `npm test` in `packages/mcp-npx` (sync-python + all node tests) → 26/26 green
- [x] Frontend template renders via `.format()` and `compile()`s clean (no brace clash)
- [x] Video-trim render test passes
- [ ] Manual: run a generated test against a slow-booting Nuxt dev server → confirm leading white/loading trimmed, video still plays, `result.json.video` valid
- [ ] Manual: run with ffmpeg absent from PATH → run succeeds, original video intact