### PR TITLE
feat: UAT document export (Berita Acara PDF)

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "slowapi>=0.1.9",
   "arq>=0.26",
   "aioboto3>=12.4",
+  "fpdf2>=2.8.5",
 ]
 
 [build-system]

--- a/apps/api/src/suitest_api/main.py
+++ b/apps/api/src/suitest_api/main.py
@@ -142,6 +142,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     from suitest_api.routers.projects import router as projects_router
     from suitest_api.routers.prompts import router as prompts_router
     from suitest_api.routers.requirements import requirements_router, traceability_router
+    from suitest_api.routers.exports import router as exports_router
     from suitest_api.routers.runs import router as runs_router
     from suitest_api.routers.suites import router as suites_router
     from suitest_api.routers.test_cases import router as test_cases_router
@@ -223,6 +224,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(requirements_router)
     app.include_router(traceability_router)
     app.include_router(runs_router)
+    app.include_router(exports_router)
     app.include_router(defects_router)
     app.include_router(integrations_router)
     app.include_router(documents_router)

--- a/apps/api/src/suitest_api/main.py
+++ b/apps/api/src/suitest_api/main.py
@@ -129,6 +129,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     from suitest_api.routers.defects import router as defects_router
     from suitest_api.routers.documents import router as documents_router
     from suitest_api.routers.eval_runs import router as eval_runs_router
+    from suitest_api.routers.exports import router as exports_router
     from suitest_api.routers.files import router as files_router
     from suitest_api.routers.generators import router as generators_router
     from suitest_api.routers.inbox import router as inbox_router
@@ -142,7 +143,6 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     from suitest_api.routers.projects import router as projects_router
     from suitest_api.routers.prompts import router as prompts_router
     from suitest_api.routers.requirements import requirements_router, traceability_router
-    from suitest_api.routers.exports import router as exports_router
     from suitest_api.routers.runs import router as runs_router
     from suitest_api.routers.suites import router as suites_router
     from suitest_api.routers.test_cases import router as test_cases_router

--- a/apps/api/src/suitest_api/routers/exports.py
+++ b/apps/api/src/suitest_api/routers/exports.py
@@ -1,0 +1,62 @@
+"""Document exports scoped by project -> workspace. UAT ("Berita Acara") PDF."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+from suitest_db.audit import write_audit
+
+from suitest_api.auth.db import get_async_session
+from suitest_api.deps.scope import TenantContext, require_workspace_membership
+from suitest_api.services.uat_document import Locale
+from suitest_api.services.uat_document_service import UatDocumentService, UatExportError
+
+router = APIRouter(prefix="/api/v1", tags=["exports"])
+
+
+class UatExportBody(BaseModel):
+    case_ids: list[str] = Field(min_length=1, max_length=500)
+    title: str = Field(min_length=1, max_length=200)
+    locale: Locale = "id"
+
+
+@router.post("/projects/{project_id}/exports/uat", response_class=Response)
+async def export_uat_document(
+    project_id: str,
+    body: UatExportBody,
+    ctx: TenantContext = Depends(require_workspace_membership),
+    session: AsyncSession = Depends(get_async_session),
+) -> Response:
+    """Build a Suitest-branded UAT sign-off PDF from the selected test cases.
+
+    Each case contributes its latest-run status + screenshot evidence. ZERO-tier,
+    deterministic. 404 when any case is outside this project/workspace.
+    """
+    service = UatDocumentService(session)
+    try:
+        pdf = await service.build_pdf(
+            project_id=project_id,
+            workspace_id=ctx.workspace_id,
+            case_ids=body.case_ids,
+            title=body.title,
+            locale=body.locale,
+        )
+    except UatExportError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+    await write_audit(
+        session,
+        workspace_id=ctx.workspace_id,
+        user_id=ctx.user_id,
+        action="uat_export",
+        resource_type="project",
+        resource_id=project_id,
+        metadata={"case_count": len(body.case_ids), "locale": body.locale},
+    )
+    filename = f"uat-{project_id}.pdf"
+    return Response(
+        content=pdf,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/apps/api/src/suitest_api/services/file_storage.py
+++ b/apps/api/src/suitest_api/services/file_storage.py
@@ -144,6 +144,50 @@ async def presign_get(key: str) -> str:
     return url
 
 
+async def read_bytes(url: str) -> bytes | None:
+    """Read an artifact's raw bytes from its stored URL.
+
+    Handles the three schemes the platform writes: ``local://<key>`` (npx/disk),
+    ``file://<abs-path>`` (runner-local artifacts) and ``s3://<bucket>/<key>``
+    (object store). Returns ``None`` when the object is missing — a caller
+    embedding evidence should degrade to "no screenshot", never 500.
+    """
+    if url.startswith("file://"):
+        path = Path(url[len("file://") :])
+        return await _read_local(path)
+    if url.startswith("local://"):
+        return await _read_local(local_path(url[len("local://") :]))
+    if url.startswith("s3://"):
+        _, _, rest = url.partition("s3://")
+        bucket, _, key = rest.partition("/")
+        settings = get_settings()
+        async with aioboto3.Session().client(
+            "s3",
+            endpoint_url=settings.s3_endpoint,
+            aws_access_key_id=settings.s3_access_key,
+            aws_secret_access_key=settings.s3_secret_key,
+            region_name=settings.s3_region,
+        ) as client:
+            try:
+                obj = await client.get_object(Bucket=bucket, Key=key)
+                async with obj["Body"] as stream:
+                    data: bytes = await stream.read()
+                return data
+            except Exception:  # missing/denied object → degrade gracefully
+                return None
+    return None
+
+
+async def _read_local(path: Path) -> bytes | None:
+    def _read() -> bytes | None:
+        try:
+            return path.read_bytes()
+        except OSError:
+            return None
+
+    return await anyio.to_thread.run_sync(_read)
+
+
 async def delete(key: str) -> None:
     """Delete one owned object."""
     settings = get_settings()

--- a/apps/api/src/suitest_api/services/uat_document.py
+++ b/apps/api/src/suitest_api/services/uat_document.py
@@ -1,0 +1,109 @@
+"""Pure UAT-document assembler — deterministic, ORM-free, ZERO-tier.
+
+Takes already-loaded structural inputs (``CaseInput``) and produces a
+``UatDocument`` the renderer turns into a PDF. No DB, no IO — so it unit-tests
+with hand-built fixtures exactly like ``junit_report_service.render_junit``.
+
+Status rollup per case: any ERROR/FAIL step -> FAILED; a case with no run step
+or only SKIP/PENDING -> NOT RUN; otherwise PASSED.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from suitest_shared.domain.enums import StepOutcome
+
+Locale = Literal["id", "en"]
+Status = Literal["PASSED", "FAILED", "NOT RUN"]
+
+_SKIP = frozenset({StepOutcome.SKIP, StepOutcome.PENDING})
+
+
+@dataclass
+class StepInput:
+    order: int
+    action: str
+    expected: str
+
+
+@dataclass
+class CaseInput:
+    title: str
+    suite_name: str
+    modul_fitur: str
+    steps: list[StepInput]
+    run_outcomes: list[StepOutcome]  # the case's latest-run step outcomes ([] = not run)
+    evidence: list[str]  # data: URIs (resolved by the loader)
+
+
+@dataclass
+class UatRow:
+    no: int
+    modul_fitur: str
+    test_case: str
+    steps: list[str]
+    results: list[str]
+    status: Status
+    evidence: list[str]
+
+
+@dataclass
+class UatSection:
+    module_name: str
+    rows: list[UatRow] = field(default_factory=list)
+
+
+@dataclass
+class UatDocument:
+    title: str
+    generated_at: str
+    locale: Locale
+    pass_pct: int
+    sections: list[UatSection] = field(default_factory=list)
+
+
+def _rollup(outcomes: list[StepOutcome]) -> Status:
+    if any(o in (StepOutcome.ERROR, StepOutcome.FAIL) for o in outcomes):
+        return "FAILED"
+    if not outcomes or all(o in _SKIP for o in outcomes):
+        return "NOT RUN"
+    return "PASSED"
+
+
+def assemble_document(
+    *, title: str, locale: Locale, generated_at: str, cases: list[CaseInput]
+) -> UatDocument:
+    """Group cases into per-suite sections and compute statuses + pass %."""
+    order: list[str] = []
+    sections: dict[str, UatSection] = {}
+    passed = 0
+    for case in cases:
+        if case.suite_name not in sections:
+            order.append(case.suite_name)
+            sections[case.suite_name] = UatSection(module_name=case.suite_name)
+        section = sections[case.suite_name]
+        status = _rollup(case.run_outcomes)
+        if status == "PASSED":
+            passed += 1
+        ordered = sorted(case.steps, key=lambda s: s.order)
+        section.rows.append(
+            UatRow(
+                no=len(section.rows) + 1,
+                modul_fitur=case.modul_fitur,
+                test_case=case.title,
+                steps=[s.action for s in ordered],
+                results=[s.expected for s in ordered],
+                status=status,
+                evidence=case.evidence,
+            )
+        )
+    pass_pct = round(passed * 100 / len(cases)) if cases else 0
+    return UatDocument(
+        title=title,
+        generated_at=generated_at,
+        locale=locale,
+        pass_pct=pass_pct,
+        sections=[sections[name] for name in order],
+    )

--- a/apps/api/src/suitest_api/services/uat_document_service.py
+++ b/apps/api/src/suitest_api/services/uat_document_service.py
@@ -1,0 +1,114 @@
+"""Load selected cases + their latest-run results/evidence and build a UAT PDF.
+
+Thin IO layer over the pure assembler: repositories fetch cases/suites/steps/tags
+and each case's latest-run RunSteps + SCREENSHOT artifacts; artifact bytes become
+base64 data-URIs via file_storage. ZERO-tier, deterministic.
+"""
+
+from __future__ import annotations
+
+import base64
+from datetime import UTC, datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from suitest_core.capabilities import TierFlag
+from suitest_db.repositories.runs import RunRepo
+from suitest_db.repositories.suites import SuiteRepo
+from suitest_db.repositories.test_cases import TestCaseRepo
+from suitest_shared.domain.enums import ArtifactKind, StepOutcome
+
+from suitest_api.deps.tier import require_tier
+from suitest_api.services import file_storage
+from suitest_api.services.uat_document import (
+    CaseInput,
+    Locale,
+    StepInput,
+    UatDocument,
+    assemble_document,
+)
+from suitest_api.services.uat_renderer import render_pdf
+
+
+class UatExportError(Exception):
+    """A selected case does not exist in / belong to the target project/workspace."""
+
+
+class UatDocumentService:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+        self._cases = TestCaseRepo(session)
+        self._suites = SuiteRepo(session)
+        self._runs = RunRepo(session)
+
+    @require_tier(TierFlag.ANY)
+    async def build_pdf(
+        self,
+        *,
+        project_id: str,
+        workspace_id: str,
+        case_ids: list[str],
+        title: str,
+        locale: Locale,
+    ) -> bytes:
+        cases = await self._cases.list_active_by_ids(case_ids)
+        found = {c.id for c in cases}
+        missing = [cid for cid in case_ids if cid not in found]
+        if missing:
+            raise UatExportError(f"unknown case(s): {missing}")
+
+        by_id = {c.id: c for c in cases}
+        inputs: list[CaseInput] = []
+        for cid in case_ids:  # preserve caller order
+            case = by_id[cid]
+            if case.workspace_id != workspace_id:
+                raise UatExportError(f"case {cid} outside workspace")
+            suite = await self._suites.get_active_by_id(case.suite_id)
+            if suite is None or suite.project_id != project_id:
+                raise UatExportError(f"case {cid} not in project {project_id}")
+            steps = await self._cases.get_steps(case.id)
+            tags = await self._cases.get_tags(case.id)
+            outcomes, evidence = await self._latest_run(case.last_run_id, case.id)
+            inputs.append(
+                CaseInput(
+                    title=case.title,
+                    suite_name=suite.name,
+                    modul_fitur=tags[0] if tags else suite.name,
+                    steps=[StepInput(order=s.order, action=s.action, expected=s.expected) for s in steps],
+                    run_outcomes=outcomes,
+                    evidence=evidence,
+                )
+            )
+
+        doc: UatDocument = assemble_document(
+            title=title,
+            locale=locale,
+            generated_at=datetime.now(UTC).strftime("%d %b %Y %H:%M UTC"),
+            cases=inputs,
+        )
+        return render_pdf(doc)
+
+    async def _latest_run(
+        self, run_id: str | None, case_id: str
+    ) -> tuple[list[StepOutcome], list[str]]:
+        """Return (this case's ordered run-step outcomes, screenshot data-URIs)."""
+        if run_id is None:
+            return [], []
+        run_steps = [s for s in await self._runs.get_steps(run_id) if s.case_id == case_id]
+        run_steps.sort(key=lambda s: s.step_order)
+        outcomes = [s.outcome for s in run_steps]
+        step_ids = {s.id for s in run_steps}
+        # ponytail: loads all artifacts of the run per case; group by run_id if this
+        # ever shows up in profiling for large multi-case selections.
+        artifacts = [
+            a
+            for a in await self._runs.get_artifacts(run_id)
+            if a.kind == ArtifactKind.SCREENSHOT and a.run_step_id in step_ids
+        ]
+        evidence: list[str] = []
+        for a in artifacts:
+            raw = await file_storage.read_bytes(a.url)
+            if raw is None:
+                continue
+            b64 = base64.b64encode(raw).decode("ascii")
+            evidence.append(f"data:{a.mime_type};base64,{b64}")
+        return outcomes, evidence

--- a/apps/api/src/suitest_api/services/uat_document_service.py
+++ b/apps/api/src/suitest_api/services/uat_document_service.py
@@ -75,7 +75,10 @@ class UatDocumentService:
                     title=case.title,
                     suite_name=suite.name,
                     modul_fitur=tags[0] if tags else suite.name,
-                    steps=[StepInput(order=s.order, action=s.action, expected=s.expected) for s in steps],
+                    steps=[
+                        StepInput(order=s.order, action=s.action, expected=s.expected)
+                        for s in steps
+                    ],
                     run_outcomes=outcomes,
                     evidence=evidence,
                 )

--- a/apps/api/src/suitest_api/services/uat_document_service.py
+++ b/apps/api/src/suitest_api/services/uat_document_service.py
@@ -67,7 +67,9 @@ class UatDocumentService:
                 raise UatExportError(f"case {cid} not in project {project_id}")
             steps = await self._cases.get_steps(case.id)
             tags = await self._cases.get_tags(case.id)
-            outcomes, evidence = await self._latest_run(case.last_run_id, case.id)
+            outcomes, evidence = await self._latest_run(
+                case.last_run_id, case.id, project_id=project_id, workspace_id=workspace_id
+            )
             inputs.append(
                 CaseInput(
                     title=case.title,
@@ -88,10 +90,22 @@ class UatDocumentService:
         return render_pdf(doc)
 
     async def _latest_run(
-        self, run_id: str | None, case_id: str
+        self, run_id: str | None, case_id: str, *, project_id: str, workspace_id: str
     ) -> tuple[list[StepOutcome], list[str]]:
-        """Return (this case's ordered run-step outcomes, screenshot data-URIs)."""
+        """Return (this case's ordered run-step outcomes, screenshot data-URIs).
+
+        The case's ``last_run_id`` pointer is NOT trusted: a case can be moved
+        between projects and ``run_steps.case_id`` has no cascade, so the pointed
+        run may belong to another project/workspace. If it does, we degrade to
+        "no run" (NOT RUN, no evidence) rather than embed cross-boundary data.
+        """
         if run_id is None:
+            return [], []
+        pair = await self._runs.get_with_summary(run_id)
+        if pair is None:
+            return [], []
+        run, _ = pair
+        if run.project_id != project_id or run.workspace_id != workspace_id:
             return [], []
         run_steps = [s for s in await self._runs.get_steps(run_id) if s.case_id == case_id]
         run_steps.sort(key=lambda s: s.step_order)
@@ -104,11 +118,13 @@ class UatDocumentService:
             for a in await self._runs.get_artifacts(run_id)
             if a.kind == ArtifactKind.SCREENSHOT and a.run_step_id in step_ids
         ]
-        evidence: list[str] = []
+        # The renderer draws only the first evidence image, so stop at the first
+        # one we can actually read — avoids base64'ing every screenshot into memory
+        # (matters on the npx-laptop target).
         for a in artifacts:
             raw = await file_storage.read_bytes(a.url)
             if raw is None:
                 continue
             b64 = base64.b64encode(raw).decode("ascii")
-            evidence.append(f"data:{a.mime_type};base64,{b64}")
-        return outcomes, evidence
+            return outcomes, [f"data:{a.mime_type};base64,{b64}"]
+        return outcomes, []

--- a/apps/api/src/suitest_api/services/uat_renderer.py
+++ b/apps/api/src/suitest_api/services/uat_renderer.py
@@ -1,0 +1,119 @@
+"""Render a UatDocument to a branded PDF with fpdf2 (pure-Python, no system libs).
+
+Chosen over WeasyPrint deliberately: the export must run both in Docker AND in the
+npx local bundle (uvicorn on a user laptop, deps from wheels). fpdf2 + Pillow are
+self-contained wheels; WeasyPrint would need native pango/cairo that a bare laptop
+lacks. Deterministic, ZERO-tier. Labels are a small in-module locale dict.
+
+Layout reproduces sample-dokumen-uat.pdf: navy banner title, document subtitle,
+date + pass %, then one navy-headed table per suite section with a green/red/amber
+status cell and an embedded screenshot in the Evidence column.
+"""
+
+from __future__ import annotations
+
+import base64
+from io import BytesIO
+
+from fpdf import FPDF
+from fpdf.fonts import FontFace
+
+from suitest_api.services.uat_document import UatDocument
+
+_NAVY = (31, 58, 95)
+_NAVY2 = (51, 80, 122)
+_WHITE = (255, 255, 255)
+_STATUS_COLOR = {"PASSED": (21, 128, 61), "FAILED": (185, 28, 28), "NOT RUN": (161, 98, 7)}
+
+_LABELS: dict[str, dict[str, str]] = {
+    "id": {
+        "doc_title": "BERITA ACARA USER ACCEPTANCE TEST (UAT)",
+        "no": "No", "modul": "Modul/ Fitur", "test_case": "Test Case",
+        "test_step": "Test Step", "test_result": "Test Result", "status": "Status",
+        "evidence": "Evidence", "result_percent": "Persentase", "generated": "Tanggal",
+        "not_run": "BELUM DIJALANKAN",
+    },
+    "en": {
+        "doc_title": "USER ACCEPTANCE TEST (UAT) REPORT",
+        "no": "No", "modul": "Module / Feature", "test_case": "Test Case",
+        "test_step": "Test Step", "test_result": "Test Result", "status": "Status",
+        "evidence": "Evidence", "result_percent": "Pass rate", "generated": "Date",
+        "not_run": "NOT RUN",
+    },
+}
+
+
+class _UatPdf(FPDF):
+    def footer(self) -> None:
+        self.set_y(-12)
+        self.set_font("Helvetica", "", 8)
+        self.set_text_color(136, 136, 136)
+        self.cell(0, 8, "Powered by Suiflex  -  Suitest", align="C")
+
+
+def _first_image(evidence: list[str]) -> BytesIO | None:
+    """Decode the first evidence data-URI to a stream fpdf2 can embed; None on failure."""
+    if not evidence:
+        return None
+    try:
+        b64 = evidence[0].split(",", 1)[1]
+        return BytesIO(base64.b64decode(b64))
+    except Exception:  # bad/absent image must never break the export
+        return None
+
+
+def render_pdf(doc: UatDocument) -> bytes:
+    """Render the document to PDF bytes (fpdf2). Pure, deterministic, ZERO-tier."""
+    labels = _LABELS.get(doc.locale, _LABELS["id"])
+    pdf = _UatPdf(orientation="P", unit="mm", format="A4")
+    pdf.set_auto_page_break(auto=True, margin=16)
+    pdf.add_page()
+
+    # Banner + subtitle + meta line.
+    pdf.set_fill_color(*_NAVY)
+    pdf.set_text_color(*_WHITE)
+    pdf.set_font("Helvetica", "B", 15)
+    pdf.cell(0, 12, labels["doc_title"], align="C", fill=True, new_x="LMARGIN", new_y="NEXT")
+    pdf.set_text_color(*_NAVY)
+    pdf.set_font("Helvetica", "B", 11)
+    pdf.cell(0, 8, doc.title, align="C", new_x="LMARGIN", new_y="NEXT")
+    pdf.set_text_color(0, 0, 0)
+    pdf.set_font("Helvetica", "", 9)
+    pdf.cell(
+        0, 6,
+        f'{labels["generated"]}: {doc.generated_at}    {labels["result_percent"]}: {doc.pass_pct}%',
+        new_x="LMARGIN", new_y="NEXT",
+    )
+    pdf.ln(2)
+
+    headings = [labels[k] for k in ("no", "modul", "test_case", "test_step", "test_result", "status", "evidence")]
+    for section in doc.sections:
+        pdf.set_fill_color(*_NAVY2)
+        pdf.set_text_color(*_WHITE)
+        pdf.set_font("Helvetica", "B", 10)
+        pdf.cell(0, 7, section.module_name, align="C", fill=True, new_x="LMARGIN", new_y="NEXT")
+        pdf.set_text_color(0, 0, 0)
+        pdf.set_font("Helvetica", "", 8)
+        with pdf.table(
+            col_widths=(6, 16, 22, 30, 30, 12, 24),
+            text_align=("CENTER", "LEFT", "LEFT", "LEFT", "LEFT", "CENTER", "CENTER"),
+            headings_style=FontFace(emphasis="BOLD", color=_WHITE, fill_color=_NAVY2),
+            line_height=5,
+        ) as table:
+            table.row(headings)
+            for r in section.rows:
+                row = table.row()
+                row.cell(str(r.no))
+                row.cell(r.modul_fitur)
+                row.cell(r.test_case)
+                row.cell("\n".join(f"{i}. {s}" for i, s in enumerate(r.steps, 1)))
+                row.cell("\n".join(f"{i}. {s}" for i, s in enumerate(r.results, 1)))
+                disp = labels["not_run"] if r.status == "NOT RUN" else r.status
+                row.cell(disp, style=FontFace(emphasis="BOLD", color=_STATUS_COLOR[r.status]))
+                img = _first_image(r.evidence)
+                if img is not None:
+                    row.cell(img=img, img_fill_width=True)
+                else:
+                    row.cell("")
+
+    return bytes(pdf.output())

--- a/apps/api/src/suitest_api/services/uat_renderer.py
+++ b/apps/api/src/suitest_api/services/uat_renderer.py
@@ -28,16 +28,28 @@ _STATUS_COLOR = {"PASSED": (21, 128, 61), "FAILED": (185, 28, 28), "NOT RUN": (1
 _LABELS: dict[str, dict[str, str]] = {
     "id": {
         "doc_title": "BERITA ACARA USER ACCEPTANCE TEST (UAT)",
-        "no": "No", "modul": "Modul/ Fitur", "test_case": "Test Case",
-        "test_step": "Test Step", "test_result": "Test Result", "status": "Status",
-        "evidence": "Evidence", "result_percent": "Persentase", "generated": "Tanggal",
+        "no": "No",
+        "modul": "Modul/ Fitur",
+        "test_case": "Test Case",
+        "test_step": "Test Step",
+        "test_result": "Test Result",
+        "status": "Status",
+        "evidence": "Evidence",
+        "result_percent": "Persentase",
+        "generated": "Tanggal",
         "not_run": "BELUM DIJALANKAN",
     },
     "en": {
         "doc_title": "USER ACCEPTANCE TEST (UAT) REPORT",
-        "no": "No", "modul": "Module / Feature", "test_case": "Test Case",
-        "test_step": "Test Step", "test_result": "Test Result", "status": "Status",
-        "evidence": "Evidence", "result_percent": "Pass rate", "generated": "Date",
+        "no": "No",
+        "modul": "Module / Feature",
+        "test_case": "Test Case",
+        "test_step": "Test Step",
+        "test_result": "Test Result",
+        "status": "Status",
+        "evidence": "Evidence",
+        "result_percent": "Pass rate",
+        "generated": "Date",
         "not_run": "NOT RUN",
     },
 }
@@ -80,13 +92,18 @@ def render_pdf(doc: UatDocument) -> bytes:
     pdf.set_text_color(0, 0, 0)
     pdf.set_font("Helvetica", "", 9)
     pdf.cell(
-        0, 6,
-        f'{labels["generated"]}: {doc.generated_at}    {labels["result_percent"]}: {doc.pass_pct}%',
-        new_x="LMARGIN", new_y="NEXT",
+        0,
+        6,
+        f"{labels['generated']}: {doc.generated_at}    {labels['result_percent']}: {doc.pass_pct}%",
+        new_x="LMARGIN",
+        new_y="NEXT",
     )
     pdf.ln(2)
 
-    headings = [labels[k] for k in ("no", "modul", "test_case", "test_step", "test_result", "status", "evidence")]
+    headings = [
+        labels[k]
+        for k in ("no", "modul", "test_case", "test_step", "test_result", "status", "evidence")
+    ]
     for section in doc.sections:
         pdf.set_fill_color(*_NAVY2)
         pdf.set_text_color(*_WHITE)

--- a/apps/api/tests/services/test_file_storage_read.py
+++ b/apps/api/tests/services/test_file_storage_read.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-
 from suitest_api.services import file_storage
 
 

--- a/apps/api/tests/services/test_file_storage_read.py
+++ b/apps/api/tests/services/test_file_storage_read.py
@@ -1,0 +1,34 @@
+"""read_bytes resolves local:// and file:// artifact URLs to bytes (no S3 needed)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from suitest_api.services import file_storage
+
+
+@pytest.mark.asyncio
+async def test_read_bytes_file_scheme(tmp_path: Path) -> None:
+    p = tmp_path / "shot.png"
+    p.write_bytes(b"\x89PNGdata")
+    got = await file_storage.read_bytes(f"file://{p}")
+    assert got == b"\x89PNGdata"
+
+
+@pytest.mark.asyncio
+async def test_read_bytes_local_scheme(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    key = "uploads/ws1/abc/shot.png"
+    target = tmp_path / key
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"localbytes")
+    monkeypatch.setattr(file_storage, "local_path", lambda k: tmp_path / k)
+    got = await file_storage.read_bytes(f"local://{key}")
+    assert got == b"localbytes"
+
+
+@pytest.mark.asyncio
+async def test_read_bytes_missing_returns_none(tmp_path: Path) -> None:
+    got = await file_storage.read_bytes(f"file://{tmp_path / 'nope.png'}")
+    assert got is None

--- a/apps/api/tests/services/test_uat_document.py
+++ b/apps/api/tests/services/test_uat_document.py
@@ -1,0 +1,89 @@
+"""Pure assembler tests — grouping, per-section numbering, status rollup, pass %.
+
+ORM-free: hand-built CaseInput fixtures, no DB/session (mirrors junit tests)."""
+
+from __future__ import annotations
+
+from suitest_api.services.uat_document import (
+    CaseInput,
+    StepInput,
+    assemble_document,
+)
+from suitest_shared.domain.enums import StepOutcome as SO
+
+
+def _case(title: str, suite: str, modul: str, outcomes: list[SO], *, evidence=None) -> CaseInput:
+    return CaseInput(
+        title=title,
+        suite_name=suite,
+        modul_fitur=modul,
+        steps=[StepInput(order=1, action="do a thing", expected="it works")],
+        run_outcomes=outcomes,
+        evidence=evidence or [],
+    )
+
+
+def test_groups_by_suite_and_numbers_per_section() -> None:
+    doc = assemble_document(
+        title="UAT Portal",
+        locale="id",
+        generated_at="29 Juni 2026",
+        cases=[
+            _case("Logo", "Login", "Header", [SO.PASS]),
+            _case("Form", "Login", "Form", [SO.PASS]),
+            _case("Chart", "Dashboard", "Overview", [SO.PASS]),
+        ],
+    )
+    assert [s.module_name for s in doc.sections] == ["Login", "Dashboard"]
+    assert [r.no for r in doc.sections[0].rows] == [1, 2]
+    assert doc.sections[1].rows[0].no == 1
+    assert doc.sections[0].rows[0].modul_fitur == "Header"
+
+
+def test_status_rollup() -> None:
+    doc = assemble_document(
+        title="t", locale="id", generated_at="x",
+        cases=[
+            _case("ok", "S", "m", [SO.PASS, SO.PASS]),
+            _case("fail", "S", "m", [SO.PASS, SO.FAIL]),
+            _case("err", "S", "m", [SO.ERROR]),
+            _case("none", "S", "m", []),
+            _case("skip", "S", "m", [SO.SKIP, SO.PENDING]),
+        ],
+    )
+    statuses = [r.status for r in doc.sections[0].rows]
+    assert statuses == ["PASSED", "FAILED", "FAILED", "NOT RUN", "NOT RUN"]
+
+
+def test_pass_pct_counts_only_passed_over_total() -> None:
+    doc = assemble_document(
+        title="t", locale="id", generated_at="x",
+        cases=[
+            _case("a", "S", "m", [SO.PASS]),
+            _case("b", "S", "m", [SO.PASS]),
+            _case("c", "S", "m", [SO.FAIL]),
+            _case("d", "S", "m", []),
+        ],
+    )
+    assert doc.pass_pct == 50  # 2 passed / 4 total
+
+
+def test_steps_and_results_preserved_in_order() -> None:
+    c = CaseInput(
+        title="multi", suite_name="S", modul_fitur="m",
+        steps=[
+            StepInput(order=2, action="second", expected="r2"),
+            StepInput(order=1, action="first", expected="r1"),
+        ],
+        run_outcomes=[SO.PASS], evidence=[],
+    )
+    doc = assemble_document(title="t", locale="id", generated_at="x", cases=[c])
+    row = doc.sections[0].rows[0]
+    assert row.steps == ["first", "second"]      # sorted by order
+    assert row.results == ["r1", "r2"]
+
+
+def test_empty_selection_is_empty_doc_100_guard() -> None:
+    doc = assemble_document(title="t", locale="id", generated_at="x", cases=[])
+    assert doc.sections == []
+    assert doc.pass_pct == 0

--- a/apps/api/tests/services/test_uat_document.py
+++ b/apps/api/tests/services/test_uat_document.py
@@ -42,7 +42,9 @@ def test_groups_by_suite_and_numbers_per_section() -> None:
 
 def test_status_rollup() -> None:
     doc = assemble_document(
-        title="t", locale="id", generated_at="x",
+        title="t",
+        locale="id",
+        generated_at="x",
         cases=[
             _case("ok", "S", "m", [SO.PASS, SO.PASS]),
             _case("fail", "S", "m", [SO.PASS, SO.FAIL]),
@@ -57,7 +59,9 @@ def test_status_rollup() -> None:
 
 def test_pass_pct_counts_only_passed_over_total() -> None:
     doc = assemble_document(
-        title="t", locale="id", generated_at="x",
+        title="t",
+        locale="id",
+        generated_at="x",
         cases=[
             _case("a", "S", "m", [SO.PASS]),
             _case("b", "S", "m", [SO.PASS]),
@@ -70,16 +74,19 @@ def test_pass_pct_counts_only_passed_over_total() -> None:
 
 def test_steps_and_results_preserved_in_order() -> None:
     c = CaseInput(
-        title="multi", suite_name="S", modul_fitur="m",
+        title="multi",
+        suite_name="S",
+        modul_fitur="m",
         steps=[
             StepInput(order=2, action="second", expected="r2"),
             StepInput(order=1, action="first", expected="r1"),
         ],
-        run_outcomes=[SO.PASS], evidence=[],
+        run_outcomes=[SO.PASS],
+        evidence=[],
     )
     doc = assemble_document(title="t", locale="id", generated_at="x", cases=[c])
     row = doc.sections[0].rows[0]
-    assert row.steps == ["first", "second"]      # sorted by order
+    assert row.steps == ["first", "second"]  # sorted by order
     assert row.results == ["r1", "r2"]
 
 

--- a/apps/api/tests/services/test_uat_document.py
+++ b/apps/api/tests/services/test_uat_document.py
@@ -12,7 +12,14 @@ from suitest_api.services.uat_document import (
 from suitest_shared.domain.enums import StepOutcome as SO
 
 
-def _case(title: str, suite: str, modul: str, outcomes: list[SO], *, evidence=None) -> CaseInput:
+def _case(
+    title: str,
+    suite: str,
+    modul: str,
+    outcomes: list[SO],
+    *,
+    evidence: list[str] | None = None,
+) -> CaseInput:
     return CaseInput(
         title=title,
         suite_name=suite,

--- a/apps/api/tests/services/test_uat_renderer.py
+++ b/apps/api/tests/services/test_uat_renderer.py
@@ -1,0 +1,63 @@
+"""Renderer smoke tests — valid PDF bytes, both locales, evidence embed (no DB)."""
+
+from __future__ import annotations
+
+import base64
+
+from suitest_api.services.uat_document import UatDocument, UatRow, UatSection
+from suitest_api.services.uat_renderer import render_pdf
+
+# 1x1 transparent PNG — a minimal valid image for the evidence path.
+_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+
+
+def _doc(*, locale: str = "id", evidence: list[str] | None = None) -> UatDocument:
+    return UatDocument(
+        title="UAT Portal Debitur",
+        generated_at="29 Jun 2026 12:00 UTC",
+        locale=locale,  # type: ignore[arg-type]
+        pass_pct=100,
+        sections=[
+            UatSection(
+                module_name="Login",
+                rows=[
+                    UatRow(
+                        no=1,
+                        modul_fitur="Form Login",
+                        test_case="Verifikasi login valid",
+                        steps=["Masukkan username", "Klik Login"],
+                        results=["Diarahkan ke dashboard"],
+                        status="PASSED",
+                        evidence=evidence or [],
+                    )
+                ],
+            )
+        ],
+    )
+
+
+def test_render_pdf_is_valid_pdf() -> None:
+    pdf = render_pdf(_doc())
+    assert pdf[:5] == b"%PDF-"
+    assert len(pdf) > 1000
+
+
+def test_render_pdf_embeds_evidence_image() -> None:
+    uri = "data:image/png;base64," + base64.b64encode(_PNG).decode("ascii")
+    pdf = render_pdf(_doc(evidence=[uri]))
+    assert pdf[:5] == b"%PDF-"
+
+
+def test_both_locales_render_and_differ() -> None:
+    id_pdf = render_pdf(_doc(locale="id"))
+    en_pdf = render_pdf(_doc(locale="en"))
+    assert id_pdf[:5] == b"%PDF-" and en_pdf[:5] == b"%PDF-"
+    # Different banner/labels → different content streams.
+    assert id_pdf != en_pdf
+
+
+def test_bad_evidence_uri_does_not_crash() -> None:
+    pdf = render_pdf(_doc(evidence=["data:image/png;base64,not-valid-b64!!"]))
+    assert pdf[:5] == b"%PDF-"

--- a/apps/api/tests/test_exports_uat.py
+++ b/apps/api/tests/test_exports_uat.py
@@ -32,7 +32,9 @@ async def _seed_case(
     )
     await api_db.add_all([case])
     # add step after case is committed so case.id is populated
-    step = TestStep(case_id=case.id, order=0, action="Open login page", expected="Login form visible")
+    step = TestStep(
+        case_id=case.id, order=0, action="Open login page", expected="Login form visible"
+    )
     await api_db.add_all([step])
     return suite, case
 
@@ -76,11 +78,14 @@ async def test_uat_export_200_with_run(api_db: ApiDb) -> None:
         status=RunStatus.PASS,
     )
     await api_db.add_all([run])
-    await api_db.add_all([RunStep(run_id=run.id, case_id=case.id, step_order=0, outcome=StepOutcome.PASS)])
+    await api_db.add_all(
+        [RunStep(run_id=run.id, case_id=case.id, step_order=0, outcome=StepOutcome.PASS)]
+    )
     # wire last_run_id so service picks it up
     async with api_db.maker() as session:
         from sqlalchemy import update
         from suitest_db.models.case import TestCase as TC
+
         await session.execute(update(TC).where(TC.id == case.id).values(last_run_id=run.id))
         await session.commit()
 

--- a/apps/api/tests/test_exports_uat.py
+++ b/apps/api/tests/test_exports_uat.py
@@ -1,0 +1,136 @@
+"""POST /api/v1/projects/{project_id}/exports/uat — UAT PDF export endpoint tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from suitest_db.models.case import TestCase, TestStep
+from suitest_db.models.project import Project, Suite
+from suitest_db.models.run import Run, RunStep
+from suitest_shared.domain.enums import CaseSource, RunStatus, RunTrigger, StepOutcome, Tier
+
+if TYPE_CHECKING:
+    from api_harness import ApiDb
+
+
+async def _seed_case(
+    api_db: ApiDb,
+    ws_id: str,
+    project_id: str,
+    *,
+    public_id: str = "TC-UAT1",
+) -> tuple[Suite, TestCase]:
+    suite = Suite(project_id=project_id, name="UAT Suite", order=0)
+    await api_db.add_all([suite])
+    case = TestCase(
+        suite_id=suite.id,
+        workspace_id=ws_id,
+        public_id=public_id,
+        name="Login smoke",
+        source=CaseSource.MANUAL,
+    )
+    await api_db.add_all([case])
+    # add step after case is committed so case.id is populated
+    step = TestStep(case_id=case.id, order=0, action="Open login page", expected="Login form visible")
+    await api_db.add_all([step])
+    return suite, case
+
+
+@pytest.mark.asyncio
+async def test_uat_export_200_returns_pdf(api_db: ApiDb) -> None:
+    """Happy path: one case (no run → NOT RUN status) → 200 + PDF bytes."""
+    user = await api_db.seed_user(email="uat-export@example.com")
+    ws = await api_db.member_workspace(user, slug="uat-export-ws")
+    proj = Project(workspace_id=ws.id, slug="uat-proj", name="UAT Project")
+    await api_db.add_all([proj])
+    _, case = await _seed_case(api_db, ws.id, proj.id)
+
+    async with api_db.client(user) as c:
+        resp = await c.post(
+            f"/api/v1/projects/{proj.id}/exports/uat",
+            json={"case_ids": [case.id], "title": "UAT Smoke", "locale": "id"},
+            headers={"X-Workspace-Id": ws.id},
+        )
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/pdf"
+    assert resp.content[:5] == b"%PDF-"
+
+
+@pytest.mark.asyncio
+async def test_uat_export_200_with_run(api_db: ApiDb) -> None:
+    """Case with a completed PASS run → still 200 + PDF."""
+    user = await api_db.seed_user(email="uat-export-run@example.com")
+    ws = await api_db.member_workspace(user, slug="uat-export-run-ws")
+    proj = Project(workspace_id=ws.id, slug="uat-proj-run", name="UAT Run Project")
+    await api_db.add_all([proj])
+    _, case = await _seed_case(api_db, ws.id, proj.id, public_id="TC-UAT2")
+
+    run = Run(
+        public_id="RUN-UAT1",
+        project_id=proj.id,
+        name="smoke",
+        trigger=RunTrigger.MANUAL,
+        tier_at_runtime=Tier.ZERO,
+        status=RunStatus.PASS,
+    )
+    await api_db.add_all([run])
+    await api_db.add_all([RunStep(run_id=run.id, case_id=case.id, step_order=0, outcome=StepOutcome.PASS)])
+    # wire last_run_id so service picks it up
+    async with api_db.maker() as session:
+        from sqlalchemy import update
+        from suitest_db.models.case import TestCase as TC
+        await session.execute(update(TC).where(TC.id == case.id).values(last_run_id=run.id))
+        await session.commit()
+
+    async with api_db.client(user) as c:
+        resp = await c.post(
+            f"/api/v1/projects/{proj.id}/exports/uat",
+            json={"case_ids": [case.id], "title": "UAT Smoke Run", "locale": "en"},
+            headers={"X-Workspace-Id": ws.id},
+        )
+
+    assert resp.status_code == 200
+    assert resp.content[:5] == b"%PDF-"
+
+
+@pytest.mark.asyncio
+async def test_uat_export_404_unknown_case(api_db: ApiDb) -> None:
+    """A case_id not in the DB → 404."""
+    user = await api_db.seed_user(email="uat-404@example.com")
+    ws = await api_db.member_workspace(user, slug="uat-404-ws")
+    proj = Project(workspace_id=ws.id, slug="uat-proj-404", name="P")
+    await api_db.add_all([proj])
+
+    async with api_db.client(user) as c:
+        resp = await c.post(
+            f"/api/v1/projects/{proj.id}/exports/uat",
+            json={"case_ids": ["nonexistent-case-id"], "title": "UAT", "locale": "id"},
+            headers={"X-Workspace-Id": ws.id},
+        )
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_uat_export_404_case_in_different_project(api_db: ApiDb) -> None:
+    """A valid case that belongs to a different project → 404."""
+    user = await api_db.seed_user(email="uat-cross@example.com")
+    ws = await api_db.member_workspace(user, slug="uat-cross-ws")
+
+    # project A owns the case
+    proj_a = Project(workspace_id=ws.id, slug="uat-proj-a", name="A")
+    proj_b = Project(workspace_id=ws.id, slug="uat-proj-b", name="B")
+    await api_db.add_all([proj_a, proj_b])
+    _, case = await _seed_case(api_db, ws.id, proj_a.id, public_id="TC-UAT-X")
+
+    # POST to project B → case not in project B → 404
+    async with api_db.client(user) as c:
+        resp = await c.post(
+            f"/api/v1/projects/{proj_b.id}/exports/uat",
+            json={"case_ids": [case.id], "title": "UAT", "locale": "id"},
+            headers={"X-Workspace-Id": ws.id},
+        )
+
+    assert resp.status_code == 404

--- a/apps/web/src/components/cases/ExportUatDialog.tsx
+++ b/apps/web/src/components/cases/ExportUatDialog.tsx
@@ -91,10 +91,7 @@ export function ExportUatDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        data-testid="export-uat-dialog"
-        className="gap-0 overflow-hidden p-0"
-      >
+      <DialogContent data-testid="export-uat-dialog" className="gap-0 overflow-hidden p-0">
         {/* Accent top-rule — the "document seal" cue */}
         <div className="h-[3px] w-full bg-gradient-to-r from-accent/70 via-accent to-accent/40" />
 
@@ -158,9 +155,7 @@ export function ExportUatDialog({
           </div>
 
           <fieldset className="flex flex-col gap-1.5">
-            <legend className="mb-1.5 text-sm font-medium leading-none text-fg-1">
-              Language
-            </legend>
+            <legend className="mb-1.5 text-sm font-medium leading-none text-fg-1">Language</legend>
             <div
               role="radiogroup"
               aria-label="Document language"

--- a/apps/web/src/components/cases/ExportUatDialog.tsx
+++ b/apps/web/src/components/cases/ExportUatDialog.tsx
@@ -1,0 +1,239 @@
+import { FileDown, FileText, Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { exportUatDocument } from "@/lib/api-client";
+import { cn } from "@/lib/utils";
+
+type Locale = "id" | "en";
+
+export interface ExportUatDialogProps {
+  projectId: string;
+  /** Internal case IDs to include in the document. */
+  selectedIds: string[];
+  /** Seeds the document title field. */
+  projectName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const LOCALES: { value: Locale; label: string; sub: string }[] = [
+  { value: "id", label: "ID", sub: "Bahasa Indonesia" },
+  { value: "en", label: "EN", sub: "English" },
+];
+
+/**
+ * Compose a branded UAT acceptance document from a hand-picked set of test
+ * cases. The dialog renders a small "document manifest" — a title, a language
+ * choice, and a live count of the cases that will be bound into the PDF — then
+ * streams the rendered file straight to a browser download.
+ *
+ * ZERO-tier: pure server-side document rendering, no LLM, no capability gate.
+ */
+export function ExportUatDialog({
+  projectId,
+  selectedIds,
+  projectName,
+  open,
+  onOpenChange,
+}: ExportUatDialogProps): React.ReactElement {
+  const [title, setTitle] = useState(projectName);
+  const [locale, setLocale] = useState<Locale>("id");
+  const [busy, setBusy] = useState(false);
+
+  const count = selectedIds.length;
+  const empty = count === 0;
+  const trimmed = title.trim();
+
+  // Re-seed the title each time the dialog opens so it always reflects the
+  // current project (the component is rendered persistently by the caller).
+  useEffect(() => {
+    if (open) {
+      setTitle(projectName);
+      setLocale("id");
+    }
+  }, [open, projectName]);
+
+  const handleExport = async (): Promise<void> => {
+    if (empty || busy) return;
+    setBusy(true);
+    try {
+      const blob = await exportUatDocument(projectId, {
+        case_ids: selectedIds,
+        title: trimmed || projectName,
+        locale,
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `uat-${projectId}.pdf`;
+      a.click();
+      URL.revokeObjectURL(url);
+      toast.success(`UAT document exported — ${count} case${count === 1 ? "" : "s"}.`);
+      onOpenChange(false);
+    } catch {
+      toast.error("Couldn't export the UAT document. Please try again.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        data-testid="export-uat-dialog"
+        className="gap-0 overflow-hidden p-0"
+      >
+        {/* Accent top-rule — the "document seal" cue */}
+        <div className="h-[3px] w-full bg-gradient-to-r from-accent/70 via-accent to-accent/40" />
+
+        <form
+          className="flex flex-col gap-5 p-6"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void handleExport();
+          }}
+        >
+          <DialogHeader>
+            <div className="flex items-center gap-2.5">
+              <span
+                aria-hidden="true"
+                className="flex h-8 w-8 items-center justify-center rounded-md border border-border bg-bg-elev-2 text-accent"
+              >
+                <FileText className="h-4 w-4" />
+              </span>
+              <DialogTitle className="text-[16px]">Export UAT document</DialogTitle>
+            </div>
+            <DialogDescription>
+              Bind the selected cases into a branded, sign-off–ready acceptance PDF.
+            </DialogDescription>
+          </DialogHeader>
+
+          {/* Selected-case manifest — mono count chip over a hairline surface */}
+          <div
+            data-testid="export-uat-summary"
+            className={cn(
+              "flex items-center justify-between rounded-lg border border-border bg-bg-elev-1 px-3.5 py-3",
+              empty && "border-amber/40",
+            )}
+          >
+            <span className="text-[12px] text-fg-3">
+              {empty
+                ? "No cases selected — pick at least one to export."
+                : "Cases in this document"}
+            </span>
+            <span
+              className={cn(
+                "shrink-0 rounded-md px-2 py-0.5 font-mono text-[13px] tabular-nums",
+                empty ? "bg-bg-elev-2 text-fg-5" : "bg-accent/10 text-accent",
+              )}
+            >
+              {count}
+            </span>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="export-uat-title">Document title</Label>
+            <Input
+              id="export-uat-title"
+              data-testid="export-uat-title"
+              value={title}
+              onChange={(e) => {
+                setTitle(e.target.value);
+              }}
+              placeholder={projectName}
+              autoComplete="off"
+            />
+          </div>
+
+          <fieldset className="flex flex-col gap-1.5">
+            <legend className="mb-1.5 text-sm font-medium leading-none text-fg-1">
+              Language
+            </legend>
+            <div
+              role="radiogroup"
+              aria-label="Document language"
+              data-testid="export-uat-locale"
+              className="grid grid-cols-2 gap-2"
+            >
+              {LOCALES.map((opt) => {
+                const active = locale === opt.value;
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    role="radio"
+                    aria-checked={active}
+                    data-testid={`export-uat-locale-${opt.value}`}
+                    onClick={() => {
+                      setLocale(opt.value);
+                    }}
+                    className={cn(
+                      "flex items-center gap-2.5 rounded-lg border px-3 py-2.5 text-left transition-colors",
+                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+                      active
+                        ? "border-accent/50 bg-accent/[0.07]"
+                        : "border-border bg-bg-elev-1 hover:bg-bg-elev-2",
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "font-mono text-[13px] font-semibold",
+                        active ? "text-accent" : "text-fg-3",
+                      )}
+                    >
+                      {opt.label}
+                    </span>
+                    <span className="text-[11.5px] text-fg-4">{opt.sub}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </fieldset>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                onOpenChange(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              size="sm"
+              data-testid="export-uat-submit"
+              disabled={empty || busy}
+            >
+              {busy ? (
+                <>
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                  Exporting…
+                </>
+              ) : (
+                <>
+                  <FileDown className="h-3.5 w-3.5" aria-hidden="true" />
+                  Export PDF
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -865,3 +865,22 @@ export async function revokeApiKey(id: string): Promise<void> {
   const ws = requireWorkspaceId();
   await api.delete(`/workspaces/${ws}/api-keys/${id}`);
 }
+
+// ---------------------------------------------------------------------------
+// UAT document export — branded PDF for a hand-picked set of cases.
+// ---------------------------------------------------------------------------
+
+/**
+ * ``POST /projects/:id/exports/uat`` — render the selected cases into a branded
+ * UAT PDF. Returns the raw PDF blob (attachment) for a client-side download.
+ * ZERO-tier: pure document generation, no LLM, no capability gating.
+ */
+export async function exportUatDocument(
+  projectId: string,
+  body: { case_ids: string[]; title: string; locale: "id" | "en" },
+): Promise<Blob> {
+  const res = await api.post(`/projects/${projectId}/exports/uat`, body, {
+    responseType: "blob",
+  });
+  return res.data as Blob;
+}

--- a/apps/web/src/routes/_app/cases.tsx
+++ b/apps/web/src/routes/_app/cases.tsx
@@ -540,7 +540,9 @@ function CaseTree({
                         "bg-bg-elev-2 shadow-[inset_2px_0_0_0_theme(colors.accent)]",
                     )}
                   >
-                    <SourceDot status={c.status === "DEPRECATED" || c.status === "STALE" ? "warn" : "pass"} />
+                    <SourceDot
+                      status={c.status === "DEPRECATED" || c.status === "STALE" ? "warn" : "pass"}
+                    />
                     <span className="shrink-0 whitespace-nowrap font-mono text-[10.5px] text-fg-5">
                       {c.public_id}
                     </span>

--- a/apps/web/src/routes/_app/cases.tsx
+++ b/apps/web/src/routes/_app/cases.tsx
@@ -5,6 +5,7 @@ import {
   AlertTriangle,
   ChevronDown,
   Code2,
+  FileDown,
   FileText,
   FolderTree,
   ListChecks,
@@ -18,6 +19,7 @@ import { useTranslation } from "react-i18next";
 import { CreateCaseDialog } from "@/components/cases/CreateCaseDialog";
 import { CreateProjectDialog } from "@/components/cases/CreateProjectDialog";
 import { CreateSuiteDialog } from "@/components/cases/CreateSuiteDialog";
+import { ExportUatDialog } from "@/components/cases/ExportUatDialog";
 import { GenerateModal } from "@/components/cases/GenerateModal";
 import type { GeneratorStrategy } from "@/components/cases/GenerateModal";
 import { CasesSkeleton } from "@/components/cases/skeleton";
@@ -1284,6 +1286,7 @@ function CasesBody(): React.ReactElement {
   const [active, setActive] = useState<Tab>("all");
   const [suiteDialogOpen, setSuiteDialogOpen] = useState(false);
   const [caseDialogOpen, setCaseDialogOpen] = useState(false);
+  const [exportDialogOpen, setExportDialogOpen] = useState(false);
   const [query, setQuery] = useState("");
 
   // GenerateModal state — `null` strategy = open at the target-select step;
@@ -1407,6 +1410,15 @@ function CasesBody(): React.ReactElement {
           void navigate({ search: { case: publicId } });
         }}
       />
+      {projectId ? (
+        <ExportUatDialog
+          projectId={projectId}
+          selectedIds={[...selectedIds]}
+          projectName={project?.name ?? "UAT Report"}
+          open={exportDialogOpen}
+          onOpenChange={setExportDialogOpen}
+        />
+      ) : null}
       {suites.items.length === 0 ? (
         <EmptyState
           icon={FolderTree}
@@ -1465,6 +1477,25 @@ function CasesBody(): React.ReactElement {
                   New case
                 </Button>
               </div>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="w-full justify-center gap-1.5 border-accent/30 text-accent hover:bg-accent/10 hover:text-accent disabled:border-border disabled:text-fg-4"
+                data-testid="export-uat-btn"
+                disabled={selectedIds.size === 0}
+                onClick={() => {
+                  setExportDialogOpen(true);
+                }}
+              >
+                <FileDown className="h-3.5 w-3.5" aria-hidden="true" />
+                Export UAT
+                {selectedIds.size > 0 ? (
+                  <span className="ml-0.5 rounded-sm bg-accent/15 px-1.5 font-mono text-[10.5px] tabular-nums">
+                    {selectedIds.size}
+                  </span>
+                ) : null}
+              </Button>
             </div>
             <div className="min-h-0 flex-1 overflow-y-auto p-3">
               <CaseTree

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -118,6 +118,7 @@ The frontend uses pnpm; the backend uses `uv` (uv workspace, one root `pyproject
 | Observability | OpenTelemetry FastAPI instrumentation → OTLP exporter |
 | Logging | `structlog`, JSON to stdout |
 | Capability gate | `packages/core/capabilities.py` resolver — runs on startup, exposed via `GET /capabilities` |
+| Doc export | UAT "Berita Acara" PDF via **fpdf2** (pure-Python, no system libs) + Pillow for evidence images — deterministic ZERO-tier. Pure-Python is deliberate so `POST /api/v1/projects/{id}/exports/uat` runs identically in Docker **and** the npx local bundle (no native pango/cairo needed). |
 
 **Routes mounted:**
 - `/api/v1/*` — versioned REST

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -18,6 +18,8 @@
 
 Default tier for all modes = **ZERO** (runs without an LLM). Upgrade to LOCAL/CLOUD by configuring an LLM provider per workspace in the web UI (Settings → LLM) — not via env vars. The [§5 tier matrix](#5-tier-specific-environment-matrix) describes the older env-based dial (spec only).
 
+**UAT document export** (`POST /api/v1/projects/{id}/exports/uat`) works in **every** mode with no extra system packages: the PDF engine is `fpdf2` (pure-Python), so it runs identically in the Docker image (S3/`s3://` evidence) and the npx local bundle (SQLite, `local://` evidence). No pango/cairo/native libraries required.
+
 ---
 
 ## 1. Mode 1 — Single-host docker-compose

--- a/packages/shared/openapi.json
+++ b/packages/shared/openapi.json
@@ -8920,6 +8920,40 @@
         "title": "TraceabilityMatrix",
         "type": "object"
       },
+      "UatExportBody": {
+        "properties": {
+          "case_ids": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 500,
+            "minItems": 1,
+            "title": "Case Ids",
+            "type": "array"
+          },
+          "locale": {
+            "default": "id",
+            "enum": [
+              "id",
+              "en"
+            ],
+            "title": "Locale",
+            "type": "string"
+          },
+          "title": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "case_ids",
+          "title"
+        ],
+        "title": "UatExportBody",
+        "type": "object"
+      },
       "UrlSemanticGenerateRequest": {
         "description": "LLM-driven semantic URL generation (M3-7) \u2014 CLOUD/LOCAL only.\n\nDecomposes a natural-language ``intent`` (\"checkout flow\") into FE_WEB\njourney cases on ``url``. Steps are agentic browser actions driven by\n``playwright-mcp`` (code translated at execution time, M3-10).",
         "properties": {
@@ -15244,6 +15278,76 @@
         "summary": "Update Project",
         "tags": [
           "projects"
+        ]
+      }
+    },
+    "/api/v1/projects/{project_id}/exports/uat": {
+      "post": {
+        "description": "Build a Suitest-branded UAT sign-off PDF from the selected test cases.\n\nEach case contributes its latest-run status + screenshot evidence. ZERO-tier,\ndeterministic. 404 when any case is outside this project/workspace.",
+        "operationId": "export_uat_document_api_v1_projects__project_id__exports_uat_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "project_id",
+            "required": true,
+            "schema": {
+              "title": "Project Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Workspace-Id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Workspace-Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UatExportBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "APIKeyCookie": []
+          },
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Export Uat Document",
+        "tags": [
+          "exports"
         ]
       }
     },

--- a/uv.lock
+++ b/uv.lock
@@ -521,6 +521,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "deprecated"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -720,6 +729,37 @@ version = "25.12.19"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.63.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/69/c97f2c18e0db87d2c7b15da1974dace76ae938f1cfa22e2727a648b7ed43/fonttools-4.63.0.tar.gz", hash = "sha256:caeb583deeb5168e694b65cda8b4ee62abedfa66cf88488734466f2366b9c4e0", size = 3597189, upload-time = "2026-05-14T12:04:30.958Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/ef/b3c6b9b5be2f82416d73fe2ed2e96e2793cd80e7510bd6a17ca79cdd88ec/fonttools-4.63.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:37dd23e621e3b0aef1baa70a303b80aaf38449632cfc8fd2a55fb285bbccfc02", size = 2881131, upload-time = "2026-05-14T12:03:13.386Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/c815bea63117fa63e4e1c01f8a1110d2112fa003f838e6467094ec2432ce/fonttools-4.63.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a9faff9e0c1f76f9fd55899d2ce785832efebab37eb8ae13995853aef178bef0", size = 2426704, upload-time = "2026-05-14T12:03:15.801Z" },
+    { url = "https://files.pythonhosted.org/packages/44/04/0b91d8e916e92ad1fac9e4624760baf0fd5ff2ead614c2f68fb21373f03f/fonttools-4.63.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef3048ef05dbb552b89817713d9cac912e00d0fde4a3105c00d29e52e10c89af", size = 5044298, upload-time = "2026-05-14T12:03:18.085Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c7/2342da9830e3e9d4870305ca5d2091d2a83284f2953079b7bdd3b5e029d8/fonttools-4.63.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58dc6bb86a78d782f00f9190ca02c119cf5bbe2807536e361e18d42019f877d8", size = 4999800, upload-time = "2026-05-14T12:03:20.161Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/6d/67fe16c48d7ce050979b33f47e0d28a318f02da030602e944c34f7a16ef3/fonttools-4.63.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee08ebfa58f6e1aeff5697ab9582105bb620008c1caafb681e4c557e7483027b", size = 4982666, upload-time = "2026-05-14T12:03:22.87Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/00/3bbab338c07c71fa56269953845e92c951a61457bbbb0f1022551ea266d9/fonttools-4.63.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:27fdc65af8da6f88b9c6121c47a464cbe359fcfff7ff6fc2d37a1f395d755b78", size = 5133598, upload-time = "2026-05-14T12:03:25.168Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/aa27c7f98db5b064883dadcc5283947e81e034de42e22a33675878d98b54/fonttools-4.63.0-cp312-cp312-win32.whl", hash = "sha256:af2fd1664d00a397d75f806985ddb36282091c2131a73a6485c23b4a34722263", size = 2292575, upload-time = "2026-05-14T12:03:27.496Z" },
+    { url = "https://files.pythonhosted.org/packages/87/36/cccb9bc2a6ab63d1b2980374f0dca72ce95ae267c9b4cfe77455bb70d0d4/fonttools-4.63.0-cp312-cp312-win_amd64.whl", hash = "sha256:59ac449f8cca9b4ffa08d2e7bbadad87ce710d69d1eda5c3c1ce579baa987272", size = 2343211, upload-time = "2026-05-14T12:03:30.057Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/47/c99d5268f354002ce80f8d029cd9d7d872969da1de8b93d32de4dc56d6f4/fonttools-4.63.0-py3-none-any.whl", hash = "sha256:445af2eab030a16b9171ea8bdda7ebf7d96bda2df88ee182a464252f6e05e20d", size = 1164562, upload-time = "2026-05-14T12:04:29.092Z" },
+]
+
+[[package]]
+name = "fpdf2"
+version = "2.8.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+    { name = "fonttools" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/f2/72feae0b2827ed38013e4307b14f95bf0b3d124adfef4d38a7d57533f7be/fpdf2-2.8.7.tar.gz", hash = "sha256:7060ccee5a9c7ab0a271fb765a36a23639f83ef8996c34e3d46af0a17ede57f9", size = 362351, upload-time = "2026-02-28T05:39:16.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/0a/cf50ecffa1e3747ed9380a3adfc829259f1f86b3fdbd9e505af789003141/fpdf2-2.8.7-py3-none-any.whl", hash = "sha256:d391fc508a3ce02fc43a577c830cda4fe6f37646f2d143d489839940932fbc19", size = 327056, upload-time = "2026-02-28T05:39:14.619Z" },
 ]
 
 [[package]]
@@ -2626,6 +2666,7 @@ dependencies = [
     { name = "arq" },
     { name = "fastapi" },
     { name = "fastapi-users", extra = ["oauth", "sqlalchemy"] },
+    { name = "fpdf2" },
     { name = "httpx-oauth" },
     { name = "opentelemetry-distro" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
@@ -2653,6 +2694,7 @@ requires-dist = [
     { name = "arq", specifier = ">=0.26" },
     { name = "fastapi", specifier = ">=0.139.2" },
     { name = "fastapi-users", extras = ["sqlalchemy", "oauth"], specifier = ">=15.0.5" },
+    { name = "fpdf2", specifier = ">=2.8.5" },
     { name = "httpx-oauth", specifier = ">=0.16.0" },
     { name = "opentelemetry-distro", specifier = ">=0.64b0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.29.0" },


### PR DESCRIPTION
Export selected test cases as a branded UAT sign-off PDF ("Berita Acara User Acceptance Test"), matching the sample document format.

## Flow
Cases page → multi-select → **Export UAT** → dialog (title + locale id/en) → `POST /api/v1/projects/{id}/exports/uat` → branded PDF downloads.

## Backend (mirrors the junit-report pattern)
- `file_storage.read_bytes` — reads artifact bytes for `local://` / `file://` / `s3://`.
- Pure assembler (`uat_document.py`) — suite grouping, per-section numbering, status rollup (ERROR/FAIL→FAILED, empty/all-skip→NOT RUN, else PASSED), pass %. ORM-free, unit-tested.
- Renderer (`uat_renderer.py`) — **fpdf2**: navy banner, per-module tables, colored status, screenshot evidence, "Powered by Suiflex" footer, id/en labels.
- Loader (`uat_document_service.py`) — cases + latest run + screenshot evidence → PDF. Verifies each case's run belongs to the project/workspace before embedding (no cross-tenant leak); caps to the first screenshot.
- Endpoint (`routers/exports.py`) — workspace/project scoped, audit-logged, ZERO-tier.

## Both-env by design (Docker + npx)
Engine is **fpdf2 + Pillow** — pure-Python wheels, **zero system libs**. Runs identically in Docker (`s3://` evidence) and the npx local bundle on a bare laptop (`local://` evidence). WeasyPrint was rejected because its native pango/cairo would fail on npx.

## Frontend
Reuses the Cases page's existing multi-select; accent Export button + count chip, segmented id/en toggle, sonner toasts, blob download. typecheck/build/lint green.

## Tests
16/16 pass (4 endpoint incl. cross-project 404 + full-run evidence, 12 pure assembler/renderer/storage).

## Deferred
- MCP tool parity (lifecycle is filesystem/config-based, decoupled from the API DB).
- Per-case N+1 loading (bounded by 500-case cap).