### PR TITLE
fix(ci): restore Python release gate

### DIFF
--- a/apps/api/tests/test_test_strategies.py
+++ b/apps/api/tests/test_test_strategies.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy import select
-from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.asyncio import AsyncSession
 from suitest_api.schemas.test_strategy import TestStrategyDraftRequest as StrategyDraftRequest
 from suitest_api.services.test_strategy_service import TestStrategyService as StrategyService
@@ -23,8 +22,8 @@ if TYPE_CHECKING:
 
 def test_strategy_approach_selection_without_database() -> None:
     black, _ = StrategyService._approach(StrategyDraftRequest())
-    gray, _ = StrategyService._approach(StrategyDraftRequest(hasRepository=True))
-    white, _ = StrategyService._approach(StrategyDraftRequest(hasInternalTestProvider=True))
+    gray, _ = StrategyService._approach(StrategyDraftRequest(has_repository=True))
+    white, _ = StrategyService._approach(StrategyDraftRequest(has_internal_test_provider=True))
     assert (black, gray, white) == (
         Approach.BLACK_BOX,
         Approach.GRAY_BOX,
@@ -40,7 +39,7 @@ async def test_next_strategy_version_locks_project_first() -> None:
 
     assert await repo.next_version("project-1") == 3
     statement = session.execute.await_args.args[0]
-    sql = str(statement.compile(dialect=postgresql.dialect()))
+    sql = str(statement)
     assert "FOR UPDATE" in sql
 
 

--- a/packages/shared/openapi.json
+++ b/packages/shared/openapi.json
@@ -3266,11 +3266,13 @@
       "IngestArtifact": {
         "properties": {
           "kind": {
+            "maxLength": 64,
             "title": "Kind",
             "type": "string"
           },
           "mimeType": {
             "default": "application/octet-stream",
+            "maxLength": 255,
             "title": "Mimetype",
             "type": "string"
           },
@@ -3280,6 +3282,7 @@
             "type": "integer"
           },
           "url": {
+            "maxLength": 4096,
             "title": "Url",
             "type": "string"
           }
@@ -3486,6 +3489,7 @@
             "items": {
               "$ref": "#/components/schemas/IngestArtifact"
             },
+            "maxItems": 100,
             "title": "Artifacts",
             "type": "array"
           },
@@ -3496,41 +3500,49 @@
           },
           "error": {
             "default": "",
+            "maxLength": 1000000,
             "title": "Error",
             "type": "string"
           },
           "failureKind": {
             "default": "",
+            "maxLength": 128,
             "title": "Failurekind",
             "type": "string"
           },
           "name": {
             "default": "",
+            "maxLength": 255,
             "title": "Name",
             "type": "string"
           },
           "outcome": {
             "default": "PASSED",
+            "maxLength": 32,
             "title": "Outcome",
             "type": "string"
           },
           "slug": {
             "default": "",
+            "maxLength": 255,
             "title": "Slug",
             "type": "string"
           },
           "sourceRef": {
             "default": "",
+            "maxLength": 2048,
             "title": "Sourceref",
             "type": "string"
           },
           "stderr": {
             "default": "",
+            "maxLength": 1000000,
             "title": "Stderr",
             "type": "string"
           },
           "stdout": {
             "default": "",
+            "maxLength": 1000000,
             "title": "Stdout",
             "type": "string"
           },
@@ -3538,6 +3550,7 @@
             "items": {
               "$ref": "#/components/schemas/IngestRunStep"
             },
+            "maxItems": 500,
             "title": "Steps",
             "type": "array"
           }
@@ -3549,6 +3562,7 @@
         "properties": {
           "description": {
             "default": "",
+            "maxLength": 16384,
             "title": "Description",
             "type": "string"
           },
@@ -3574,6 +3588,7 @@
           },
           "screenshot": {
             "default": "",
+            "maxLength": 4096,
             "title": "Screenshot",
             "type": "string"
           },
@@ -7195,6 +7210,7 @@
             "items": {
               "$ref": "#/components/schemas/IngestResult"
             },
+            "maxItems": 500,
             "title": "Results",
             "type": "array"
           },
@@ -8504,6 +8520,7 @@
                 "items": {
                   "type": "string"
                 },
+                "maxItems": 1000,
                 "type": "array"
               },
               {


### PR DESCRIPTION
## What changed

- use typed Pydantic field names in the strategy tests
- avoid the untyped PostgreSQL dialect helper in the lock assertion
- regenerate the committed OpenAPI snapshot with the repository exporter

## Why

Main CI failed after PR #67: mypy reported three test errors and the stale OpenAPI snapshot prevented pytest from starting. This hotfix restores the release gate so the npm and Python packages can be versioned safely afterward.

## Validation

- uv run mypy apps/api — 254 source files clean
- uv run ruff check apps packages — passed
- uv run ruff format --check apps packages — 636 files formatted
- focused strategy tests — 2 passed
- generated OpenAPI snapshot byte-identical to a fresh export
- ForgeGuard changed gate (static) — 0 errors, 0 warnings