### PR TITLE
fix(release): add launcher provenance metadata

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/mcp-npx": "0.4.0",
+  "packages/mcp-npx": "0.5.0",
   "sdk/typescript": "0.1.1",
-  "packages/suitest-npx": "0.4.0"
+  "packages/suitest-npx": "0.5.0"
 }

--- a/packages/mcp-npx/VERSION
+++ b/packages/mcp-npx/VERSION
@@ -1,1 +1,1 @@
-0.4.0 # x-release-please-version
+0.5.0 # x-release-please-version

--- a/packages/mcp-npx/package.json
+++ b/packages/mcp-npx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suiflex/suitest-mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/suitest-npx/CHANGELOG.md
+++ b/packages/suitest-npx/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.5.0] (unreleased)
+
+Includes the post-0.4.0 launcher updates currently on `main`.
+
 ## [0.4.0](https://github.com/suiflex/suitest/compare/launcher-v0.3.0...launcher-v0.4.0) (2026-07-25)
 
 

--- a/packages/suitest-npx/package.json
+++ b/packages/suitest-npx/package.json
@@ -3,6 +3,10 @@
   "version": "0.5.0",
   "description": "Suitest local bundle — one command runs the full local stack (dashboard + SQLite + MCP).",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/suiflex/suitest"
+  },
   "bin": {
     "suitest": "bin/suitest.js"
   },

--- a/packages/suitest-npx/package.json
+++ b/packages/suitest-npx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suiflex/suitest",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Suitest local bundle — one command runs the full local stack (dashboard + SQLite + MCP).",
   "license": "MIT",
   "bin": {
@@ -16,7 +16,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@suiflex/suitest-mcp": "^0.1.4"
+    "@suiflex/suitest-mcp": "^0.5.0"
   },
   "scripts": {
     "sync-assets": "node scripts/sync-assets.js",


### PR DESCRIPTION
Adds the repository URL required by npm trusted publishing provenance for launcher-v0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)