### PR TITLE
feat(cli): brand suitest/suitest-mcp with a connected onboarding wizard

### DIFF
--- a/packages/mcp-npx/lib/creds.js
+++ b/packages/mcp-npx/lib/creds.js
@@ -19,6 +19,7 @@ const path = require("node:path");
 const readline = require("node:readline");
 
 const { askSecret } = require("./prompt.js");
+const theme = require("./theme.js");
 
 const PLACEHOLDER = {
   apiUrl: "http://localhost:4000",
@@ -95,11 +96,13 @@ function ask(question) {
 async function promptCreds(defaults = {}) {
   const urlHint = defaults.apiUrl ? ` [${defaults.apiUrl}]` : "";
   const keyHint = defaults.apiKey ? " [keep existing]" : "";
+  // point() (not gutter()) so the marker sits on the connector column, same
+  // as the collapsed confirm()/select() lines just above it (install.js).
   const apiUrl =
-    (await ask(`SUITEST_API_URL${urlHint}: `)) || defaults.apiUrl || "";
+    (await ask(theme.point(`SUITEST_API_URL${urlHint}: `))) || defaults.apiUrl || "";
   // Secret: mask so the key never echoes to the terminal / screen-share.
   const apiKey =
-    (await askSecret(`SUITEST_API_KEY${keyHint}: `)) || defaults.apiKey || "";
+    (await askSecret(theme.point(`SUITEST_API_KEY${keyHint}: `))) || defaults.apiKey || "";
   if (!apiUrl || !apiKey) return null;
   return { apiUrl, apiKey };
 }

--- a/packages/mcp-npx/lib/install.js
+++ b/packages/mcp-npx/lib/install.js
@@ -16,6 +16,7 @@ const { spawnSync } = require("node:child_process");
 
 const creds = require("./creds.js");
 const picker = require("./picker.js");
+const theme = require("./theme.js");
 const { findPython } = require("./python.js");
 
 const PKG = "@suiflex/suitest-mcp";
@@ -418,22 +419,24 @@ function doctor(only) {
 // --- interactive orchestration -------------------------------------------
 
 async function runInteractive(opts) {
-  process.stdout.write("suitest-mcp install — interactive setup\n");
-  process.stdout.write("─".repeat(38) + "\n\n");
+  process.stdout.write(theme.banner() + "\n\n");
 
   const py = findPython();
-  process.stdout.write(
-    py
-      ? `[ok]   Python interpreter: ${py.cmd} (${py.version})\n`
-      : "[fail] Python >= 3.11 not found on PATH\n",
-  );
   const saved = creds.loadCreds();
   process.stdout.write(
-    saved
-      ? "[ok]   Credentials saved (reused automatically)\n"
-      : "[info] No saved credentials — you'll be asked once\n",
+    theme.step(
+      "install — preflight",
+      [
+        py
+          ? `[ok]   Python interpreter: ${py.cmd} (${py.version})`
+          : "[fail] Python >= 3.11 not found on PATH",
+        saved
+          ? "[ok]   Credentials saved (reused automatically)"
+          : "[info] No saved credentials — you'll be asked once",
+      ],
+      { color: py ? theme.accent : theme.amber },
+    ) + "\n",
   );
-  process.stdout.write("\n");
 
   if (!py) {
     throw new Error(
@@ -458,15 +461,17 @@ async function runInteractive(opts) {
     label: CLIENTS[id].label,
     hint: CLIENTS[id].hint,
   }));
-  const clientId = await picker.select("Pick the MCP client to install into:", items);
+  const clientIds = await picker.multiselect("Pick the MCP client(s) to install into:", items);
 
-  installClient(clientId, { ...opts, env });
+  for (const clientId of clientIds) {
+    installClient(clientId, { ...opts, env });
+  }
 }
 
 // Interactive credential step for `install`. Order: honor flags/env first (no
 // prompt), else ask "log in now?"; on yes, offer saved-vs-new; on skip, placeholder.
 // Returns the same shape as creds.resolveCreds ({apiUrl, apiKey, warn}).
-async function interactiveLogin(opts) {
+async function interactiveLogin(opts, streams = {}) {
   // Non-interactive override: explicit flags or env win, no questions asked.
   if (opts.apiUrl && opts.apiKey) {
     return { apiUrl: opts.apiUrl, apiKey: opts.apiKey, warn: false };
@@ -479,25 +484,35 @@ async function interactiveLogin(opts) {
     };
   }
 
-  const want = await picker.select("Set up Suitest login now?", [
-    { value: "yes", label: "Yes, log in", hint: "enter or reuse API URL + key" },
-    { value: "skip", label: "Skip", hint: "write placeholder, edit later" },
-  ]);
-  if (want === "skip") {
-    return { ...creds.PLACEHOLDER, warn: true };
-  }
-
   const saved = creds.loadCreds();
-  let useExisting = false;
-  if (saved) {
-    const pick = await picker.select("Saved credentials found — use them?", [
-      { value: "existing", label: "Use existing", hint: saved.apiUrl },
-      { value: "new", label: "Enter new credentials" },
-    ]);
-    useExisting = pick === "existing";
-  }
-  if (useExisting) {
-    return { ...saved, warn: false };
+
+  // Esc on the second question ("use saved creds?") re-asks the first
+  // ("log in now?") instead of aborting — Ctrl-C still aborts the whole flow.
+  let wantLogin;
+  for (;;) {
+    try {
+      wantLogin = await picker.confirm("Set up Suitest login now?", { default: "yes" }, streams);
+    } catch (err) {
+      if (err.code !== "BACK") throw err; // nowhere earlier to go back to
+      continue;
+    }
+    if (!wantLogin) return { ...creds.PLACEHOLDER, warn: true };
+
+    if (!saved) break; // nothing to choose between — fall through to entering creds
+
+    let useExisting;
+    try {
+      useExisting = await picker.confirm(
+        `Saved credentials found (${saved.apiUrl}) — use them?`,
+        { default: "yes" },
+        streams,
+      );
+    } catch (err) {
+      if (err.code === "BACK") continue; // -> back to "log in now?"
+      throw err;
+    }
+    if (useExisting) return { ...saved, warn: false };
+    break;
   }
 
   const entered = await creds.promptCreds(saved || {});
@@ -607,6 +622,7 @@ module.exports = {
   loadJsonObject,
   ensureObjectPath,
   installClient,
+  interactiveLogin,
   parseArgs,
   handleInstall,
   handleLogin,

--- a/packages/mcp-npx/lib/picker.js
+++ b/packages/mcp-npx/lib/picker.js
@@ -6,17 +6,19 @@
  */
 
 const readline = require("node:readline");
+const theme = require("./theme.js");
 
 /**
  * @param {string} prompt
  * @param {{value:string,label:string,hint?:string}[]} items
+ * @param {{input?:NodeJS.ReadableStream, output?:NodeJS.WritableStream}} [streams]
  * @returns {Promise<string>} chosen value (rejects on cancel / no TTY)
  */
-function select(prompt, items) {
-  const stdin = process.stdin;
-  const stdout = process.stdout;
+function select(prompt, items, streams = {}) {
+  const stdin = streams.input || process.stdin;
+  const stdout = streams.output || process.stdout;
 
-  if (!stdin.isTTY) {
+  if (!stdin.isTTY && !streams.input) {
     return Promise.reject(
       new Error("no TTY for interactive picker — pass --client <target>"),
     );
@@ -43,24 +45,37 @@ function select(prompt, items) {
       if (index >= rows.length) index = Math.max(0, rows.length - 1);
 
       const lines = [];
-      lines.push(`? ${prompt}${filter ? `  (filter: ${filter})` : ""}`);
+      lines.push(theme.point(`${prompt}${filter ? `  (filter: ${filter})` : ""}`, { marker: "◆" }, stdout));
       for (let i = 0; i < rows.length; i++) {
         const it = rows[i];
         const marker = i === index ? ">" : " ";
         const label = it.label.padEnd(labelWidth);
         const hint = it.hint ? `(${it.hint})` : "";
-        lines.push(`${marker} ${label}${hint}`);
+        lines.push(theme.gutter(`${marker} ${label}${hint}`, {}, stdout));
       }
-      lines.push("[↑↓ to move, enter to select, type to filter]");
+      lines.push(theme.gutter("[↑↓ move, enter select, esc back, type to filter]", {}, stdout));
 
       // Redraw in place: move cursor up over the previous block and clear.
+      // No trailing newline after the block — the cursor stays on its last
+      // row (end of the gutter line) instead of idling on a blank row below
+      // with no "│", which reads as detached from the connector column.
       if (lastLines > 0) {
-        readline.moveCursor(stdout, 0, -lastLines);
+        readline.moveCursor(stdout, 0, -(lastLines - 1));
       }
       readline.cursorTo(stdout, 0);
       readline.clearScreenDown(stdout);
-      stdout.write(lines.join("\n") + "\n");
+      stdout.write(lines.join("\n"));
       lastLines = lines.length;
+    }
+
+    // Replace the expanded question block with a single answered line —
+    // once a step is past, it collapses into its own "◇ label  value" point
+    // instead of leaving the full option list on screen.
+    function collapse(line) {
+      readline.moveCursor(stdout, 0, -(lastLines - 1));
+      readline.cursorTo(stdout, 0);
+      readline.clearScreenDown(stdout);
+      stdout.write(line + "\n");
     }
 
     function cleanup() {
@@ -76,12 +91,12 @@ function select(prompt, items) {
       if (key.ctrl && key.name === "c") {
         cleanup();
         stdout.write("\n");
-        return reject(new Error("selection cancelled"));
+        return reject(Object.assign(new Error("selection cancelled"), { code: "CANCEL" }));
       }
       if (key.name === "escape") {
         cleanup();
         stdout.write("\n");
-        return reject(new Error("selection cancelled"));
+        return reject(Object.assign(new Error("back"), { code: "BACK" }));
       }
       if (key.name === "up") {
         index = index > 0 ? index - 1 : Math.max(0, rows.length - 1);
@@ -95,6 +110,7 @@ function select(prompt, items) {
         if (!rows.length) return; // nothing matches the filter
         const chosen = rows[index];
         cleanup();
+        collapse(theme.point(`${prompt}  ${theme.accent(chosen.label, stdout)}`, {}, stdout));
         return resolve(chosen.value);
       }
       if (key.name === "backspace") {
@@ -111,11 +127,199 @@ function select(prompt, items) {
     }
 
     readline.emitKeypressEvents(stdin);
-    stdin.setRawMode(true);
+    if (stdin.isTTY) stdin.setRawMode(true);
     stdin.resume();
     stdin.on("keypress", onKeypress);
     render();
   });
 }
 
-module.exports = { select };
+/**
+ * Yes/No radio prompt — same keypress/redraw plumbing as select(), but a
+ * fixed two-row ○/● list instead of a filterable one.
+ * @param {string} prompt
+ * @param {{default?: "yes"|"no"}} [opts]
+ * @param {{input?:NodeJS.ReadableStream, output?:NodeJS.WritableStream}} [streams]
+ * @returns {Promise<boolean>} rejects on cancel / no TTY
+ */
+function confirm(prompt, opts = {}, streams = {}) {
+  const stdin = streams.input || process.stdin;
+  const stdout = streams.output || process.stdout;
+  const rows = [
+    { value: true, label: "Yes" },
+    { value: false, label: "No" },
+  ];
+
+  if (!stdin.isTTY && !streams.input) {
+    return Promise.reject(new Error("no TTY for interactive prompt"));
+  }
+
+  return new Promise((resolve, reject) => {
+    let index = opts.default === "yes" ? 0 : 1;
+    let lastLines = 0;
+
+    function render() {
+      const lines = [theme.point(prompt, { marker: "◆" }, stdout)];
+      for (let i = 0; i < rows.length; i++) {
+        const selected = i === index;
+        const marker = selected ? "●" : "○";
+        const label = selected ? theme.accent(rows[i].label, stdout) : rows[i].label;
+        lines.push(theme.gutter(`  ${marker} ${label}`, {}, stdout));
+      }
+      lines.push(theme.gutter("[↑↓ toggle, enter confirm, esc back]", {}, stdout));
+      // See select()'s render() for why there's no trailing newline here.
+      if (lastLines > 0) readline.moveCursor(stdout, 0, -(lastLines - 1));
+      readline.cursorTo(stdout, 0);
+      readline.clearScreenDown(stdout);
+      stdout.write(lines.join("\n"));
+      lastLines = lines.length;
+    }
+
+    // Replace the expanded Yes/No block with a single answered line — see
+    // select()'s collapse() for why.
+    function collapse(line) {
+      readline.moveCursor(stdout, 0, -(lastLines - 1));
+      readline.cursorTo(stdout, 0);
+      readline.clearScreenDown(stdout);
+      stdout.write(line + "\n");
+    }
+
+    function cleanup() {
+      stdin.removeListener("keypress", onKeypress);
+      if (stdin.isTTY) stdin.setRawMode(false);
+      stdin.pause();
+    }
+
+    function onKeypress(str, key) {
+      if (!key) return;
+      if (key.ctrl && key.name === "c") {
+        cleanup();
+        stdout.write("\n");
+        return reject(Object.assign(new Error("selection cancelled"), { code: "CANCEL" }));
+      }
+      if (key.name === "escape") {
+        cleanup();
+        stdout.write("\n");
+        return reject(Object.assign(new Error("back"), { code: "BACK" }));
+      }
+      if (["up", "down", "left", "right"].includes(key.name)) {
+        index = index === 0 ? 1 : 0;
+        return render();
+      }
+      if (key.name === "return") {
+        cleanup();
+        collapse(theme.point(`${prompt}  ${theme.accent(rows[index].label, stdout)}`, {}, stdout));
+        return resolve(rows[index].value);
+      }
+    }
+
+    readline.emitKeypressEvents(stdin);
+    if (stdin.isTTY) stdin.setRawMode(true);
+    stdin.resume();
+    stdin.on("keypress", onKeypress);
+    render();
+  });
+}
+
+/**
+ * Checkbox multi-select — same keypress/redraw plumbing as select(), but
+ * space toggles membership in a set instead of enter picking one row.
+ * @param {string} prompt
+ * @param {{value:string,label:string,hint?:string}[]} items
+ * @param {{input?:NodeJS.ReadableStream, output?:NodeJS.WritableStream}} [streams]
+ * @returns {Promise<string[]>} chosen values, in item order (rejects on cancel / no TTY)
+ */
+function multiselect(prompt, items, streams = {}) {
+  const stdin = streams.input || process.stdin;
+  const stdout = streams.output || process.stdout;
+
+  if (!stdin.isTTY && !streams.input) {
+    return Promise.reject(
+      new Error("no TTY for interactive picker — pass --client <target>"),
+    );
+  }
+
+  return new Promise((resolve, reject) => {
+    let index = 0;
+    const checked = new Set();
+    const labelWidth = Math.max(...items.map((i) => i.label.length)) + 2;
+    let lastLines = 0;
+
+    function render() {
+      const lines = [theme.point(prompt, { marker: "◆" }, stdout)];
+      for (let i = 0; i < items.length; i++) {
+        const it = items[i];
+        const isChecked = checked.has(it.value);
+        const box = isChecked ? "◉" : "○";
+        const boxed = i === index ? theme.accent(box, stdout) : box;
+        const label = it.label.padEnd(labelWidth);
+        const hint = it.hint ? `(${it.hint})` : "";
+        lines.push(theme.gutter(`${boxed} ${label}${hint}`, {}, stdout));
+      }
+      lines.push(theme.gutter("[space toggle, ↑↓ move, enter confirm, esc back]", {}, stdout));
+      if (lastLines > 0) readline.moveCursor(stdout, 0, -(lastLines - 1));
+      readline.cursorTo(stdout, 0);
+      readline.clearScreenDown(stdout);
+      stdout.write(lines.join("\n"));
+      lastLines = lines.length;
+    }
+
+    function collapse(line) {
+      readline.moveCursor(stdout, 0, -(lastLines - 1));
+      readline.cursorTo(stdout, 0);
+      readline.clearScreenDown(stdout);
+      stdout.write(line + "\n");
+    }
+
+    function cleanup() {
+      stdin.removeListener("keypress", onKeypress);
+      if (stdin.isTTY) stdin.setRawMode(false);
+      stdin.pause();
+    }
+
+    function onKeypress(str, key) {
+      if (!key) return;
+      if (key.ctrl && key.name === "c") {
+        cleanup();
+        stdout.write("\n");
+        return reject(Object.assign(new Error("selection cancelled"), { code: "CANCEL" }));
+      }
+      if (key.name === "escape") {
+        cleanup();
+        stdout.write("\n");
+        return reject(Object.assign(new Error("back"), { code: "BACK" }));
+      }
+      if (key.name === "up") {
+        index = index > 0 ? index - 1 : items.length - 1;
+        return render();
+      }
+      if (key.name === "down") {
+        index = (index + 1) % items.length;
+        return render();
+      }
+      if (key.name === "space") {
+        const value = items[index].value;
+        if (checked.has(value)) checked.delete(value);
+        else checked.add(value);
+        return render();
+      }
+      if (key.name === "return") {
+        cleanup();
+        const chosen = items.filter((it) => checked.has(it.value));
+        const summary = chosen.length
+          ? chosen.map((it) => theme.accent(it.label, stdout)).join(", ")
+          : theme.fg3("(none)", stdout);
+        collapse(theme.point(`${prompt}  ${summary}`, {}, stdout));
+        return resolve(chosen.map((it) => it.value));
+      }
+    }
+
+    readline.emitKeypressEvents(stdin);
+    if (stdin.isTTY) stdin.setRawMode(true);
+    stdin.resume();
+    stdin.on("keypress", onKeypress);
+    render();
+  });
+}
+
+module.exports = { select, confirm, multiselect };

--- a/packages/mcp-npx/lib/theme.js
+++ b/packages/mcp-npx/lib/theme.js
@@ -37,16 +37,20 @@ const fg1 = paint(CODES.bold + CODES.fg1);
 const fg3 = paint(CODES.fg3);
 const border = paint(CODES.border);
 
-// Small boxed wordmark, accent green like the real logomark (apps/web/public/logo.svg).
-// Deliberately plain block letters, not figlet — no dependency, and it collapses
-// to three lines of plain text when colorEnabled() is false.
+// Small boxed wordmark, accent green like the real logomark (apps/web/public/logo.svg:
+// a rounded square with a checkmark stroke). The icon is a crisp outlined mini-box
+// (box-drawing chars, not filled quadrant blocks — those render as a solid blob
+// that crushes the checkmark) — a 3-row badge next to the wordmark, not one small
+// glyph. No figlet, no image; collapses to plain text when colorEnabled() is false.
 function banner(stream = process.stdout) {
+  const icon = ["┌───┐", "│ ✓ │", "└───┘"];
   const word = "S U I T E S T";
-  const width = word.length + 4;
+  const rows = [icon[0], `${icon[1]}  ${word}`, icon[2]];
+  const width = Math.max(...rows.map((r) => r.length)) + 4;
   const top = `┌${"─".repeat(width)}┐`;
-  const mid = `│  ${word}  │`;
+  const mid = rows.map((r) => `│  ${r.padEnd(width - 4)}  │`);
   const bot = `└${"─".repeat(width)}┘`;
-  return [accent(top, stream), accent(mid, stream), accent(bot, stream)].join("\n");
+  return [accent(top, stream), ...mid.map((r) => accent(r, stream)), accent(bot, stream)].join("\n");
 }
 
 // Prefix a line with the wizard-step connector column. Defaults to accent —

--- a/packages/mcp-npx/lib/theme.js
+++ b/packages/mcp-npx/lib/theme.js
@@ -1,0 +1,116 @@
+"use strict";
+
+/**
+ * Suitest CLI branding — ANSI colors, banner, bordered panels. Stdlib only
+ * (no chalk/boxen), colors bound to the same tokens as apps/web/tailwind.config.ts
+ * (CLAUDE.md §3.3), so the terminal and the dashboard read as one product.
+ */
+
+const CODES = {
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+  // approximate 24-bit tokens as 256-color for wide terminal support
+  accent: "\x1b[38;5;114m", // #4ade80
+  red: "\x1b[38;5;210m", // #f87171
+  amber: "\x1b[38;5;221m", // #fbbf24
+  violet: "\x1b[38;5;146m", // #a78bfa
+  fg1: "\x1b[38;5;255m", // #fafafa
+  fg3: "\x1b[38;5;247m", // #a3a3a3
+  border: "\x1b[38;5;238m", // #262626-ish (visible on dark bg)
+};
+
+function colorEnabled(stream = process.stdout) {
+  return Boolean(stream && stream.isTTY) && !process.env.NO_COLOR;
+}
+
+function paint(code) {
+  return (text, stream = process.stdout) =>
+    colorEnabled(stream) ? `${code}${text}${CODES.reset}` : text;
+}
+
+const accent = paint(CODES.accent);
+const red = paint(CODES.red);
+const amber = paint(CODES.amber);
+const violet = paint(CODES.violet);
+const fg1 = paint(CODES.bold + CODES.fg1);
+const fg3 = paint(CODES.fg3);
+const border = paint(CODES.border);
+
+// Small boxed wordmark, accent green like the real logomark (apps/web/public/logo.svg).
+// Deliberately plain block letters, not figlet — no dependency, and it collapses
+// to three lines of plain text when colorEnabled() is false.
+function banner(stream = process.stdout) {
+  const word = "S U I T E S T";
+  const width = word.length + 4;
+  const top = `┌${"─".repeat(width)}┐`;
+  const mid = `│  ${word}  │`;
+  const bot = `└${"─".repeat(width)}┘`;
+  return [accent(top, stream), accent(mid, stream), accent(bot, stream)].join("\n");
+}
+
+// Prefix a line with the wizard-step connector column. Defaults to accent —
+// `border` (#262626-ish) is a box-edge color, meant to sit next to bright
+// content; alone on a near-black background it's effectively invisible.
+function gutter(text, { color = accent } = {}, stream = process.stdout) {
+  return `${color("│", stream)}${text ? ` ${text}` : ""}`;
+}
+
+// A row that IS a point on the connector column — the marker sits at column
+// 0, same spot gutter() puts "│". Never combine the two on one row (that's
+// what pushed markers a cell to the right of the "│" column in v2).
+function point(text, { marker = "◇", color = accent } = {}, stream = process.stdout) {
+  return color(`${marker} ${text}`, stream);
+}
+
+// One step in a connected wizard flow: a labeled rule, then body lines under
+// a shared "│" gutter, with blank connector lines above/below so consecutive
+// step()/prompt blocks read as one continuous flow (not floating boxes).
+function step(label, lines, { marker = "◇", color = accent } = {}, stream = process.stdout) {
+  const body = Array.isArray(lines) ? lines : String(lines).split("\n");
+  const rule = "─".repeat(Math.max(3, 30 - label.length));
+  const out = [point(`${label} ${rule}`, { marker, color }, stream), gutter("", { color }, stream)];
+  for (const line of body) out.push(gutter(fg1(line, stream), { color }, stream));
+  out.push(gutter("", { color }, stream));
+  return out.join("\n");
+}
+
+// Bordered panel around a block of lines. `color` picks the border paint
+// function (accent/red/amber/violet/border); defaults to the neutral border.
+function panel(lines, { title, color = border } = {}, stream = process.stdout) {
+  const body = Array.isArray(lines) ? lines : String(lines).split("\n");
+  const contentWidth = Math.max(
+    title ? title.length : 0,
+    ...body.map((l) => l.length),
+    20,
+  );
+  const rule = "─".repeat(contentWidth + 2);
+  const out = [];
+  if (title) {
+    const pad = "─".repeat(Math.max(0, contentWidth + 2 - title.length - 3));
+    out.push(color(`┌─ ${title} ${pad}┐`, stream));
+  } else {
+    out.push(color(`┌${rule}┐`, stream));
+  }
+  for (const line of body) {
+    out.push(`${color("│", stream)} ${fg1(line.padEnd(contentWidth), stream)} ${color("│", stream)}`);
+  }
+  out.push(color(`└${rule}┘`, stream));
+  return out.join("\n");
+}
+
+module.exports = {
+  colorEnabled,
+  accent,
+  red,
+  amber,
+  violet,
+  fg1,
+  fg3,
+  border,
+  banner,
+  panel,
+  gutter,
+  point,
+  step,
+};

--- a/packages/mcp-npx/test/install.test.js
+++ b/packages/mcp-npx/test/install.test.js
@@ -11,9 +11,16 @@ const assert = require("node:assert");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const { PassThrough } = require("node:stream");
 
 const install = require("../lib/install.js");
 const creds = require("../lib/creds.js");
+const { multiselect } = require("../lib/picker.js");
+
+const KEY_ESC = "\x1b";
+const KEY_ENTER = "\r";
+const KEY_DOWN = "\x1b[B";
+const KEY_SPACE = " ";
 
 const ENV = { SUITEST_API_URL: "http://localhost:4000", SUITEST_API_KEY: "sk_test" };
 
@@ -158,4 +165,98 @@ function silence(fn) {
   if (prevDir !== undefined) process.env.SUITEST_CONFIG_DIR = prevDir;
 }
 
-process.stdout.write("install.test.js OK\n");
+// 8. interactiveLogin: Esc on "use saved creds?" goes back to "log in now?"
+// instead of aborting — feed Esc then re-answer Yes/Yes to land on the saved creds.
+(async () => {
+  const prevDir = process.env.SUITEST_CONFIG_DIR;
+  const dir = tmp("interactive-login-back");
+  process.env.SUITEST_CONFIG_DIR = dir;
+  creds.saveCreds({ apiUrl: "http://127.0.0.1:4000", apiKey: "sk_saved" });
+
+  const input = new PassThrough();
+  const output = new PassThrough();
+  output.on("data", () => {});
+
+  const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+  const p = install.interactiveLogin({}, { input, output });
+  await delay(20);
+  input.write(KEY_ENTER); // "log in now?" -> Yes (default)
+  await delay(20);
+  input.write(KEY_ESC); // "use saved creds?" -> back
+  // readline debounces a lone ESC to distinguish it from the start of an
+  // escape sequence (e.g. arrow keys) — give its internal timeout room to
+  // fire before sending the next key, or they get parsed as one sequence.
+  await delay(600);
+  input.write(KEY_ENTER); // "log in now?" again -> Yes
+  await delay(20);
+  input.write(KEY_ENTER); // "use saved creds?" -> Yes (default)
+
+  const resolved = await p;
+  assert.strictEqual(resolved.apiUrl, "http://127.0.0.1:4000");
+  assert.strictEqual(resolved.apiKey, "sk_saved");
+  assert.strictEqual(resolved.warn, false);
+
+  fs.rmSync(dir, { recursive: true, force: true });
+  if (prevDir === undefined) delete process.env.SUITEST_CONFIG_DIR;
+  else process.env.SUITEST_CONFIG_DIR = prevDir;
+
+  // 9. multiselect() -> install into every picked client (this is the exact
+  // pattern install.js's runInteractive() follows: multiselect then loop).
+  {
+    const claudeTarget = tmp("multi-client-claude.json");
+    const cursorTarget = tmp("multi-client-cursor.json");
+    const prevClaude = process.env.CLAUDE_CODE_CONFIG;
+    const prevCursor = process.env.CURSOR_CONFIG;
+    process.env.CLAUDE_CODE_CONFIG = claudeTarget;
+    process.env.CURSOR_CONFIG = cursorTarget;
+
+    const items = install.CLIENT_ORDER.map((id) => ({
+      value: id,
+      label: install.CLIENTS[id].label,
+      hint: install.CLIENTS[id].hint,
+    }));
+
+    const mInput = new PassThrough();
+    const mOutput = new PassThrough();
+    mOutput.on("data", () => {});
+    const picked = multiselect("Pick the MCP client(s) to install into:", items, {
+      input: mInput,
+      output: mOutput,
+    });
+    // CLIENT_ORDER is [claude-code, claude-desktop, cursor, ...] — check
+    // claude-code, skip claude-desktop (no safe env-redirected target, would
+    // touch the real Claude Desktop config dir), land on cursor and check it.
+    await delay(20);
+    mInput.write(KEY_SPACE); // check claude-code
+    await delay(20);
+    mInput.write(KEY_DOWN);
+    await delay(20);
+    mInput.write(KEY_DOWN); // now on cursor
+    await delay(20);
+    mInput.write(KEY_SPACE); // check cursor
+    await delay(20);
+    mInput.write(KEY_ENTER);
+
+    const clientIds = await picked;
+    assert.deepStrictEqual(clientIds.sort(), ["claude-code", "cursor"]);
+
+    for (const clientId of clientIds) {
+      silence(() => install.installClient(clientId, { name: "suitest", scope: "global", env: ENV }));
+    }
+    assert.ok(fs.existsSync(claudeTarget), "expected claude-code config to be written");
+    assert.ok(fs.existsSync(cursorTarget), "expected cursor config to be written");
+
+    fs.rmSync(claudeTarget, { force: true });
+    fs.rmSync(cursorTarget, { force: true });
+    if (prevClaude === undefined) delete process.env.CLAUDE_CODE_CONFIG;
+    else process.env.CLAUDE_CODE_CONFIG = prevClaude;
+    if (prevCursor === undefined) delete process.env.CURSOR_CONFIG;
+    else process.env.CURSOR_CONFIG = prevCursor;
+  }
+
+  process.stdout.write("install.test.js OK\n");
+})().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/packages/mcp-npx/test/picker.test.js
+++ b/packages/mcp-npx/test/picker.test.js
@@ -1,0 +1,157 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert");
+const { PassThrough } = require("node:stream");
+
+const { select, confirm, multiselect } = require("../lib/picker.js");
+
+const KEY_UP = "\x1b[A";
+const KEY_DOWN = "\x1b[B";
+const KEY_SPACE = " ";
+const KEY_ENTER = "\r";
+const KEY_CTRL_C = "\x03";
+const KEY_ESC = "\x1b";
+
+function pair() {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  output.on("data", () => {}); // drain, we don't assert on rendered frames
+  return { input, output };
+}
+
+// Same as pair(), but keeps every write so tests can assert on rendered text.
+function capturedPair() {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  let written = "";
+  output.on("data", (chunk) => {
+    written += chunk.toString();
+  });
+  return { input, output, text: () => written };
+}
+
+test("confirm() resolves the default value on bare Enter", async () => {
+  const { input, output } = pair();
+  const p = confirm("Continue?", { default: "yes" }, { input, output });
+  setImmediate(() => input.write(KEY_ENTER));
+  assert.strictEqual(await p, true);
+});
+
+test("confirm() toggles with arrow keys before resolving", async () => {
+  const { input, output } = pair();
+  const p = confirm("Continue?", { default: "yes" }, { input, output });
+  setImmediate(() => {
+    input.write(KEY_UP); // yes -> no (only two rows, any arrow toggles)
+    input.write(KEY_ENTER);
+  });
+  assert.strictEqual(await p, false);
+});
+
+test("confirm() rejects with code CANCEL on Ctrl-C", async () => {
+  const { input, output } = pair();
+  const p = confirm("Continue?", {}, { input, output });
+  setImmediate(() => input.write(KEY_CTRL_C));
+  await assert.rejects(p, (err) => err.code === "CANCEL");
+});
+
+test("confirm() rejects with code BACK on Esc", async () => {
+  const { input, output } = pair();
+  const p = confirm("Continue?", {}, { input, output });
+  setImmediate(() => input.write(KEY_ESC));
+  await assert.rejects(p, (err) => err.code === "BACK");
+});
+
+test("select() resolves the highlighted item on Enter", async () => {
+  const { input, output } = pair();
+  const items = [
+    { value: "a", label: "Alpha" },
+    { value: "b", label: "Beta" },
+  ];
+  const p = select("Pick one", items, { input, output });
+  setImmediate(() => input.write(KEY_ENTER));
+  assert.strictEqual(await p, "a");
+});
+
+test("select() rejects with code BACK on Esc, CANCEL on Ctrl-C", async () => {
+  const items = [{ value: "a", label: "Alpha" }];
+
+  const p1 = pair();
+  const back = select("Pick one", items, p1);
+  setImmediate(() => p1.input.write(KEY_ESC));
+  await assert.rejects(back, (err) => err.code === "BACK");
+
+  const p2 = pair();
+  const cancel = select("Pick one", items, p2);
+  setImmediate(() => p2.input.write(KEY_CTRL_C));
+  await assert.rejects(cancel, (err) => err.code === "CANCEL");
+});
+
+test("confirm()'s question and answered lines start with the marker, not the gutter pipe", async () => {
+  const { input, output, text } = capturedPair();
+  const p = confirm("Continue?", { default: "yes" }, { input, output });
+  setImmediate(() => input.write(KEY_ENTER));
+  await p;
+  const out = text();
+  assert.ok(out.includes("◆ Continue?"), `expected the question marker, got: ${JSON.stringify(out)}`);
+  assert.ok(out.includes("◇ Continue?"), `expected the collapsed marker, got: ${JSON.stringify(out)}`);
+  // The gutter pipe is immediately followed by a space then content (see
+  // gutter()) — "│ ◆"/"│ ◇" is exactly the column-2 bug this guards against.
+  assert.ok(!out.includes("│ ◆"), `marker should not sit right after a gutter pipe: ${JSON.stringify(out)}`);
+  assert.ok(!out.includes("│ ◇"), `marker should not sit right after a gutter pipe: ${JSON.stringify(out)}`);
+});
+
+test("multiselect() resolves an empty array on bare Enter (nothing toggled)", async () => {
+  const { input, output } = pair();
+  const items = [
+    { value: "a", label: "Alpha" },
+    { value: "b", label: "Beta" },
+  ];
+  const p = multiselect("Pick some", items, { input, output });
+  setImmediate(() => input.write(KEY_ENTER));
+  assert.deepStrictEqual(await p, []);
+});
+
+test("multiselect() toggles multiple rows with space before confirming", async () => {
+  const { input, output } = pair();
+  const items = [
+    { value: "a", label: "Alpha" },
+    { value: "b", label: "Beta" },
+    { value: "c", label: "Gamma" },
+  ];
+  const p = multiselect("Pick some", items, { input, output });
+  setImmediate(() => {
+    input.write(KEY_SPACE); // check Alpha
+    input.write(KEY_DOWN);
+    input.write(KEY_DOWN); // move to Gamma, skipping Beta
+    input.write(KEY_SPACE); // check Gamma
+    input.write(KEY_ENTER);
+  });
+  assert.deepStrictEqual(await p, ["a", "c"]);
+});
+
+test("multiselect() un-toggles on a second space", async () => {
+  const { input, output } = pair();
+  const items = [{ value: "a", label: "Alpha" }];
+  const p = multiselect("Pick some", items, { input, output });
+  setImmediate(() => {
+    input.write(KEY_SPACE);
+    input.write(KEY_SPACE);
+    input.write(KEY_ENTER);
+  });
+  assert.deepStrictEqual(await p, []);
+});
+
+test("multiselect() rejects with code BACK on Esc, CANCEL on Ctrl-C", async () => {
+  const items = [{ value: "a", label: "Alpha" }];
+
+  const p1 = pair();
+  const back = multiselect("Pick some", items, p1);
+  setImmediate(() => p1.input.write(KEY_ESC));
+  await assert.rejects(back, (err) => err.code === "BACK");
+
+  const p2 = pair();
+  const cancel = multiselect("Pick some", items, p2);
+  setImmediate(() => p2.input.write(KEY_CTRL_C));
+  await assert.rejects(cancel, (err) => err.code === "CANCEL");
+});

--- a/packages/mcp-npx/test/theme.test.js
+++ b/packages/mcp-npx/test/theme.test.js
@@ -1,0 +1,106 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert");
+const { PassThrough } = require("node:stream");
+
+const theme = require("../lib/theme.js");
+
+function ttyStream() {
+  const s = new PassThrough();
+  s.isTTY = true;
+  return s;
+}
+
+function nonTtyStream() {
+  const s = new PassThrough();
+  s.isTTY = false;
+  return s;
+}
+
+test("colorEnabled is false on a non-TTY stream", () => {
+  assert.strictEqual(theme.colorEnabled(nonTtyStream()), false);
+});
+
+test("colorEnabled is false when NO_COLOR is set, even on a TTY", () => {
+  const prev = process.env.NO_COLOR;
+  process.env.NO_COLOR = "1";
+  try {
+    assert.strictEqual(theme.colorEnabled(ttyStream()), false);
+  } finally {
+    if (prev === undefined) delete process.env.NO_COLOR;
+    else process.env.NO_COLOR = prev;
+  }
+});
+
+test("colorEnabled is true on a TTY without NO_COLOR", () => {
+  const prev = process.env.NO_COLOR;
+  delete process.env.NO_COLOR;
+  try {
+    assert.strictEqual(theme.colorEnabled(ttyStream()), true);
+  } finally {
+    if (prev !== undefined) process.env.NO_COLOR = prev;
+  }
+});
+
+test("color wrappers return the raw string unchanged when color disabled", () => {
+  const out = nonTtyStream();
+  assert.strictEqual(theme.accent("hello", out), "hello");
+  assert.strictEqual(theme.red("hello", out), "hello");
+});
+
+test("color wrappers add ANSI codes when color enabled", () => {
+  const out = ttyStream();
+  const painted = theme.accent("hello", out);
+  assert.notStrictEqual(painted, "hello");
+  assert.ok(painted.includes("hello"));
+});
+
+test("panel() produces lines of consistent width", () => {
+  const out = nonTtyStream();
+  const rendered = theme.panel(["short", "a much longer line here"], {}, out);
+  const lines = rendered.split("\n");
+  const widths = new Set(lines.map((l) => l.length));
+  assert.strictEqual(widths.size, 1, `expected uniform width, got: ${[...widths]}`);
+});
+
+test("banner() collapses to plain text when color disabled", () => {
+  const out = nonTtyStream();
+  const rendered = theme.banner(out);
+  assert.ok(!rendered.includes("\x1b["));
+  assert.ok(rendered.includes("S U I T E S T"));
+});
+
+test("banner() uses the accent color, not the neutral border color", () => {
+  const out = ttyStream();
+  const rendered = theme.banner(out);
+  const accentCode = theme.accent("Z", out).split("Z")[0];
+  const borderCode = theme.border("Z", out).split("Z")[0];
+  assert.ok(rendered.includes(accentCode), "banner should carry the accent ANSI code");
+  assert.ok(!rendered.includes(borderCode), "banner should not carry the neutral border code");
+});
+
+test("gutter() prefixes a line with the connector column", () => {
+  const out = nonTtyStream();
+  assert.strictEqual(theme.gutter("hello", {}, out), "│ hello");
+  assert.strictEqual(theme.gutter("", {}, out), "│");
+});
+
+test("point() puts the marker at column 0, no leading gutter pipe", () => {
+  const out = nonTtyStream();
+  assert.strictEqual(theme.point("hello"), "◇ hello");
+  assert.strictEqual(theme.point("hello", { marker: "◆" }), "◆ hello");
+  assert.ok(!theme.point("hello", {}, out).startsWith("│"));
+});
+
+test("step() wraps every body line with the gutter and brackets with blank connectors", () => {
+  const out = nonTtyStream();
+  const rendered = theme.step("do the thing", ["line one", "line two"], {}, out);
+  const lines = rendered.split("\n");
+  assert.ok(lines[0].startsWith("◇ do the thing"));
+  assert.strictEqual(lines[1], "│");
+  assert.ok(lines[2].includes("line one"));
+  assert.ok(lines[2].startsWith("│"));
+  assert.ok(lines[3].includes("line two"));
+  assert.strictEqual(lines[4], "│");
+});

--- a/packages/suitest-npx/bin/suitest.js
+++ b/packages/suitest-npx/bin/suitest.js
@@ -38,6 +38,8 @@ async function main() {
   // Pre-parse: strict parseArgs would throw on unknown --help/--version (mcp-npx convention).
   const rawArgs = process.argv.slice(2);
   if (rawArgs.includes("--help")) {
+    const { loadMcpLib } = require("../lib/onboard.js");
+    process.stdout.write(loadMcpLib("theme.js").banner() + "\n\n");
     process.stdout.write(USAGE);
     process.exit(0);
   }

--- a/packages/suitest-npx/lib/onboard.js
+++ b/packages/suitest-npx/lib/onboard.js
@@ -27,7 +27,14 @@ async function promptAccount(credPath, opts = {}) {
   }
   const readline = require("node:readline/promises");
   const { askSecret } = loadMcpLib("prompt.js");
-  console.log("Create the admin account for your local Suitest (you'll log in with this):");
+  const theme = loadMcpLib("theme.js");
+  console.log(
+    theme.step(
+      "create admin account",
+      ["Create the admin account for your local Suitest.", "You'll log in with this."],
+      { color: theme.violet },
+    ),
+  );
 
   // Email over a plain interface, closed before we prompt for secrets so the
   // masked-secret interface owns stdin without two readers competing.
@@ -35,7 +42,7 @@ async function promptAccount(credPath, opts = {}) {
   let email = "";
   try {
     while (!email.includes("@")) {
-      email = (await rl.question("  email: ")).trim();
+      email = (await rl.question(theme.point("email: ", { color: theme.violet }))).trim();
     }
   } finally {
     rl.close();
@@ -44,11 +51,11 @@ async function promptAccount(credPath, opts = {}) {
   // Password typed twice, masked (`askSecret` echoes `*`, never the chars).
   let password = "";
   for (;;) {
-    password = await askSecret("  password (min 8 chars): ");
+    password = await askSecret(theme.point("password (min 8 chars): ", { color: theme.violet }));
     if (password.length < 8) continue;
-    const confirm = await askSecret("  confirm password: ");
+    const confirm = await askSecret(theme.point("confirm password: ", { color: theme.violet }));
     if (confirm === password) break;
-    console.log("  Passwords don't match, try again.");
+    console.log(theme.point("Passwords don't match, try again.", { color: theme.violet }));
   }
   return loadOrCreateCredentials(credPath, { email, password });
 }
@@ -97,6 +104,8 @@ async function resolvePort(dirs, opts) {
 }
 
 async function onboard(cwd, opts = {}) {
+  console.log(loadMcpLib("theme.js").banner());
+  console.log("");
   const { dirs, webDist, python } = await prepare(cwd);
   await promptAccount(dirs.credentials, opts);
   const port = await resolvePort(dirs, opts);
@@ -123,14 +132,21 @@ async function onboard(cwd, opts = {}) {
     console.error("Re-run later: suitest init --ide <claude-code|cursor|windsurf>");
   }
 
-  console.log(`
-Suitest local ready:
-  dashboard : ${apiUrl}
-  login     : ${creds.email} (password you set; stored in ${dirs.credentials})
-  MCP config: ${mcpConfigPath || "(not wired)"}
-  data      : ${dirs.root}
-  stop      : suitest down
-  start again (after reboot): suitest up`);
+  const theme = loadMcpLib("theme.js");
+  console.log("");
+  console.log(
+    theme.panel(
+      [
+        `dashboard : ${apiUrl}`,
+        `login     : ${creds.email} (password you set; stored in ${dirs.credentials})`,
+        `MCP config: ${mcpConfigPath || "(not wired)"}`,
+        `data      : ${dirs.root}`,
+        `stop      : suitest down`,
+        `start again (after reboot): suitest up`,
+      ],
+      { title: "Suitest local ready", color: theme.accent },
+    ),
+  );
   return { ...running, apiUrl, mcpConfigPath };
 }
 


### PR DESCRIPTION
## Summary
- Both CLIs (`suitest`, `suitest-mcp`) printed bare `console.log` output with no visual identity or connected flow between onboarding steps.
- Add a shared ANSI theme matching the web app's design tokens (accent green, etc.), and rework interactive prompts so `onboard`/`install` read as one continuous wizard.

## Changes
- `packages/mcp-npx/lib/theme.js` (new): `banner()`, `step()`, `point()`, `gutter()`, `panel()` — accent-green wordmark plus a `│` connector column linking steps, questions, and text input into a single thread.
- `packages/mcp-npx/lib/picker.js`: `confirm()`/`select()` now distinguish Esc (`code: "BACK"`, step back) from Ctrl-C (`code: "CANCEL"`, abort); answered prompts collapse from an expanded question into a single point once submitted; new `multiselect()` checkbox picker.
- `packages/mcp-npx/lib/install.js`: login flow (`interactiveLogin`) uses Esc-back to return from "use saved credentials?" to "log in now?"; the MCP client step now uses `multiselect()` so install can target more than one client (claude-code, cursor, ...) per run.
- `packages/mcp-npx/lib/creds.js`, `packages/suitest-npx/lib/onboard.js`, `packages/suitest-npx/bin/suitest.js`: wire the banner/step/point styling into the credential and admin-account prompts and the `--help` output.

## Test plan
- [x] `node --test packages/mcp-npx/test/*.test.js` (48 tests)
- [x] `node --test packages/suitest-npx/test/*.test.js` (39 tests)
- [x] Manual TTY run of `suitest-mcp install` and `suitest onboard` — banner color, connected `│` gutter, Esc-back navigation, and checkbox multiselect verified visually
- [x] `NO_COLOR=1` / piped (non-TTY) output verified to degrade to plain text without throwing

## Evidance
<img width="1600" height="769" alt="WhatsApp Image 2026-08-06 at 21 14 42" src="https://github.com/user-attachments/assets/36ca122e-5a5f-4695-a73b-07be1cffb3ec" />
