### PR TITLE
chore(openapi): regenerate snapshot to include FE_DESKTOP enum

### DIFF
--- a/packages/shared/openapi.json
+++ b/packages/shared/openapi.json
@@ -8658,6 +8658,7 @@
           "BE_GRPC",
           "FE_WEB",
           "FE_MOBILE",
+          "FE_DESKTOP",
           "DATA",
           "INFRA",
           "CUSTOM"


### PR DESCRIPTION
Follow-up to #76 (merged by Badrus before the fix landed). The committed packages/shared/openapi.json was stale — the FE_DESKTOP TargetKind value (added in migration 0048) was not present, failing CI's 'Diff committed snapshot' step. Regenerated via scripts/export-openapi.py; only the FE_DESKTOP enum line changed.