### PR TITLE
fix(suitest-npx): correct license field to Apache-2.0

### DIFF
--- a/packages/suitest-npx/package.json
+++ b/packages/suitest-npx/package.json
@@ -2,7 +2,7 @@
   "name": "@suiflex/suitest",
   "version": "0.6.0",
   "description": "Suitest local bundle — one command runs the full local stack (dashboard + SQLite + MCP).",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/suiflex/suitest"


### PR DESCRIPTION
## Summary
- `packages/suitest-npx/package.json` declared `MIT` while repo `LICENSE` and sibling packages (`sdk/typescript`, `mcp-npx`) are `Apache-2.0`, causing npm to display the wrong license for `@suiflex/suitest`.

## Changes
- Changed `license` field from `MIT` to `Apache-2.0` in `packages/suitest-npx/package.json`.

## Test plan
- [x] Verified repo `LICENSE` is Apache-2.0
- [x] Verified sibling packages (`sdk/typescript`, `mcp-npx`) already use `Apache-2.0`
- [x] Confirmed no package-local `LICENSE` override exists in `suitest-npx`