### PR TITLE
fix(ci): make release-launcher GitHub Release creation idempotent

### DIFF
--- a/.github/workflows/release-launcher.yml
+++ b/.github/workflows/release-launcher.yml
@@ -103,7 +103,9 @@ jobs:
         working-directory: packages/suitest-npx
         run: npm publish --access public
       - name: GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes
+        run: |
+          gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1 || \
+            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes
         env:
           GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## Summary
- `release-launcher` CI failed on the `launcher-v0.6.1` tag push: `gh release create` returned `HTTP 422: Release.tag_name already exists`, because release-please already creates the GitHub Release for the tag before this workflow's own tag-push trigger runs. The npm publish step itself succeeded — only the redundant release-creation step failed the job.

## Changes
- `.github/workflows/release-launcher.yml`: guard the `GitHub Release` step with `gh release view` so it only calls `gh release create` when no release exists yet for that tag.

## Test plan
- [x] Confirmed root cause via failed run logs (run `31515707380`, job `@suiflex/suitest → npm`)
- [x] Confirmed release-please already created the release for `launcher-v0.6.1` in an earlier run
- [ ] Verify next `launcher-v*` tag push succeeds end-to-end without the duplicate-release failure