### PR TITLE
fix: use released MCP package for launcher

### DIFF
--- a/packages/suitest-npx/CHANGELOG.md
+++ b/packages/suitest-npx/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.2](https://github.com/suiflex/suitest/compare/launcher-v0.6.1...launcher-v0.6.2) (2026-08-12)
+
+### Bug Fixes
+
+* use the released MCP package containing the onboarding theme module
+
 ## [0.6.1](https://github.com/suiflex/suitest/compare/launcher-v0.6.0...launcher-v0.6.1) (2026-08-11)
 
 

--- a/packages/suitest-npx/package.json
+++ b/packages/suitest-npx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suiflex/suitest",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Suitest local bundle — one command runs the full local stack (dashboard + SQLite + MCP).",
   "license": "Apache-2.0",
   "repository": {
@@ -20,7 +20,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@suiflex/suitest-mcp": "^0.5.2"
+    "@suiflex/suitest-mcp": "^0.6.1"
   },
   "scripts": {
     "sync-assets": "node scripts/sync-assets.js",


### PR DESCRIPTION
Updates @suiflex/suitest to 0.6.2 and points it at @suiflex/suitest-mcp ^0.6.1, which contains the published onboarding theme module.