### PR TITLE
fix: publish launcher with MCP 0.6.1

### DIFF
--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -75,7 +75,7 @@ jobs:
         run: npm install -g npm@11.5.2
       - name: Tag matches package version
         run: |
-          TAG_VERSION="${GITHUB_REF_NAME#mcp-v}"
+          TAG_VERSION="${RELEASE_TAG:-${GITHUB_REF_NAME#mcp-v}}"
           PKG_VERSION="$(node -p "require('./package.json').version")"
           [ "$TAG_VERSION" = "$PKG_VERSION" ] || {
             echo "tag $GITHUB_REF_NAME != package.json $PKG_VERSION" >&2; exit 1; }
@@ -116,10 +116,12 @@ jobs:
 
   pypi:
     name: "suiflex-suitest-lifecycle → PyPI"
-    if: github.event_name != 'workflow_dispatch'
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
       - uses: astral-sh/setup-uv@v7
       - uses: actions/setup-python@v7
         with:
@@ -145,7 +147,7 @@ jobs:
             | python3 -c 'import sys, json; m = json.loads(sys.stdin.readline()); assert "suitest" in m["result"]["serverInfo"]["name"]; print("boot OK")'
 
       - name: Publish lifecycle package
-        if: startsWith(github.ref, 'refs/tags/mcp-v')
+        if: startsWith(github.ref, 'refs/tags/mcp-v') || github.event_name == 'workflow_dispatch'
         run: |
           python3 - <<'PY'
           import hashlib

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,13 +4,12 @@ name: release-please
 #   - packages/mcp-npx     → @suiflex/suitest-mcp  → tag mcp-v*      → release-mcp.yml
 #   - sdk/typescript       → @suiflex/suitest-sdk  → tag tssdk-v*    → release-ts-sdk.yml
 #   - packages/suitest-npx → @suiflex/suitest      → tag launcher-v* → release-launcher.yml
-# On every push to main, release-please opens/updates a separate release PR per
-# package (separate-pull-requests) that bumps its package.json (+ VERSION for mcp)
-# from the conventional commits since that package's last release. Merging a PR
-# tags `<component>-v<version>`, which triggers the matching publish workflow.
+# Run this workflow manually to prepare release PRs. Merging to main does not
+# create release tags or publish packages automatically. Publishing is performed
+# by manually dispatching the package workflow against an existing tag after the
+# release commit is on main.
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/release-python-sdk.yml
+++ b/.github/workflows/release-python-sdk.yml
@@ -19,6 +19,12 @@ on:
       - "sdk/python/**"
       - "cli/**"
       - ".github/workflows/release-python-sdk.yml"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing Python SDK/CLI release tag to publish
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -35,6 +41,8 @@ jobs:
             artifact: "dist-cli"
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
@@ -53,7 +61,7 @@ jobs:
 
   publish-sdk:
     needs: build
-    if: startsWith(github.ref, 'refs/tags/pysdk-v')
+    if: startsWith(github.ref, 'refs/tags/pysdk-v') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -69,7 +77,7 @@ jobs:
 
   publish-cli:
     needs: build
-    if: startsWith(github.ref, 'refs/tags/pysdk-v')
+    if: startsWith(github.ref, 'refs/tags/pysdk-v') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: pypi-cli
     permissions:

--- a/packages/suitest-npx/CHANGELOG.md
+++ b/packages/suitest-npx/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.3](https://github.com/suiflex/suitest/compare/launcher-v0.6.2...launcher-v0.6.3) (2026-08-12)
+
+### Bug Fixes
+
+* publish the launcher with the released `@suiflex/suitest-mcp@0.6.1` dependency
+
 ## [0.6.2](https://github.com/suiflex/suitest/compare/launcher-v0.6.1...launcher-v0.6.2) (2026-08-12)
 
 ### Bug Fixes

--- a/packages/suitest-npx/package.json
+++ b/packages/suitest-npx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suiflex/suitest",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Suitest local bundle — one command runs the full local stack (dashboard + SQLite + MCP).",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Release @suiflex/suitest 0.6.3 with the published @suiflex/suitest-mcp ^0.6.1 dependency. The 0.6.2 npm artifact was built from the pre-merge tag and still references unavailable ^0.5.2.