### PR TITLE
ci(release-please): auto-finalize tag on merged release PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,12 +4,16 @@ name: release-please
 #   - packages/mcp-npx     → @suiflex/suitest-mcp  → tag mcp-v*      → release-mcp.yml
 #   - sdk/typescript       → @suiflex/suitest-sdk  → tag tssdk-v*    → release-ts-sdk.yml
 #   - packages/suitest-npx → @suiflex/suitest      → tag launcher-v* → release-launcher.yml
-# Run this workflow manually to prepare release PRs. Merging to main does not
-# create release tags or publish packages automatically. Publishing is performed
-# by manually dispatching the package workflow against an existing tag after the
-# release commit is on main.
+# A maintainer starts release preparation explicitly (workflow_dispatch) to
+# open/update a release PR. Merging that PR finalizes it automatically into a
+# tag + GitHub Release, which then triggers the matching publish workflow
+# above via its `push: tags` trigger. Every other PR merge is ignored by the
+# job-level `if`, so this stays quiet on ordinary application PRs.
 on:
   workflow_dispatch:
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 permissions:
   contents: write
@@ -17,6 +21,12 @@ permissions:
 
 jobs:
   release-please:
+    # Manual runs prepare/update the release PR. Pull request runs only
+    # finalize a merged Release Please PR, never an application PR.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release-please--'))
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v5


### PR DESCRIPTION
## Summary
- Release PR preparation was already made `workflow_dispatch`-only to stop opening a release PR on every push to `main`
- That left no trigger to finalize the tag once the PR is merged — a maintainer had to manually re-dispatch the workflow a second time just to create the tag

## Changes
- Add a `pull_request: closed` trigger to `release-please.yml`, gated at the job level to only run for a merged `release-please--*` branch (never an ordinary application PR)
- Mirrors `rdb`'s `release-please.yml` pattern: one explicit dispatch to open/update the release PR, then automatic finalize into a tag + GitHub Release on merge
- Publish workflows (`release-mcp.yml`, `release-ts-sdk.yml`, `release-launcher.yml`) are unchanged — they already auto-trigger on the resulting tag push

## Test plan
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Dispatch manually on a branch to confirm the release PR still opens/updates as before
- [ ] Confirm an ordinary application PR merge does not trigger this job (skipped, not run)
- [ ] Merge an actual release-please PR and confirm the tag + GitHub Release get created without a second manual dispatch