### PR TITLE
chore(release): sync launcher manifest version with package.json

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/mcp-npx": "0.6.2",
   "sdk/typescript": "0.1.1",
-  "packages/suitest-npx": "0.6.1"
+  "packages/suitest-npx": "0.6.3"
 }


### PR DESCRIPTION
`packages/suitest-npx` was hand-bumped to 0.6.2 and 0.6.3 in the fix commits, but `.release-please-manifest.json` still recorded 0.6.1. release-please would have computed the next launcher version from a stale baseline.

Verified: manifest now matches `packages/suitest-npx/package.json` (0.6.3) and `packages/mcp-npx/package.json` (0.6.2).