### PR TITLE
chore(release): mcp 0.7.0 and launcher 0.6.4

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/mcp-npx": "0.6.2",
+  "packages/mcp-npx": "0.7.0",
   "sdk/typescript": "0.1.1",
-  "packages/suitest-npx": "0.6.3"
+  "packages/suitest-npx": "0.6.4"
 }

--- a/packages/mcp-npx/CHANGELOG.md
+++ b/packages/mcp-npx/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## Unreleased
+## [0.7.0](https://github.com/suiflex/suitest/compare/mcp-v0.6.2...mcp-v0.7.0) (2026-08-13)
+
+
+### Features
+
+* detect more FE/BE frameworks in `init` ([553e62c](https://github.com/suiflex/suitest/commit/553e62c))
+
 
 ### Bug Fixes
 

--- a/packages/mcp-npx/VERSION
+++ b/packages/mcp-npx/VERSION
@@ -1,1 +1,1 @@
-0.6.2 # x-release-please-version
+0.7.0 # x-release-please-version

--- a/packages/mcp-npx/package.json
+++ b/packages/mcp-npx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suiflex/suitest-mcp",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/suitest-npx/CHANGELOG.md
+++ b/packages/suitest-npx/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.4](https://github.com/suiflex/suitest/compare/launcher-v0.6.3...launcher-v0.6.4) (2026-08-13)
+
+### Features
+
+* onboard with `@suiflex/suitest-mcp@0.7.0`, which detects more FE/BE frameworks in `init`
+
 ## [0.6.3](https://github.com/suiflex/suitest/compare/launcher-v0.6.2...launcher-v0.6.3) (2026-08-12)
 
 ### Bug Fixes

--- a/packages/suitest-npx/package.json
+++ b/packages/suitest-npx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suiflex/suitest",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Suitest local bundle — one command runs the full local stack (dashboard + SQLite + MCP).",
   "license": "Apache-2.0",
   "repository": {
@@ -20,7 +20,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@suiflex/suitest-mcp": "^0.6.1"
+    "@suiflex/suitest-mcp": "^0.7.0"
   },
   "scripts": {
     "sync-assets": "node scripts/sync-assets.js",


### PR DESCRIPTION
Cuts the mcp work that has been sitting unreleased on `main`:

- `feat(mcp-npx): detect more FE/BE frameworks in init` (553e62c)
- terminal theme module required by launcher onboarding

Caret ranges pin the minor on 0.x, so `^0.6.1` would never resolve `0.7.0`. The launcher dependency moves to `^0.7.0` and the launcher ships as 0.6.4, otherwise `npx @suiflex/suitest onboard` keeps installing mcp 0.6.2 and the new detection never reaches users.

Verified locally: mcp `npm test` 76/76 pass, launcher `npm test` 39/39 pass, manifest/VERSION/package.json versions consistent, `forgeguard gate --changed` clean.

Tags `mcp-v0.7.0` then `launcher-v0.6.4` go out after merge, in that order.