### PR TITLE
fix(onboard): reject already-in-use ports during setup

### DIFF
--- a/packages/suitest-npx/lib/onboard.js
+++ b/packages/suitest-npx/lib/onboard.js
@@ -7,7 +7,7 @@ const { ensureProjectDirs, loadOrCreateCredentials } = require("./project.js");
 const { ensureWebDist, ensureWheels } = require("./assets.js");
 const { ensureVenv } = require("./venv.js");
 const { preflight } = require("./preflight.js");
-const { up } = require("./stack.js");
+const { up, isFree } = require("./stack.js");
 
 // First run → the user MUST set the superadmin account; nothing is auto-generated
 // (a generated password gets lost, and it's the only superadmin). Interactive prompt
@@ -90,14 +90,19 @@ async function resolvePort(dirs, opts) {
   const readline = require("node:readline/promises");
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   try {
-    const answer = (await rl.question(`Dashboard port [${current}]: `)).trim();
-    if (!answer) return current;
-    if (/^\d+$/.test(answer)) {
-      const n = Number(answer);
-      if (n >= 1024 && n <= 65535) return n;
+    for (;;) {
+      const answer = (await rl.question(`Dashboard port [${current}]: `)).trim();
+      let candidate = current;
+      if (answer) {
+        if (!/^\d+$/.test(answer) || Number(answer) < 1024 || Number(answer) > 65535) {
+          console.log(`  Ignoring invalid port "${answer}" — using ${current}.`);
+        } else {
+          candidate = Number(answer);
+        }
+      }
+      if (await isFree(candidate)) return candidate;
+      console.log(`  Port ${candidate} is already in use — pick another.`);
     }
-    console.log(`  Ignoring invalid port "${answer}" — using ${current}.`);
-    return current;
   } finally {
     rl.close();
   }


### PR DESCRIPTION
## Summary
- Onboarding's dashboard port prompt only checked the input was numeric and in range, never that the port was actually free.
- A busy port sailed through account setup, prepare, and mcp init before failing late inside `up()` -> `pickPort()`, forcing users to redo onboarding from scratch.

## Changes
- `packages/suitest-npx/lib/onboard.js`: `resolvePort()` now reuses the existing `isFree()` probe from `stack.js` to check port availability right after the prompt, and reprompts instead of proceeding on a busy port.

## Test plan
- [x] `node --check` on the edited file
- [x] Manual: start a listener on a port, run `suitest onboard`, confirm it reprompts instead of proceeding
- [x] Manual: run with a free port, confirm normal accept-on-enter / accept-on-valid-number behavior unchanged