### PR TITLE
fix(onboard): export isFree from stack.js

### DIFF
--- a/packages/suitest-npx/lib/stack.js
+++ b/packages/suitest-npx/lib/stack.js
@@ -220,4 +220,4 @@ function down(cwd) {
   return true;
 }
 
-module.exports = { pickPort, buildEnv, up, down, status, isAlive, isHealthy, waitHealthy };
+module.exports = { pickPort, isFree, buildEnv, up, down, status, isAlive, isHealthy, waitHealthy };


### PR DESCRIPTION
## Summary
- The port-in-use check merged in #96 imports `isFree` from `stack.js` into `onboard.js`, but `stack.js` never added `isFree` to its `module.exports`.
- Result: any TTY user who typed a busy port crashed with `TypeError: isFree is not a function` instead of getting reprompted — the exact regression the #96 fix was meant to prevent.

## Changes
- `packages/suitest-npx/lib/stack.js`: add `isFree` to `module.exports`.

## Test plan
- [x] Manually drove `resolvePort()` with a dummy `net` listener bound to a busy port + `expect` to feed answers: before the fix, crashed with `TypeError: isFree is not a function`; after the fix, correctly reprompts on the busy port and resolves to the next free one.