### PR TITLE
fix(publish): bind by API key and heal a dead projectId; sign local JWTs per install

### DIFF
--- a/apps/api/src/suitest_api/services/ingest_service.py
+++ b/apps/api/src/suitest_api/services/ingest_service.py
@@ -189,8 +189,9 @@ async def resolve_project(
     - explicit id exists in the workspace → ``valid``
     - id missing/stale but exactly one active project matches the slug or the
       (case-insensitive) name → ``repaired`` with the surviving id
-    - anything else → ``missing`` (ambiguous matches are listed as candidates;
-      the client must fail loudly or recreate only on an explicit flag)
+    - anything else → ``missing`` (ambiguous matches are listed as candidates,
+      and a client that sees them must fail loudly rather than guess; with no
+      candidates the binding is simply gone and the client may rebind by slug)
     """
     from sqlalchemy import func
     from suitest_db.models.project import Project

--- a/packages/lifecycle/src/suitest_lifecycle/http_client.py
+++ b/packages/lifecycle/src/suitest_lifecycle/http_client.py
@@ -48,7 +48,12 @@ class SuitestClient:
         self._headers: dict[str, str] = {"Accept": "application/json"}
         if token:
             self._headers["Authorization"] = f"Bearer {token}"
-        if workspace_id:
+        # An API key is pinned to its own workspace server-side, so the header can
+        # only ever agree with the key or be rejected with 403. Sending a stale
+        # workspaceId from suitest.config.json (a reinstall, or a config shared
+        # between people who each have their own workspace) would break every
+        # publish for no gain, so the key wins whenever there is one.
+        if workspace_id and not token:
             self._headers["X-Workspace-Id"] = workspace_id
 
     def __enter__(self) -> SuitestClient:

--- a/packages/lifecycle/src/suitest_lifecycle/retest.py
+++ b/packages/lifecycle/src/suitest_lifecycle/retest.py
@@ -181,6 +181,17 @@ def resolve_binding(
             detail=f"projectId '{config.publish.project_id}' not found; "
             f"explicit recreate flag set — server will find-or-create slug '{slug}'",
         )
+    if not candidates:
+        # Nothing to be ambiguous about: the id is gone and no project resembles
+        # this one (a reinstall wipes the local database, so every configured id
+        # dangles). Rebinding by slug is what the same config would have done
+        # with no projectId at all, and publish rewrites the healed id back.
+        return BindingResult(
+            "recreate_requested",
+            "will_recreate_by_slug",
+            detail=f"projectId '{config.publish.project_id}' not found and no project "
+            f"matched by name or slug — server will find-or-create slug '{slug}'",
+        )
     return BindingResult(
         "missing",
         "fail",

--- a/packages/lifecycle/tests/test_http_client.py
+++ b/packages/lifecycle/tests/test_http_client.py
@@ -18,6 +18,7 @@ class _Handler(BaseHTTPRequestHandler):
         body = self.rfile.read(int(self.headers.get("Content-Length", "0")))
         _seen["path"] = self.path
         _seen["auth"] = self.headers.get("Authorization")
+        _seen["workspace"] = self.headers.get("X-Workspace-Id")
         _seen["content_type"] = self.headers.get("Content-Type")
         _seen["body"] = body
         if self.path == "/api/v1/boom":
@@ -54,6 +55,20 @@ def test_json_post_carries_auth_and_body(server_url: str) -> None:
     assert _seen["auth"] == "Bearer sk_x"
     sent = json.loads(_seen["body"])
     assert sent["suiteName"] == "s" and sent["results"] == [{"slug": "a"}]
+
+
+def test_api_key_owns_the_workspace_and_suppresses_the_header(server_url: str) -> None:
+    # The key is pinned to its workspace server-side; a stale configured id could
+    # only ever 403 the run, so it must not be sent alongside a token.
+    with SuitestClient(server_url, token="sk_x", workspace_id="ws_from_a_dead_install") as c:
+        c.ingest_run(suite_name="s", name="n", results=[])
+    assert _seen["workspace"] is None
+
+
+def test_workspace_header_still_sent_without_a_token(server_url: str) -> None:
+    with SuitestClient(server_url, workspace_id="ws1") as c:
+        c.ingest_run(suite_name="s", name="n", results=[])
+    assert _seen["workspace"] == "ws1"
 
 
 def test_http_error_maps_to_api_error(server_url: str) -> None:

--- a/packages/lifecycle/tests/test_retest.py
+++ b/packages/lifecycle/tests/test_retest.py
@@ -180,19 +180,39 @@ def test_binding_stale_id_auto_repairs_and_rewrites_config(tmp_path: Path) -> No
     assert raw["publish"]["projectId"] == "proj_new"  # config file rewritten
 
 
-def test_binding_stale_id_unrepairable_fails_and_never_recreates(tmp_path: Path) -> None:
+def _ambiguous() -> dict[str, object]:
+    """Server response for a dead id that several live projects could answer to."""
+    return {
+        "status": "missing",
+        "candidates": [{"id": "proj_a", "name": "Demo App"}, {"id": "proj_b", "name": "Demo App"}],
+    }
+
+
+def test_binding_ambiguous_candidates_fail_and_never_recreate(tmp_path: Path) -> None:
     cfg = _config(tmp_path, project_id="proj_gone")
-    b = rt.resolve_binding(cfg, client=FakeBindingClient({"status": "missing"}))
+    b = rt.resolve_binding(cfg, client=FakeBindingClient(_ambiguous()))
     assert b.status == "missing"
     assert b.blocks_publish
     assert "recreateProject" in b.detail  # clear next action in the message
+    assert len(b.candidates) == 2
+    raw = json.loads(cfg.config_path.read_text())
+    assert raw["publish"]["projectId"] == "proj_gone"  # never rebound behind the user's back
 
 
-def test_binding_recreate_only_with_explicit_flag(tmp_path: Path) -> None:
+def test_binding_dead_id_without_candidates_rebinds_by_slug(tmp_path: Path) -> None:
+    # A reinstall drops the whole local database, so the configured id dangles and
+    # nothing resembles it. That is unambiguous — publish should heal, not stop.
     cfg = _config(tmp_path, project_id="proj_gone")
-    missing = FakeBindingClient({"status": "missing"})
-    assert rt.resolve_binding(cfg, client=missing).status == "missing"
-    b = rt.resolve_binding(cfg, recreate=True, client=FakeBindingClient({"status": "missing"}))
+    b = rt.resolve_binding(cfg, client=FakeBindingClient({"status": "missing"}))
+    assert b.status == "recreate_requested"
+    assert not b.blocks_publish
+    assert "demo-app" in b.detail
+
+
+def test_binding_recreate_flag_overrides_ambiguity(tmp_path: Path) -> None:
+    cfg = _config(tmp_path, project_id="proj_gone")
+    assert rt.resolve_binding(cfg, client=FakeBindingClient(_ambiguous())).status == "missing"
+    b = rt.resolve_binding(cfg, recreate=True, client=FakeBindingClient(_ambiguous()))
     assert b.status == "recreate_requested"
     assert not b.blocks_publish
 

--- a/packages/suitest-npx/lib/project.js
+++ b/packages/suitest-npx/lib/project.js
@@ -47,17 +47,26 @@ function cacheDir(version) {
 
 // Superadmin bootstrap credentials for local API; apiKey is filled after mint (api-key.js).
 // encryptionKey feeds SUITEST_ENCRYPTION_KEY (urlsafe-b64, 32 bytes) — api_keys are
-// AES-GCM encrypted at rest, so minting 500s without it. Backfilled on load for
-// credential files created before this field existed.
+// AES-GCM encrypted at rest, so minting 500s without it.
+// authSecret feeds SUITEST_AUTH_SECRET, which signs the session JWTs. Without it the
+// API falls back to the published default in settings.py, so every install on earth
+// would sign tokens anyone could forge. Both are backfilled on load for credential
+// files created before the field existed.
 // Password is NEVER auto-generated: the superadmin must set one they can remember,
 // so account creation happens in `suitest onboard` (prompt or --email/--password).
 function loadOrCreateCredentials(credPath, defaults = {}) {
   if (fs.existsSync(credPath)) {
     const creds = JSON.parse(fs.readFileSync(credPath, "utf8"));
+    let backfilled = false;
     if (!creds.encryptionKey) {
       creds.encryptionKey = crypto.randomBytes(32).toString("base64");
-      saveCredentials(credPath, creds);
+      backfilled = true;
     }
+    if (!creds.authSecret) {
+      creds.authSecret = crypto.randomBytes(32).toString("base64");
+      backfilled = true;
+    }
+    if (backfilled) saveCredentials(credPath, creds);
     return creds;
   }
   if (!defaults.password) {
@@ -67,6 +76,7 @@ function loadOrCreateCredentials(credPath, defaults = {}) {
     email: defaults.email || "admin@suitest.local",
     password: defaults.password,
     encryptionKey: crypto.randomBytes(32).toString("base64"),
+    authSecret: crypto.randomBytes(32).toString("base64"),
     apiKey: null,
   };
   saveCredentials(credPath, creds);

--- a/packages/suitest-npx/lib/stack.js
+++ b/packages/suitest-npx/lib/stack.js
@@ -56,6 +56,7 @@ function buildEnv(cwd, { port, webDist, creds }) {
     SUITEST_SUPERADMIN_EMAIL: creds.email,
     SUITEST_SUPERADMIN_PASSWORD: creds.password,
     SUITEST_ENCRYPTION_KEY: creds.encryptionKey,
+    SUITEST_AUTH_SECRET: creds.authSecret,
     SUITEST_API_URL: `http://127.0.0.1:${port}`,
   };
 }

--- a/packages/suitest-npx/test/project.test.js
+++ b/packages/suitest-npx/test/project.test.js
@@ -45,17 +45,20 @@ test("credentials are created once from user input, persisted with mode 600", ()
   assert.strictEqual(first.apiKey, null);
   // 32 bytes base64 = 44 chars, decodes back to 32 (crypto.py urlsafe_b64decode)
   assert.strictEqual(Buffer.from(first.encryptionKey, "base64").length, 32);
+  // JWT signing key: >= 32 bytes for SHA256, and unique per install
+  assert.ok(Buffer.from(first.authSecret, "base64").length >= 32);
   const mode = fs.statSync(dirs.credentials).mode & 0o777;
   assert.strictEqual(mode, 0o600);
   const again = loadOrCreateCredentials(dirs.credentials);
   assert.strictEqual(again.password, first.password);
   assert.strictEqual(again.encryptionKey, first.encryptionKey);
+  assert.strictEqual(again.authSecret, first.authSecret); // stable across restarts
   first.apiKey = "sk_suitest_x";
   saveCredentials(dirs.credentials, first);
   assert.strictEqual(loadOrCreateCredentials(dirs.credentials).apiKey, "sk_suitest_x");
 });
 
-test("pre-encryptionKey credential files are backfilled on load", () => {
+test("older credential files are backfilled with both generated keys on load", () => {
   const cwd = tmp();
   const dirs = ensureProjectDirs(cwd);
   fs.writeFileSync(
@@ -64,9 +67,21 @@ test("pre-encryptionKey credential files are backfilled on load", () => {
   );
   const creds = loadOrCreateCredentials(dirs.credentials);
   assert.strictEqual(Buffer.from(creds.encryptionKey, "base64").length, 32);
+  assert.ok(Buffer.from(creds.authSecret, "base64").length >= 32);
   // persisted, not just in-memory
   const reread = JSON.parse(fs.readFileSync(dirs.credentials, "utf8"));
   assert.strictEqual(reread.encryptionKey, creds.encryptionKey);
+  assert.strictEqual(reread.authSecret, creds.authSecret);
+});
+
+test("each install gets its own JWT signing secret", () => {
+  const a = ensureProjectDirs(tmp());
+  const b = ensureProjectDirs(tmp());
+  const opts = { email: "me@example.com", password: "hunter2hunter2" };
+  assert.notStrictEqual(
+    loadOrCreateCredentials(a.credentials, opts).authSecret,
+    loadOrCreateCredentials(b.credentials, opts).authSecret,
+  );
 });
 
 test("dbUrl is absolute sqlite+aiosqlite (4 slashes)", () => {

--- a/packages/suitest-npx/test/stack.test.js
+++ b/packages/suitest-npx/test/stack.test.js
@@ -34,9 +34,17 @@ test("pickPort returns the preferred port when free", async () => {
 
 test("buildEnv composes the full local env for both processes", () => {
   const cwd = tmp();
-  const creds = { email: "admin@suitest.local", password: "pw", encryptionKey: "a2V5", apiKey: null };
+  const creds = {
+    email: "admin@suitest.local",
+    password: "pw",
+    encryptionKey: "a2V5",
+    authSecret: "c2VjcmV0",
+    apiKey: null,
+  };
   const env = buildEnv(cwd, { port: 4321, webDist: "/cache/web", creds });
   assert.strictEqual(env.SUITEST_ENCRYPTION_KEY, "a2V5");
+  // without this the API falls back to the published default in settings.py
+  assert.strictEqual(env.SUITEST_AUTH_SECRET, "c2VjcmV0");
   assert.strictEqual(env.PYTHONUNBUFFERED, "1");
   assert.strictEqual(env.SUITEST_MODE, "local");
   assert.ok(env.SUITEST_DATABASE_URL.startsWith("sqlite+aiosqlite:///"));


### PR DESCRIPTION
Reported after an uninstall/reinstall: `npx @suiflex/suitest onboard` came back up but publishing from the example backend failed, and the fix was to hand-edit JSON.

## Publishing after a reinstall

A reinstall wipes the local database, so both server-side ids pinned in `suitest.config.json` dangle:

| Stale field | Failure |
|---|---|
| `publish.workspaceId` | sent as `X-Workspace-Id` (`http_client.py:51`); the new API key belongs to a new workspace → 403 `api_key.py:108` |
| `publish.projectId` | absent with no name/slug match → `ingest_service.py:229` `missing` → `retest.py:63` blocks the run and tells the user to edit the config |

An API key is pinned to its workspace server-side, so the header could only ever agree with the key or 403 the run — the key now wins whenever there is one. That also fixes a config shared between people who each have their own workspace, which is the normal case for a repo like `example/`.

For the project id: with no candidates there is nothing to confuse it for, which is the same situation as having no `projectId` at all, so it rebinds by slug and `publish.py:394` writes the healed id back. **Ambiguous candidates still fail loudly** — that guardrail is unchanged and now has its own test.

## Local JWT secret

Unrelated but found in `.suitest/logs/api.log`:

```
InsecureKeyLengthWarning: The HMAC key is 20 bytes long, which is below
the minimum recommended length of 32 bytes for SHA256
```

The launcher never set `SUITEST_AUTH_SECRET`, so every local install fell back to `settings.py`'s `dev-secret-change-me` — a published constant, so anyone could forge a session token against any local instance. It now generates a 32-byte secret per install next to the existing encryption key, backfilled for older credential files.

**Existing installs are signed out once** when the secret is backfilled.

## Verification

- `pytest packages/lifecycle/tests`: 143 passed
- `npm test` in `packages/suitest-npx`: 40 passed
- `ruff check` + `ruff format --check` clean, `mypy` clean on both changed modules
- `apps/api/tests/services/test_ingest_service.py` skips locally (needs Docker/Postgres); only its docstring changed

`forgeguard gate --changed` reports one pre-existing warning, FG-NET-001 at `stack.js:104` — the health-poll loop, untouched by this PR.