### PR TITLE
chore(release): lifecycle 0.1.7, mcp 0.7.1 and launcher 0.6.6

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/mcp-npx": "0.7.0",
+  "packages/mcp-npx": "0.7.1",
   "sdk/typescript": "0.1.1",
-  "packages/suitest-npx": "0.6.5"
+  "packages/suitest-npx": "0.6.6"
 }

--- a/packages/lifecycle/pyproject.toml
+++ b/packages/lifecycle/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "suiflex-suitest-lifecycle"
-version = "0.1.6"
+version = "0.1.7"
 description = "Suitest testing lifecycle — TestSprite-parity analyze→generate→start→wait→run→report"
 requires-python = ">=3.11"
 # No third-party runtime deps: the lifecycle core is stdlib-only so it can drive

--- a/packages/mcp-npx/CHANGELOG.md
+++ b/packages/mcp-npx/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.7.1](https://github.com/suiflex/suitest/compare/mcp-v0.7.0...mcp-v0.7.1) (2026-08-13)
+
+
+### Bug Fixes
+
+* publish against the workspace the API key belongs to, ignoring a stale `publish.workspaceId`
+* rebind a dead `publish.projectId` by slug when nothing ambiguous matches, instead of blocking the run
+
 ## [0.7.0](https://github.com/suiflex/suitest/compare/mcp-v0.6.2...mcp-v0.7.0) (2026-08-13)
 
 

--- a/packages/mcp-npx/VERSION
+++ b/packages/mcp-npx/VERSION
@@ -1,1 +1,1 @@
-0.7.0 # x-release-please-version
+0.7.1 # x-release-please-version

--- a/packages/mcp-npx/package.json
+++ b/packages/mcp-npx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suiflex/suitest-mcp",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/suitest-npx/CHANGELOG.md
+++ b/packages/suitest-npx/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.6.6](https://github.com/suiflex/suitest/compare/launcher-v0.6.5...launcher-v0.6.6) (2026-08-13)
+
+
+### Bug Fixes
+
+* sign session JWTs with a 32-byte secret generated per install, instead of the published default in `settings.py`. Existing installs are signed out once.
+* onboard with `@suiflex/suitest-mcp@0.7.1`, so publishing survives an uninstall/reinstall without hand-editing `suitest.config.json`
+
 ## [0.6.5](https://github.com/suiflex/suitest/compare/launcher-v0.6.4...launcher-v0.6.5) (2026-08-13)
 
 

--- a/packages/suitest-npx/package.json
+++ b/packages/suitest-npx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suiflex/suitest",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Suitest local bundle — one command runs the full local stack (dashboard + SQLite + MCP).",
   "license": "Apache-2.0",
   "repository": {
@@ -20,7 +20,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@suiflex/suitest-mcp": "^0.7.0"
+    "@suiflex/suitest-mcp": "^0.7.1"
   },
   "scripts": {
     "sync-assets": "node scripts/sync-assets.js",

--- a/uv.lock
+++ b/uv.lock
@@ -2648,7 +2648,7 @@ wheels = [
 
 [[package]]
 name = "suiflex-suitest-lifecycle"
-version = "0.1.5"
+version = "0.1.7"
 source = { editable = "packages/lifecycle" }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Releases the fixes from #98. Launcher 0.6.5 was cut from the commit *before* that PR landed, so npm currently serves the broken behavior:

| Package | npm/PyPI today | after this |
|---|---|---|
| `@suiflex/suitest` | 0.6.5 | 0.6.6 |
| `@suiflex/suitest-mcp` | 0.7.0 | 0.7.1 |
| `suiflex-suitest-lifecycle` | 0.1.6 | 0.1.7 |

The publish fix lives in `packages/lifecycle`, which `mcp-npx` bundles at `prepack` (`scripts/sync-python.js`) and the launcher ships as a wheel — hence all three move. The JWT secret fix is launcher-side, so the caret dependency goes to `^0.7.1` (caret pins the minor on 0.x).

**Existing installs are signed out once** when `authSecret` is backfilled into `credentials.json`.

Also relocks `uv.lock`, which had been pinning `suiflex-suitest-lifecycle` at 0.1.5 since an earlier hand-bump.

Verified: mcp `npm test` and launcher `npm test` pass, the synced `python/` tree carries the fixed `http_client.py`/`retest.py`, `forgeguard gate --changed` clean.

Tags `mcp-v0.7.1` then `launcher-v0.6.6` go out after merge, in that order.