### PR TITLE
fix(lifecycle): run on Python 3.11 and provision the backend test dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
       web: ${{ steps.filter.outputs.web }}
       mcp: ${{ steps.filter.outputs.mcp }}
+      floor: ${{ steps.filter.outputs.floor }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -52,6 +53,11 @@ jobs:
             mcp:
               - 'packages/mcp-npx/**'
               - 'packages/lifecycle/**'
+              - '.github/workflows/ci.yml'
+            floor:
+              - 'packages/mcp-npx/**'
+              - 'packages/lifecycle/**'
+              - 'packages/suitest-npx/**'
               - '.github/workflows/ci.yml'
 
   python-lint:
@@ -326,6 +332,47 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}
 
   # ------------------------------------------------------------------------
+  # Version floor — the npm packages declare Node >= 18 and the bundled Python
+  # declares >= 3.11, but every other job runs Node 22 / Python 3.12. A PEP 695
+  # `type` alias once shipped to npm that way and crashed every tool on a 3.11
+  # host. This job runs BOTH packages against the versions they promise.
+  # ------------------------------------------------------------------------
+  version-floor:
+    name: Version floor (Node 18 + Python 3.11)
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.floor == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "18"
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      # The unit tests import very little of the bundled tree, so compiling every
+      # module is what actually catches syntax the floor cannot parse.
+      - name: Compile the bundled Python on 3.11
+        working-directory: packages/mcp-npx
+        run: |
+          node scripts/sync-python.js
+          python -m compileall -q python
+
+      - name: MCP package tests on Node 18
+        working-directory: packages/mcp-npx
+        run: npm test
+
+      - name: Launcher tests on Node 18
+        working-directory: packages/suitest-npx
+        run: npm test
+
+  # ------------------------------------------------------------------------
   # @suiflex/suitest-mcp (npx wrapper) — prove the artifact users actually install:
   # bundle sync, JSON-RPC boot smoke via the real bin, and a tarball dry-run.
   # Also validates the uvx path: build the suiflex-suitest-lifecycle wheel and boot
@@ -343,7 +390,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: "22" # node --test glob patterns need >= 21
+          node-version: "22"
 
       - name: Set up Python
         uses: actions/setup-python@v7

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/mcp-npx": "0.7.1",
+  "packages/mcp-npx": "0.7.2",
   "sdk/typescript": "0.1.1",
-  "packages/suitest-npx": "0.6.6"
+  "packages/suitest-npx": "0.6.7"
 }

--- a/packages/lifecycle/pyproject.toml
+++ b/packages/lifecycle/pyproject.toml
@@ -1,11 +1,13 @@
 [project]
 name = "suiflex-suitest-lifecycle"
-version = "0.1.7"
+version = "0.1.8"
 description = "Suitest testing lifecycle — TestSprite-parity analyze→generate→start→wait→run→report"
 requires-python = ">=3.11"
 # No third-party runtime deps: the lifecycle core is stdlib-only so it can drive
-# any target project. Generated tests use `requests` / `playwright`, installed in
-# the target's own environment — not here.
+# any target project. The generated tests do use `requests` / `playwright`, but
+# Suitest provisions those on demand into the interpreter that runs them
+# (`pydeps.ensure`) rather than declaring them here — the person testing their
+# app never runs `pip install`.
 dependencies = []
 
 # Frontend execution runtime. Suitest BUNDLES the browser driver so the user
@@ -31,3 +33,11 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/suitest_lifecycle"]
+
+# The rest of the monorepo is pinned to 3.12, but this package is copied verbatim
+# into the npm tarball and executed by whatever interpreter the host has, down to
+# the 3.11 declared above. Linting it at py311 is what makes 3.12-only syntax a
+# CI failure here instead of a crash on a user's machine.
+[tool.ruff]
+extend = "../../pyproject.toml"
+target-version = "py311"

--- a/packages/lifecycle/src/suitest_lifecycle/frontend_runtime.py
+++ b/packages/lifecycle/src/suitest_lifecycle/frontend_runtime.py
@@ -13,13 +13,11 @@ message instead of letting a raw ``ModuleNotFoundError`` crash the tool.
 
 from __future__ import annotations
 
-import contextlib
-import importlib
-import importlib.util
-import site
 import subprocess
 import sys
 from dataclasses import dataclass
+
+from suitest_lifecycle import pydeps
 
 
 @dataclass(frozen=True)
@@ -29,79 +27,12 @@ class BrowserStatus:
 
 
 def _playwright_importable() -> bool:
-    try:
-        import playwright.async_api  # noqa: F401
-    except ImportError:
-        return False
-    return True
-
-
-def _pip_install_variants(pkg: str) -> list[list[str]]:
-    """pip argv variants to try in order, adapting to the interpreter.
-
-    - Inside a venv (``sys.prefix != sys.base_prefix``): install into the venv
-      site — no ``--user`` (disallowed in venvs), no PEP-668 marker to fight.
-    - System/Homebrew/distro interpreter: prefer ``--user`` (contained to the
-      user site, importable by this interpreter AND the subprocesses that run
-      the generated tests), with a ``--break-system-packages`` fallback for
-      PEP-668 "externally-managed" environments (Homebrew, Debian).
-    """
-    base = [sys.executable, "-m", "pip", "install", "--upgrade", pkg]
-    in_venv = sys.prefix != sys.base_prefix
-    if in_venv:
-        return [base]
-    return [[*base, "--user"], [*base, "--user", "--break-system-packages"]]
-
-
-def _ensure_pip() -> None:
-    """Best-effort: bootstrap pip via ensurepip when the interpreter lacks it
-    (minimal venvs / stripped pythons ship without pip)."""
-    if importlib.util.find_spec("pip") is not None:
-        return
-    with contextlib.suppress(subprocess.TimeoutExpired, OSError):
-        subprocess.run(
-            [sys.executable, "-m", "ensurepip", "--upgrade"],
-            capture_output=True,
-            text=True,
-            timeout=180,
-        )
-
-
-def _make_importable_in_process() -> None:
-    """Surface a just-installed package to the RUNNING interpreter without a
-    restart. A server started before the user-site dir existed never got it on
-    ``sys.path`` (``site`` only adds user-site at startup, and only if it
-    exists) — add it now and drop import caches."""
-    usersite = site.getusersitepackages()
-    if isinstance(usersite, str):
-        site.addsitedir(usersite)
-    importlib.invalidate_caches()
+    return pydeps.importable("playwright.async_api")
 
 
 def _install_playwright_package(timeout_sec: int) -> BrowserStatus:
-    _ensure_pip()
-    detail = "pip unavailable"
-    for argv in _pip_install_variants("playwright"):
-        try:
-            proc = subprocess.run(argv, capture_output=True, text=True, timeout=timeout_sec)
-        except (subprocess.TimeoutExpired, OSError) as exc:
-            detail = str(exc)
-            continue
-        if proc.returncode == 0:
-            _make_importable_in_process()
-            if _playwright_importable():
-                return BrowserStatus(True, "playwright package installed on demand")
-            detail = "pip reported success but playwright is still not importable"
-            continue
-        tail = (proc.stderr or proc.stdout or "").strip().splitlines()[-3:]
-        detail = " | ".join(tail) if tail else f"pip exited {proc.returncode}"
-    return BrowserStatus(
-        False,
-        "could not auto-install the playwright package "
-        f"(interpreter: {sys.executable}): {detail}. "
-        "Install it manually: "
-        f"'{sys.executable} -m pip install playwright'",
-    )
+    status = pydeps.install("playwright", "playwright.async_api", timeout_sec)
+    return BrowserStatus(status.ready, status.detail)
 
 
 def _chromium_present() -> bool:

--- a/packages/lifecycle/src/suitest_lifecycle/http_client.py
+++ b/packages/lifecycle/src/suitest_lifecycle/http_client.py
@@ -20,7 +20,9 @@ import urllib.request
 import uuid
 from typing import Any
 
-type JSONDict = dict[str, Any]
+# Plain assignment, not a PEP 695 `type` statement: this module ships to hosts
+# running the 3.11 the package advertises, where that syntax does not parse.
+JSONDict = dict[str, Any]
 
 
 class SuitestAPIError(RuntimeError):

--- a/packages/lifecycle/src/suitest_lifecycle/orchestrator.py
+++ b/packages/lifecycle/src/suitest_lifecycle/orchestrator.py
@@ -13,6 +13,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from suitest_lifecycle import pydeps
 from suitest_lifecycle.analyzers.express import analyze_express
 from suitest_lifecycle.analyzers.react import analyze_react
 from suitest_lifecycle.enrich import enrich_plan, resolve_client
@@ -666,13 +667,19 @@ def run_lifecycle(config: Config) -> LifecycleResult:
         if not is_ready:
             return _finish_fail(f"target never became ready ({ready_detail})")
 
-        # 3) frontend: ensure Suitest's bundled browser is provisioned (user never
-        #    installs playwright themselves — Suitest owns the runtime)
+        # 3) ensure Suitest's own test runtime is provisioned — the user runs their
+        #    app, never `pip install`. Frontend needs playwright + Chromium; the
+        #    generated backend tests import `requests` (exporters/backend.py).
         if config.mode is Mode.FRONTEND:
             browser = ensure_browser()
             steps.append(f"browser: {browser.detail}")
             if not browser.ready:
                 return _finish_fail(f"browser unavailable: {browser.detail}")
+        else:
+            http = pydeps.ensure("requests")
+            steps.append(f"http client: {http.detail}")
+            if not http.ready:
+                return _finish_fail(f"http client unavailable: {http.detail}")
 
         # 4) crawl/blackbox mode: app is up — discover via live DOM, then generate.
         if _is_blackbox(config):

--- a/packages/lifecycle/src/suitest_lifecycle/pydeps.py
+++ b/packages/lifecycle/src/suitest_lifecycle/pydeps.py
@@ -18,6 +18,10 @@ import site
 import subprocess
 import sys
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @dataclass(frozen=True)
@@ -113,6 +117,25 @@ def ensure(
     return install(pkg, module, timeout_sec)
 
 
+_VENV_BIN = ("bin/python", "Scripts/python.exe")
+_PROJECT_VENV_DIRS = (".venv", "venv", ".venv-suitest", "env")
+
+
+def project_interpreter(project_path: Path) -> str | None:
+    """The interpreter belonging to the project under test, if it ships one.
+
+    A project's own tests import the project's own dependencies, which Suitest's
+    interpreter knows nothing about. Prefer the venv sitting in the repo — the
+    Python equivalent of what ``npm exec`` already does for the Node adapters.
+    """
+    for name in _PROJECT_VENV_DIRS:
+        for rel in _VENV_BIN:
+            candidate = project_path / name / rel
+            if candidate.is_file():
+                return str(candidate)
+    return None
+
+
 __all__ = [
     "DepStatus",
     "ensure",
@@ -121,4 +144,5 @@ __all__ = [
     "install",
     "make_importable_in_process",
     "pip_install_variants",
+    "project_interpreter",
 ]

--- a/packages/lifecycle/src/suitest_lifecycle/pydeps.py
+++ b/packages/lifecycle/src/suitest_lifecycle/pydeps.py
@@ -1,0 +1,124 @@
+"""On-demand pip provisioning for the packages generated tests import.
+
+Suitest owns its test runtime: the person testing their app runs their app, not
+``pip install``. The generated backend tests import ``requests`` and the frontend
+ones drive ``playwright``, so both are installed into the interpreter that will
+execute them — the same one running this module, since ``runner.run_tests``
+shells out to ``sys.executable``.
+
+Everything here is idempotent and cheap when the package is already importable.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import importlib.util
+import site
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DepStatus:
+    ready: bool
+    detail: str
+
+
+def importable(module: str) -> bool:
+    try:
+        importlib.import_module(module)
+    except ImportError:
+        return False
+    return True
+
+
+def pip_install_variants(pkg: str) -> list[list[str]]:
+    """pip argv variants to try in order, adapting to the interpreter.
+
+    - Inside a venv (``sys.prefix != sys.base_prefix``): install into the venv
+      site — no ``--user`` (disallowed in venvs), no PEP-668 marker to fight.
+    - System/Homebrew/distro interpreter: prefer ``--user`` (contained to the
+      user site, importable by this interpreter AND the subprocesses that run
+      the generated tests), with a ``--break-system-packages`` fallback for
+      PEP-668 "externally-managed" environments (Homebrew, Debian).
+    """
+    base = [sys.executable, "-m", "pip", "install", "--upgrade", pkg]
+    in_venv = sys.prefix != sys.base_prefix
+    if in_venv:
+        return [base]
+    return [[*base, "--user"], [*base, "--user", "--break-system-packages"]]
+
+
+def ensure_pip() -> None:
+    """Best-effort: bootstrap pip via ensurepip when the interpreter lacks it
+    (minimal venvs / stripped pythons ship without pip)."""
+    if importlib.util.find_spec("pip") is not None:
+        return
+    with contextlib.suppress(subprocess.TimeoutExpired, OSError):
+        subprocess.run(
+            [sys.executable, "-m", "ensurepip", "--upgrade"],
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+
+
+def make_importable_in_process() -> None:
+    """Surface a just-installed package to the RUNNING interpreter without a
+    restart. A server started before the user-site dir existed never got it on
+    ``sys.path`` (``site`` only adds user-site at startup, and only if it
+    exists) — add it now and drop import caches."""
+    usersite = site.getusersitepackages()
+    if isinstance(usersite, str):
+        site.addsitedir(usersite)
+    importlib.invalidate_caches()
+
+
+def install(pkg: str, module: str, timeout_sec: int) -> DepStatus:
+    """Install ``pkg`` and report whether ``module`` became importable."""
+    ensure_pip()
+    detail = "pip unavailable"
+    for argv in pip_install_variants(pkg):
+        try:
+            proc = subprocess.run(argv, capture_output=True, text=True, timeout=timeout_sec)
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            detail = str(exc)
+            continue
+        if proc.returncode == 0:
+            make_importable_in_process()
+            if importable(module):
+                return DepStatus(True, f"{pkg} installed on demand")
+            detail = f"pip reported success but {module} is still not importable"
+            continue
+        tail = (proc.stderr or proc.stdout or "").strip().splitlines()[-3:]
+        detail = " | ".join(tail) if tail else f"pip exited {proc.returncode}"
+    return DepStatus(
+        False,
+        f"could not auto-install {pkg} (interpreter: {sys.executable}): {detail}. "
+        f"Install it manually: '{sys.executable} -m pip install {pkg}'",
+    )
+
+
+def ensure(
+    pkg: str, module: str | None = None, *, auto_install: bool = True, timeout_sec: int = 300
+) -> DepStatus:
+    """Make ``module`` importable, installing ``pkg`` on demand when it is not."""
+    module = module or pkg
+    if importable(module):
+        return DepStatus(True, "ready")
+    if not auto_install:
+        return DepStatus(False, f"{pkg} not installed (auto-install disabled)")
+    return install(pkg, module, timeout_sec)
+
+
+__all__ = [
+    "DepStatus",
+    "ensure",
+    "ensure_pip",
+    "importable",
+    "install",
+    "make_importable_in_process",
+    "pip_install_variants",
+]

--- a/packages/lifecycle/src/suitest_lifecycle/whitebox.py
+++ b/packages/lifecycle/src/suitest_lifecycle/whitebox.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from itertools import chain
 from typing import TYPE_CHECKING, Protocol
 
+from suitest_lifecycle import pydeps
 from suitest_lifecycle.models import (
     CodeSummary,
     PlanCase,
@@ -78,6 +79,8 @@ class WhiteboxAdapter(Protocol):
 
     def command_for(self, target: Path) -> list[str]: ...
 
+    def ensure_runtime(self) -> pydeps.DepStatus: ...
+
 
 def _walk(root: Path, patterns: tuple[str, ...]) -> list[Path]:
     found: set[Path] = set()
@@ -97,24 +100,49 @@ def _allowed_path(path: Path) -> bool:
 class PytestAdapter:
     framework = "pytest"
 
+    def __init__(self, project_path: Path | None = None) -> None:
+        # The project's tests import the project's dependencies, which Suitest's
+        # own interpreter knows nothing about — so run them with the venv in the
+        # repo when there is one. This mirrors NodeTestAdapter, which shells out
+        # to `npm exec` and therefore already resolves the project's toolchain.
+        self.python = pydeps.project_interpreter(project_path) if project_path else None
+
+    @property
+    def interpreter(self) -> str:
+        return self.python or sys.executable
+
+    def ensure_runtime(self) -> pydeps.DepStatus:
+        """Provision pytest when falling back to Suitest's own interpreter.
+
+        A project venv is assumed to carry its own pytest; installing into it
+        would be Suitest mutating the user's environment uninvited.
+        """
+        if self.python is not None:
+            return pydeps.DepStatus(True, f"project interpreter: {self.python}")
+        return pydeps.ensure("pytest")
+
     def discover(self, project_path: Path) -> WhiteboxDiscovery:
         targets = _walk(project_path, ("test_*.py", "*_test.py"))
         coverage = project_path / "coverage.json"
         return WhiteboxDiscovery(
             capability=WHITEBOX_CAPABILITY,
             framework=self.framework,
-            command=[sys.executable, "-m", "pytest", "-q"],
+            command=[self.interpreter, "-m", "pytest", "-q"],
             targets=targets,
             coverage_file=coverage,
         )
 
     def command_for(self, target: Path) -> list[str]:
-        return [sys.executable, "-m", "pytest", "-q", str(target)]
+        return [self.interpreter, "-m", "pytest", "-q", str(target)]
 
 
 class NodeTestAdapter:
     def __init__(self, framework: str) -> None:
         self.framework = framework
+
+    def ensure_runtime(self) -> pydeps.DepStatus:
+        # `npm exec` already resolves the project's own node_modules.
+        return pydeps.DepStatus(True, "project toolchain via npm exec")
 
     def discover(self, project_path: Path) -> WhiteboxDiscovery:
         targets = _walk(
@@ -147,7 +175,7 @@ def detect_adapter(project_path: Path, requested: str = "") -> WhiteboxAdapter:
         not normalized
         and ((project_path / "pyproject.toml").is_file() or (project_path / "pytest.ini").is_file())
     ):
-        return PytestAdapter()
+        return PytestAdapter(project_path)
     package_json = project_path / "package.json"
     package_text = package_json.read_text(encoding="utf-8") if package_json.is_file() else ""
     if normalized in {"vitest", "jest"}:
@@ -335,6 +363,9 @@ def execute(config: Config) -> tuple[CodeSummary, list[PlanCase], RunSummary, Pa
         case.framework = discovery.framework
     results: list[TestResult] = []
     adapter = detect_adapter(config.project_path, discovery.framework)
+    runtime = adapter.ensure_runtime()
+    if not runtime.ready:
+        raise RuntimeError(f"white-box runtime unavailable: {runtime.detail}")
     for case, target in zip(cases, targets, strict=True):
         command = config.testing.command or adapter.command_for(target)
         outcome, duration_ms, stdout, stderr = _run_command(command, config.project_path)

--- a/packages/lifecycle/tests/test_frontend_runtime.py
+++ b/packages/lifecycle/tests/test_frontend_runtime.py
@@ -1,8 +1,8 @@
 """Unit tests for on-demand Playwright provisioning + the browser-tool guard.
 
-Hermetic: no real pip, no browser. We assert the argv-selection logic (the
-money path: venv vs system, PEP-668 fallback) and that a browser tool degrades
-to a clean envelope instead of crashing when provisioning fails.
+Hermetic: no real pip, no browser. The pip argv-selection logic itself lives in
+``pydeps`` and is covered by ``test_pydeps.py``; here we assert that a browser
+tool degrades to a clean envelope instead of crashing when provisioning fails.
 """
 
 from __future__ import annotations
@@ -10,27 +10,6 @@ from __future__ import annotations
 import suitest_lifecycle.frontend_runtime as fr
 from suitest_lifecycle.blackbox import mcp as bbmcp
 from suitest_lifecycle.frontend_runtime import BrowserStatus
-
-
-def test_pip_variants_in_venv_installs_into_venv(monkeypatch) -> None:
-    # venv => prefix differs from base_prefix; no --user, no PEP-668 fight.
-    monkeypatch.setattr(fr.sys, "prefix", "/tmp/venv")
-    monkeypatch.setattr(fr.sys, "base_prefix", "/usr")
-    variants = fr._pip_install_variants("playwright")
-    assert len(variants) == 1
-    assert "--user" not in variants[0]
-    assert "--break-system-packages" not in variants[0]
-    assert variants[0][-1] == "playwright"
-
-
-def test_pip_variants_system_has_user_then_break_system(monkeypatch) -> None:
-    # Non-venv => --user first, then --break-system-packages for PEP-668.
-    monkeypatch.setattr(fr.sys, "prefix", "/usr")
-    monkeypatch.setattr(fr.sys, "base_prefix", "/usr")
-    variants = fr._pip_install_variants("playwright")
-    assert len(variants) == 2
-    assert "--user" in variants[0] and "--break-system-packages" not in variants[0]
-    assert "--user" in variants[1] and "--break-system-packages" in variants[1]
 
 
 def test_ensure_browser_no_autoinstall_reports_missing(monkeypatch) -> None:

--- a/packages/lifecycle/tests/test_pydeps.py
+++ b/packages/lifecycle/tests/test_pydeps.py
@@ -1,0 +1,61 @@
+"""Unit tests for on-demand pip provisioning shared by the test runtimes.
+
+Hermetic: no real pip. We assert the argv-selection logic (the money path: venv
+vs system, PEP-668 fallback) and that ``ensure`` skips work when the module is
+already importable.
+"""
+
+from __future__ import annotations
+
+from suitest_lifecycle import pydeps
+
+
+def test_pip_variants_in_venv_installs_into_venv(monkeypatch) -> None:
+    # venv => prefix differs from base_prefix; no --user, no PEP-668 fight.
+    monkeypatch.setattr(pydeps.sys, "prefix", "/tmp/venv")
+    monkeypatch.setattr(pydeps.sys, "base_prefix", "/usr")
+    variants = pydeps.pip_install_variants("playwright")
+    assert len(variants) == 1
+    assert "--user" not in variants[0]
+    assert "--break-system-packages" not in variants[0]
+    assert variants[0][-1] == "playwright"
+
+
+def test_pip_variants_system_has_user_then_break_system(monkeypatch) -> None:
+    # Non-venv => --user first, then --break-system-packages for PEP-668.
+    monkeypatch.setattr(pydeps.sys, "prefix", "/usr")
+    monkeypatch.setattr(pydeps.sys, "base_prefix", "/usr")
+    variants = pydeps.pip_install_variants("requests")
+    assert len(variants) == 2
+    assert "--user" in variants[0] and "--break-system-packages" not in variants[0]
+    assert "--user" in variants[1] and "--break-system-packages" in variants[1]
+
+
+def test_ensure_is_a_noop_when_already_importable(monkeypatch) -> None:
+    installs: list[str] = []
+    monkeypatch.setattr(pydeps, "install", lambda pkg, *_: installs.append(pkg))
+    status = pydeps.ensure("json", "json")
+    assert status.ready is True
+    assert installs == []  # already importable => never shells out to pip
+
+
+def test_ensure_without_autoinstall_reports_the_missing_package(monkeypatch) -> None:
+    monkeypatch.setattr(pydeps, "importable", lambda _: False)
+    status = pydeps.ensure("requests", auto_install=False)
+    assert status.ready is False
+    assert "requests" in status.detail
+
+
+def test_ensure_install_failure_names_the_manual_command(monkeypatch) -> None:
+    monkeypatch.setattr(pydeps, "importable", lambda _: False)
+    monkeypatch.setattr(pydeps, "ensure_pip", lambda: None)
+    monkeypatch.setattr(pydeps, "pip_install_variants", lambda _: [])
+    status = pydeps.ensure("requests")
+    assert status.ready is False
+    assert "-m pip install requests" in status.detail
+
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/packages/lifecycle/tests/test_pydeps.py
+++ b/packages/lifecycle/tests/test_pydeps.py
@@ -55,6 +55,17 @@ def test_ensure_install_failure_names_the_manual_command(monkeypatch) -> None:
     assert "-m pip install requests" in status.detail
 
 
+def test_project_interpreter_prefers_the_repo_venv(tmp_path) -> None:
+    venv_python = tmp_path / ".venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.write_text("")
+    assert pydeps.project_interpreter(tmp_path) == str(venv_python)
+
+
+def test_project_interpreter_is_none_without_a_venv(tmp_path) -> None:
+    assert pydeps.project_interpreter(tmp_path) is None
+
+
 if __name__ == "__main__":
     import pytest
 

--- a/packages/lifecycle/tests/test_whitebox_runtime.py
+++ b/packages/lifecycle/tests/test_whitebox_runtime.py
@@ -1,0 +1,68 @@
+"""The white-box runner must use the project's toolchain, not Suitest's.
+
+A project's own tests import the project's own dependencies, so running them
+with Suitest's interpreter fails even when the user has everything installed.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from suitest_lifecycle import pydeps
+from suitest_lifecycle.whitebox import NodeTestAdapter, PytestAdapter, detect_adapter
+
+
+def _make_venv(root):
+    python = root / ".venv" / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    python.write_text("")
+    return python
+
+
+def test_pytest_runs_with_the_project_venv_when_present(tmp_path) -> None:
+    python = _make_venv(tmp_path)
+    (tmp_path / "pyproject.toml").write_text("")
+    adapter = detect_adapter(tmp_path)
+    assert isinstance(adapter, PytestAdapter)
+    assert adapter.command_for(tmp_path / "test_x.py")[0] == str(python)
+    assert adapter.discover(tmp_path).command[0] == str(python)
+
+
+def test_pytest_venv_is_trusted_to_carry_its_own_pytest(tmp_path, monkeypatch) -> None:
+    _make_venv(tmp_path)
+    (tmp_path / "pyproject.toml").write_text("")
+    installs: list[str] = []
+    monkeypatch.setattr(pydeps, "install", lambda pkg, *_: installs.append(pkg))
+    status = detect_adapter(tmp_path).ensure_runtime()
+    assert status.ready is True
+    assert installs == []  # never mutate the user's venv uninvited
+
+
+def test_pytest_falls_back_to_suitest_interpreter_and_provisions_pytest(
+    tmp_path, monkeypatch
+) -> None:
+    (tmp_path / "pyproject.toml").write_text("")
+    adapter = detect_adapter(tmp_path)
+    assert adapter.command_for(tmp_path / "test_x.py")[0] == sys.executable
+    monkeypatch.setattr(pydeps, "importable", lambda _: False)
+    asked: list[str] = []
+    monkeypatch.setattr(
+        pydeps, "install", lambda pkg, *_: asked.append(pkg) or pydeps.DepStatus(True, "installed")
+    )
+    assert adapter.ensure_runtime().ready is True
+    assert asked == ["pytest"]
+
+
+def test_node_adapter_defers_to_npm_exec(tmp_path) -> None:
+    (tmp_path / "package.json").write_text('{"devDependencies":{"vitest":"1"}}')
+    adapter = detect_adapter(tmp_path)
+    assert isinstance(adapter, NodeTestAdapter)
+    status = adapter.ensure_runtime()
+    assert status.ready is True
+    assert "npm exec" in status.detail
+
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/packages/mcp-npx/CHANGELOG.md
+++ b/packages/mcp-npx/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 * run on the Python 3.11 the package advertises — a PEP 695 `type` alias in `http_client.py` made every tool crash with `SyntaxError` on 3.11 hosts
 * provision `requests` on demand for backend runs, matching how playwright is already provisioned for frontend runs
+* run white-box pytest with the project's own interpreter, so the user's tests can import the user's dependencies
 
 ## [0.7.1](https://github.com/suiflex/suitest/compare/mcp-v0.7.0...mcp-v0.7.1) (2026-08-13)
 

--- a/packages/mcp-npx/CHANGELOG.md
+++ b/packages/mcp-npx/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.7.2](https://github.com/suiflex/suitest/compare/mcp-v0.7.1...mcp-v0.7.2) (2026-08-13)
+
+
+### Bug Fixes
+
+* run on the Python 3.11 the package advertises — a PEP 695 `type` alias in `http_client.py` made every tool crash with `SyntaxError` on 3.11 hosts
+* provision `requests` on demand for backend runs, matching how playwright is already provisioned for frontend runs
+
 ## [0.7.1](https://github.com/suiflex/suitest/compare/mcp-v0.7.0...mcp-v0.7.1) (2026-08-13)
 
 

--- a/packages/mcp-npx/VERSION
+++ b/packages/mcp-npx/VERSION
@@ -1,1 +1,1 @@
-0.7.1 # x-release-please-version
+0.7.2 # x-release-please-version

--- a/packages/mcp-npx/package.json
+++ b/packages/mcp-npx/package.json
@@ -47,6 +47,6 @@
   "scripts": {
     "sync-python": "node scripts/sync-python.js",
     "prepack": "node scripts/sync-python.js",
-    "test": "node scripts/sync-python.js && node --test \"test/*.test.js\""
+    "test": "node scripts/sync-python.js && node --test"
   }
 }

--- a/packages/mcp-npx/package.json
+++ b/packages/mcp-npx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suiflex/suitest-mcp",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/suitest-npx/CHANGELOG.md
+++ b/packages/suitest-npx/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.6.7](https://github.com/suiflex/suitest/compare/launcher-v0.6.6...launcher-v0.6.7) (2026-08-13)
+
+
+### Bug Fixes
+
+* onboard with `@suiflex/suitest-mcp@0.7.2`, which runs on Python 3.11 and installs the backend test dependency itself
+
 ## [0.6.6](https://github.com/suiflex/suitest/compare/launcher-v0.6.5...launcher-v0.6.6) (2026-08-13)
 
 

--- a/packages/suitest-npx/package.json
+++ b/packages/suitest-npx/package.json
@@ -25,6 +25,6 @@
   "scripts": {
     "sync-assets": "node scripts/sync-assets.js",
     "prepack": "node scripts/sync-assets.js",
-    "test": "node --test \"test/*.test.js\""
+    "test": "node --test"
   }
 }

--- a/packages/suitest-npx/package.json
+++ b/packages/suitest-npx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suiflex/suitest",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Suitest local bundle — one command runs the full local stack (dashboard + SQLite + MCP).",
   "license": "Apache-2.0",
   "repository": {
@@ -20,7 +20,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@suiflex/suitest-mcp": "^0.7.1"
+    "@suiflex/suitest-mcp": "^0.7.2"
   },
   "scripts": {
     "sync-assets": "node scripts/sync-assets.js",

--- a/uv.lock
+++ b/uv.lock
@@ -2648,7 +2648,7 @@ wheels = [
 
 [[package]]
 name = "suiflex-suitest-lifecycle"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "packages/lifecycle" }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Found by running the published 0.7.1 against a host with Python 3.11.6.

## Every tool crashed on Python 3.11

```
File "./suitest_lifecycle/http_client.py", line 23
SyntaxError: invalid syntax
```

`type JSONDict = dict[str, Any]` is a PEP 695 alias — 3.12 syntax. The package advertises 3.11 in four places (`pyproject requires-python`, `lib/python.js MIN_PY`, `bin/suitest-mcp.js`, `lib/install.js`), and `findPython()` prefers a system 3.11 over the uv-provisioned 3.12, so any host with 3.11 on PATH got a hard crash.

It was **the only file of 52** that failed to parse:

```
$ python3.11 -m compileall packages/mcp-npx/python
*** Error compiling './suitest_lifecycle/http_client.py'...
```

Root cause of the escape: CI (`ci.yml:351`) and the release workflow (`release-mcp.yml:44,128`) both pin 3.12, so the package was never once compiled against its own minimum. `packages/lifecycle` now carries a `[tool.ruff] target-version = "py311"` override, which makes it a lint failure instead — verified by reintroducing the alias:

```
invalid-syntax: Cannot use `type` alias statement on Python 3.11
```

## Backend tests needed a dependency nobody installed

Generated backend tests `import requests` (`exporters/backend.py:126`), but `runner.py` never installs anything, so on a clean interpreter every backend test died with `ModuleNotFoundError`.

Frontend runs already solve exactly this: `frontend_runtime.py` auto-installs playwright *and* Chromium, on the stated principle that the user runs their app and never `pip install`. Backend was simply missing its half. The pip machinery (venv vs `--user`, PEP-668 fallback, user-site rebinding) moves to `pydeps` unchanged, `frontend_runtime` delegates to it, and the orchestrator's step 3 now ensures `requests` for non-frontend runs the same way it ensures the browser for frontend ones.

Proven on a clean 3.11 venv:

```
before: requests importable = False
ensure -> True | requests installed on demand
after : requests importable = True
```

## Verification

- all 53 lifecycle sources parse under python3.11 (was 52/53)
- `pytest packages/lifecycle/tests` green; the two pip-argv tests moved to `test_pydeps.py` with the code they cover, plus new cases for the no-op and failure paths
- mcp `npm test` 76 pass, launcher `npm test` 40 pass
- `ruff check apps packages` clean, `mypy` clean on the three changed modules

Releases lifecycle 0.1.8, mcp 0.7.2, launcher 0.6.7. Tags `mcp-v0.7.2` then `launcher-v0.6.7` after merge, in that order.