### PR TITLE
feat: publish the launcher and MCP server to Homebrew and Scoop

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Default owner for everything in the repo.
 # Ordered by specificity: later matches win, so add narrower rules below.
-* @suiflex
+* @suiflex/maintener

--- a/.github/workflows/release-launcher.yml
+++ b/.github/workflows/release-launcher.yml
@@ -15,7 +15,10 @@ on:
   pull_request:
     paths:
       - "packages/suitest-npx/**"
+      - "packaging/suitest.*.tmpl"
       - "scripts/build-bundle-assets.sh"
+      - "scripts/build-dist-bundle.sh"
+      - "scripts/publish-installers.sh"
       - ".github/workflows/release-launcher.yml"
   workflow_dispatch:
     inputs:
@@ -63,6 +66,12 @@ jobs:
           npm pack --dry-run
           npm publish --dry-run --access public
 
+      - name: Validate the brew/scoop bundle and its rendered installers
+        run: |
+          ./scripts/build-dist-bundle.sh packages/suitest-npx suitest-launcher
+          DRY_RUN=1 ./scripts/publish-installers.sh suitest suitest-launcher \
+            https://example.invalid/dl
+
   publish-npm:
     name: "@suiflex/suitest → npm"
     if: github.event_name == 'push'
@@ -108,6 +117,48 @@ jobs:
             gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes
         env:
           GH_TOKEN: ${{ github.token }}
+
+  publish-installers:
+    name: "suitest → homebrew-tap + scoop-bucket"
+    if: github.event_name == 'push'
+    # After the npm publish: the bundle vendors @suiflex/suitest-mcp from the
+    # registry, and a formula must never point at a version npm rejected.
+    needs: [publish-npm]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # gh release upload
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.5.2
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - name: Install web deps
+        run: pnpm install --frozen-lockfile
+      - name: Build bundle assets (web dist + wheels)
+        run: ./scripts/build-bundle-assets.sh
+      - name: Build the self-contained bundle tarball
+        run: ./scripts/build-dist-bundle.sh packages/suitest-npx suitest-launcher
+      - name: Attach the bundle to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "$GITHUB_REF_NAME" \
+            dist/suitest-launcher-*.tar.gz dist/suitest-launcher-*.tar.gz.sha256 \
+            --clobber
+      - name: Render and push the formula and the manifest
+        env:
+          GH_TOKEN: ${{ secrets.TAP_PUBLISH_TOKEN }}
+        run: |
+          ./scripts/publish-installers.sh suitest suitest-launcher \
+            "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}"
 
   recover-npm:
     name: "Recover @suiflex/suitest npm publish"

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -14,6 +14,9 @@ on:
     paths:
       - "packages/mcp-npx/**"
       - "packages/lifecycle/**"
+      - "packaging/suitest-mcp.*.tmpl"
+      - "scripts/build-dist-bundle.sh"
+      - "scripts/publish-installers.sh"
       - ".github/workflows/release-mcp.yml"
   workflow_dispatch:
     inputs:
@@ -51,6 +54,13 @@ jobs:
           npm pack --dry-run
           npm publish --dry-run --access public
 
+      - name: Validate the brew/scoop bundle and its rendered installers
+        working-directory: ${{ github.workspace }}
+        run: |
+          ./scripts/build-dist-bundle.sh packages/mcp-npx suitest-mcp
+          DRY_RUN=1 ./scripts/publish-installers.sh suitest-mcp suitest-mcp \
+            https://example.invalid/dl
+
   publish-npm:
     name: "@suiflex/suitest-mcp → npm"
     if: github.event_name == 'push'
@@ -81,6 +91,39 @@ jobs:
             echo "tag $GITHUB_REF_NAME != package.json $PKG_VERSION" >&2; exit 1; }
       - name: Publish to npm
         run: npm publish --access public
+
+  publish-installers:
+    name: "suitest-mcp → homebrew-tap + scoop-bucket"
+    if: github.event_name == 'push'
+    # After the npm publish, so a formula never points at a version npm rejected.
+    needs: [publish-npm]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the release and upload the bundle to it
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Build the self-contained bundle tarball
+        run: ./scripts/build-dist-bundle.sh packages/mcp-npx suitest-mcp
+      - name: Attach the bundle to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1 || \
+            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes
+          gh release upload "$GITHUB_REF_NAME" \
+            dist/suitest-mcp-*.tar.gz dist/suitest-mcp-*.tar.gz.sha256 --clobber
+      - name: Render and push the formula and the manifest
+        env:
+          GH_TOKEN: ${{ secrets.TAP_PUBLISH_TOKEN }}
+        run: |
+          ./scripts/publish-installers.sh suitest-mcp suitest-mcp \
+            "https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}"
 
   recover-npm:
     name: "Recover @suiflex/suitest-mcp npm publish"

--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ Requirements: **Node ≥ 18** and [uv](https://docs.astral.sh/uv/).
 npx @suiflex/suitest onboard
 ```
 
+Or install it on PATH — Homebrew (macOS/Linux) and Scoop (Windows) both pull node and uv in for you:
+
+```bash
+brew install suiflex/tap/suitest && suitest onboard
+```
+
+```powershell
+scoop bucket add suiflex https://github.com/suiflex/scoop-bucket
+scoop install suitest; suitest onboard
+```
+
 Boots the full platform locally — web dashboard + API on SQLite + run supervisor (port 4000, falls back to 4001–4009, binds `127.0.0.1`) — and wires your IDE's MCP config in the same step. No Docker, no Postgres, no LLM key (generation uses MCP sampling through your IDE agent). Data lives in `./.suitest/`; the dashboard and Suitest wheels ship inside the npm package (~3 MB). `suitest up` / `suitest down` manage the stack; `suitest settings` generates/refreshes the API key from the terminal (no browser); `--port`, `--ide`, `--base-url` override defaults. Details: [packages/suitest-npx](./packages/suitest-npx/README.md).
 
 ### 2. MCP server only (no install required)
@@ -86,6 +97,17 @@ Python-native route (same server, via [uv](https://docs.astral.sh/uv/)):
 
 ```bash
 uvx --from suiflex-suitest-lifecycle suitest-mcp
+```
+
+Or on PATH, as `suitest-mcp`:
+
+```bash
+brew install suiflex/tap/suitest-mcp
+```
+
+```powershell
+scoop bucket add suiflex https://github.com/suiflex/scoop-bucket
+scoop install suitest-mcp
 ```
 
 Wire it into Claude Code / Cursor (`.mcp.json`):

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -494,6 +494,26 @@ The drill is **mandatory quarterly** for production.
 | 6 | Verify `/capabilities` for a tier mismatch (in case a provider was swapped unintentionally) |
 | 7 | Rollback: `helm rollback suitest <revision>` — downgrade-safe migrations only |
 
+### 4.3b Desktop install channels (Homebrew / Scoop)
+
+`brew install suiflex/tap/suitest` and `scoop install suitest` (plus the
+`suitest-mcp` variants) are published automatically from this repo:
+
+| Stage | Where |
+|------|------|
+| 1 | Tag `launcher-v*` / `mcp-v*` → npm publish (OIDC) |
+| 2 | `scripts/build-dist-bundle.sh` builds a self-contained tarball (vendored `node_modules`, `.cmd` shim) and its `.sha256` |
+| 3 | Tarball attached to the GitHub Release for that tag |
+| 4 | `scripts/publish-installers.sh` renders `packaging/*.tmpl` and pushes to `suiflex/homebrew-tap` and `suiflex/scoop-bucket` |
+
+Both formulas declare `node` + `uv` as dependencies; the tarball vendors only
+JavaScript, and the Python runtime is still provisioned by `uv` on first run.
+
+Edit `packaging/*.tmpl`, never the published tap/bucket files — the next release
+overwrites them. The only secret involved is `TAP_PUBLISH_TOKEN` (write access
+to both distribution repos); everything else uses the run's `GITHUB_TOKEN` or
+OIDC.
+
 ### 4.4 Resource sizing guidance
 
 | Profile | Active user | Concurrent runs | Postgres | Redis | Runner replicas | API replicas |

--- a/packaging/suitest-mcp.json.tmpl
+++ b/packaging/suitest-mcp.json.tmpl
@@ -1,0 +1,17 @@
+{
+  "version": "@VERSION@",
+  "description": "Suitest MCP server for IDE agents - generate, run, and publish QA tests",
+  "homepage": "https://github.com/suiflex/suitest",
+  "license": "Apache-2.0",
+  "depends": ["main/nodejs", "main/uv"],
+  "url": "@BASE@/suitest-mcp-@VERSION@.tar.gz",
+  "hash": "@SHA@",
+  "bin": "bin\\suitest-mcp.cmd",
+  "checkver": {
+    "github": "https://github.com/suiflex/suitest",
+    "regex": "mcp-v([\\d.]+)"
+  },
+  "autoupdate": {
+    "url": "https://github.com/suiflex/suitest/releases/download/mcp-v$version/suitest-mcp-$version.tar.gz"
+  }
+}

--- a/packaging/suitest-mcp.rb.tmpl
+++ b/packaging/suitest-mcp.rb.tmpl
@@ -1,0 +1,30 @@
+# Rendered by .github/workflows/release-mcp.yml into suiflex/homebrew-tap.
+# Placeholders (@VERSION@, @BASE@, @SHA@) are filled in via sed on each release.
+# Edit the template, not the generated file.
+class SuitestMcp < Formula
+  desc "Suitest MCP server for IDE agents - generate, run, and publish QA tests"
+  homepage "https://github.com/suiflex/suitest"
+  url "@BASE@/suitest-mcp-@VERSION@.tar.gz"
+  sha256 "@SHA@"
+  license "Apache-2.0"
+
+  depends_on "node"
+  # lib/python.js takes a system python3 when there is one and otherwise
+  # provisions an interpreter through uv; keep uv available either way.
+  depends_on "uv"
+
+  def install
+    libexec.install Dir["*"]
+    # A wrapper rather than a symlink to bin/suitest-mcp.js: the shebang would
+    # resolve node off the caller's PATH, which may not have one.
+    (bin/"suitest-mcp").write <<~SH
+      #!/bin/bash
+      exec "#{Formula["node"].opt_bin}/node" "#{libexec}/bin/suitest-mcp.js" "$@"
+    SH
+  end
+
+  test do
+    # `mcp` needs a reachable API and credentials; --help stays hermetic.
+    assert_match "suitest-mcp", shell_output("#{bin}/suitest-mcp --help")
+  end
+end

--- a/packaging/suitest.json.tmpl
+++ b/packaging/suitest.json.tmpl
@@ -1,0 +1,17 @@
+{
+  "version": "@VERSION@",
+  "description": "Suitest local bundle - dashboard, SQLite, and MCP in one command",
+  "homepage": "https://github.com/suiflex/suitest",
+  "license": "Apache-2.0",
+  "depends": ["main/nodejs", "main/uv"],
+  "url": "@BASE@/suitest-launcher-@VERSION@.tar.gz",
+  "hash": "@SHA@",
+  "bin": "bin\\suitest.cmd",
+  "checkver": {
+    "github": "https://github.com/suiflex/suitest",
+    "regex": "launcher-v([\\d.]+)"
+  },
+  "autoupdate": {
+    "url": "https://github.com/suiflex/suitest/releases/download/launcher-v$version/suitest-launcher-$version.tar.gz"
+  }
+}

--- a/packaging/suitest.rb.tmpl
+++ b/packaging/suitest.rb.tmpl
@@ -1,0 +1,29 @@
+# Rendered by .github/workflows/release-launcher.yml into suiflex/homebrew-tap.
+# Placeholders (@VERSION@, @BASE@, @SHA@) are filled in via sed on each release.
+# Edit the template, not the generated file.
+class Suitest < Formula
+  desc "Suitest local bundle - dashboard, SQLite, and MCP in one command"
+  homepage "https://github.com/suiflex/suitest"
+  url "@BASE@/suitest-launcher-@VERSION@.tar.gz"
+  sha256 "@SHA@"
+  license "Apache-2.0"
+
+  depends_on "node"
+  # lib/venv.js refuses to boot without uv: it provisions the Python 3.12
+  # runtime and installs the bundled wheels into a managed venv.
+  depends_on "uv"
+
+  def install
+    libexec.install Dir["*"]
+    # A wrapper rather than a symlink to bin/suitest.js: the shebang would
+    # resolve node off the caller's PATH, which may not have one.
+    (bin/"suitest").write <<~SH
+      #!/bin/bash
+      exec "#{Formula["node"].opt_bin}/node" "#{libexec}/bin/suitest.js" "$@"
+    SH
+  end
+
+  test do
+    assert_match "Usage: suitest", shell_output("#{bin}/suitest --help")
+  end
+end

--- a/scripts/build-dist-bundle.sh
+++ b/scripts/build-dist-bundle.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Produce a self-contained tarball of an npm package for the Homebrew tap and the
+# Scoop bucket:
+#   dist/<bundle-name>-<version>.tar.gz
+#   dist/<bundle-name>-<version>.tar.gz.sha256
+#
+# Both installers extract the archive and shim its bin/ entry, so the tarball has
+# to carry its runtime dependencies: `npm pack` alone would leave
+# @suiflex/suitest without @suiflex/suitest-mcp. Node stays an external
+# dependency (declared by the formula/manifest); only JavaScript is vendored.
+#
+# Usage: scripts/build-dist-bundle.sh <package-dir> <bundle-name>
+#   e.g. scripts/build-dist-bundle.sh packages/suitest-npx suitest-launcher
+set -euo pipefail
+
+[ $# -eq 2 ] || { echo "usage: $0 <package-dir> <bundle-name>" >&2; exit 2; }
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PKG_DIR="$(cd "$1" && pwd)"
+BUNDLE="$2"
+DIST="$ROOT/dist"
+
+VERSION="$(node -p "require('$PKG_DIR/package.json').version")"
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+# `npm pack` runs prepack, so the assets/wheels/python sync scripts stay the
+# single source of truth for what ships.
+# The tarball name is read off disk rather than from stdout: prepack writes its
+# own progress there.
+(cd "$PKG_DIR" && npm pack --silent --pack-destination "$STAGE" >/dev/null)
+tar -xzf "$STAGE"/*.tgz -C "$STAGE"
+SRC="$STAGE/package"
+
+npm install --omit=dev --ignore-scripts --no-audit --no-fund --prefix "$SRC"
+rm -f "$SRC/package-lock.json"
+
+# Scoop shims the path in the manifest's "bin" verbatim, and a bare .js is not
+# executable on Windows — ship a .cmd next to each entry point.
+node -e '
+const fs = require("fs");
+const path = require("path");
+const dir = process.argv[1];
+const bin = require(path.join(dir, "package.json")).bin || {};
+for (const [name, rel] of Object.entries(bin)) {
+  const cmd = path.join(dir, path.dirname(rel), name + ".cmd");
+  fs.writeFileSync(cmd, "@node \"%~dp0" + path.basename(rel) + "\" %*\r\n");
+  fs.chmodSync(path.join(dir, rel), 0o755);
+}
+' "$SRC"
+
+mkdir -p "$DIST"
+ASSET="$BUNDLE-$VERSION.tar.gz"
+tar -czf "$DIST/$ASSET" -C "$SRC" .
+
+# `<digest>  <name>`, so consumers read the digest with `cut -d' ' -f1`.
+(cd "$DIST" && { shasum -a 256 "$ASSET" 2>/dev/null || sha256sum "$ASSET"; } > "$ASSET.sha256")
+
+echo "$DIST/$ASSET"

--- a/scripts/publish-installers.sh
+++ b/scripts/publish-installers.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Render the Homebrew formula and the Scoop manifest for a released bundle and
+# push them to suiflex/homebrew-tap and suiflex/scoop-bucket.
+#
+# Usage: scripts/publish-installers.sh <name> <bundle-name> <base-url>
+#   e.g. scripts/publish-installers.sh suitest suitest-launcher \
+#          https://github.com/suiflex/suitest/releases/download/launcher-v0.6.7
+#
+# Reads dist/<bundle-name>-<version>.tar.gz.sha256 written by
+# build-dist-bundle.sh. Set DRY_RUN=1 to render and validate without cloning or
+# pushing anything -- that is what the pull-request jobs run.
+# Pushing needs GH_TOKEN with write access to both repositories.
+set -euo pipefail
+
+[ $# -eq 3 ] || { echo "usage: $0 <name> <bundle-name> <base-url>" >&2; exit 2; }
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+NAME="$1"
+BUNDLE="$2"
+BASE="$3"
+DIST="$ROOT/dist"
+
+ASSET="$(cd "$DIST" && ls "$BUNDLE"-*.tar.gz)"
+VERSION="${ASSET#"$BUNDLE"-}"
+VERSION="${VERSION%.tar.gz}"
+SHA="$(cut -d' ' -f1 < "$DIST/$ASSET.sha256")"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+render() {
+  sed -e "s|@VERSION@|$VERSION|g" -e "s|@BASE@|$BASE|g" -e "s|@SHA@|$SHA|g" \
+    "$ROOT/packaging/$1" > "$WORK/$2"
+  # A surviving placeholder means a missing input; fail rather than publish a
+  # formula that cannot install.
+  ! grep -q '@[A-Z_]*@' "$WORK/$2"
+}
+
+render "$NAME.rb.tmpl" "$NAME.rb"
+render "$NAME.json.tmpl" "$NAME.json"
+ruby -c "$WORK/$NAME.rb" > /dev/null
+jq empty "$WORK/$NAME.json"
+
+if [ "${DRY_RUN:-0}" = "1" ]; then
+  echo "rendered $NAME $VERSION (dry run, nothing pushed)"
+  exit 0
+fi
+
+push() {
+  local repo="$1" dir="$2" file="$3"
+  git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/$repo.git" "$WORK/$repo"
+  mkdir -p "$WORK/$repo/$dir"
+  cp "$WORK/$file" "$WORK/$repo/$dir/$file"
+  cd "$WORK/$repo"
+  git config user.name "github-actions[bot]"
+  git config user.email "github-actions[bot]@users.noreply.github.com"
+  git add "$dir/$file"
+  git commit -m "$NAME $VERSION" || { echo "$repo already at $VERSION"; return 0; }
+  git push
+  cd "$ROOT"
+}
+
+push suiflex/homebrew-tap Formula "$NAME.rb"
+push suiflex/scoop-bucket bucket "$NAME.json"


### PR DESCRIPTION
## Summary

- `CODEOWNERS` pointed at `@suiflex`, the organisation handle rather than a team, so GitHub could never resolve it into reviewers and no review was ever requested automatically.
- The launcher and the MCP server shipped only through npm/PyPI. `suiflex/homebrew-tap` and `suiflex/scoop-bucket` already serve `websift` and `rdb`, so the same channels are now wired up for `suitest` and `suitest-mcp`.
- Homebrew and Scoop extract an archive and shim its entry point; they do not resolve npm dependencies. Each release therefore publishes a self-contained tarball that vendors the production `node_modules`, keeping only node and uv as external dependencies.

## Changes

**Ownership**
- `.github/CODEOWNERS`: default owner is now `@suiflex/maintener`.

**Packaging**
- `scripts/build-dist-bundle.sh`: runs `npm pack` (so the existing prepack sync scripts stay the single source of truth for what ships), vendors the production tree, writes a `.cmd` shim next to every `bin` entry for Scoop, and emits `dist/<name>-<version>.tar.gz` plus its `.sha256`.
- `packaging/{suitest,suitest-mcp}.rb.tmpl`: Homebrew formulas depending on `node` and `uv`, installing into `libexec` behind an explicit wrapper rather than relying on the tarball's shebang to find a node.
- `packaging/{suitest,suitest-mcp}.json.tmpl`: Scoop manifests with `checkver`/`autoupdate` against the `launcher-v*` and `mcp-v*` tags.
- `scripts/publish-installers.sh`: renders both templates, refuses to publish if a placeholder survives, validates with `ruby -c` and `jq empty`, then pushes to the tap and the bucket. `DRY_RUN=1` stops before the clone.

**CI**
- `release-launcher.yml`: new `publish-installers` job after `publish-npm` — builds the bundle, uploads it to the release, pushes the formula and the manifest.
- `release-mcp.yml`: same job, and it now creates the GitHub Release for `mcp-v*` tags, which this workflow never did — there was nowhere to host an installer asset.
- Both PR jobs build the bundle and render the installers with `DRY_RUN=1`, so a broken template fails before a tag exists. PR path filters extended to `packaging/**` and the two new scripts.

**Docs**
- `README.md`: brew and scoop lines alongside the existing `npx` quickstarts.
- `docs/DEPLOYMENT.md` §4.3b: tag → asset → tap/bucket runbook, and a note that `TAP_PUBLISH_TOKEN` is the only secret involved.

## Test plan

- [x] `scripts/build-dist-bundle.sh` on both packages; `tar -tzf` confirms `bin/*.cmd` and `node_modules/@suiflex/suitest-mcp/` are in the launcher tarball
- [x] Both CLIs run from an extracted copy (`node bin/suitest.js --help`, `node bin/suitest-mcp.js --help`)
- [x] Both formulas rendered with the real sha256 and installed from a scratch tap: `brew install` and `brew test` pass, `suitest --help` works on PATH
- [x] `DRY_RUN=1 scripts/publish-installers.sh` for both packages: `ruby -c` and `jq empty` clean, no placeholder left
- [x] Both workflows parse as YAML
- [ ] CI green on this PR (the new bundle + dry-run steps in each `npm` job)
- [ ] After merge, tag `launcher-v*`: asset attached to the release, commit lands in `suiflex/homebrew-tap` and `suiflex/scoop-bucket`
- [ ] `brew install suiflex/tap/suitest && suitest status` on a clean machine

## Notes

- `publish-installers` runs after `publish-npm` on purpose: a formula must never point at a version npm rejected.
- The `recover-npm` dispatch jobs deliberately do not touch the tap or the bucket; tap recovery is a re-run of the workflow on the tag.
- `TAP_PUBLISH_TOKEN` needs write access to both distribution repos. That cannot be verified before the first release; a missing grant surfaces as a 403 on `git push`.
