### PR TITLE
docs: show per-package versions in the README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,15 @@
 
 <p align="center">
   <a href="https://github.com/suiflex/suitest/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/suiflex/suitest/ci.yml?branch=main&style=for-the-badge" alt="CI status"></a>
-  <a href="https://github.com/suiflex/suitest/releases"><img src="https://img.shields.io/github/v/tag/suiflex/suitest?include_prereleases&style=for-the-badge&label=release" alt="Release"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/License-Apache--2.0-4ade80.svg?style=for-the-badge" alt="Apache-2.0 License"></a>
   <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP-native-4ade80?style=for-the-badge" alt="MCP native"></a>
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@suiflex/suitest"><img src="https://img.shields.io/npm/v/%40suiflex%2Fsuitest?style=for-the-badge&label=launcher&color=4ade80" alt="@suiflex/suitest on npm"></a>
+  <a href="https://www.npmjs.com/package/@suiflex/suitest-mcp"><img src="https://img.shields.io/npm/v/%40suiflex%2Fsuitest-mcp?style=for-the-badge&label=mcp&color=4ade80" alt="@suiflex/suitest-mcp on npm"></a>
+  <a href="https://www.npmjs.com/package/@suiflex/suitest-sdk"><img src="https://img.shields.io/npm/v/%40suiflex%2Fsuitest-sdk?style=for-the-badge&label=sdk%20(ts)&color=4ade80" alt="@suiflex/suitest-sdk on npm"></a>
+  <a href="https://pypi.org/project/suiflex-suitest-sdk/"><img src="https://img.shields.io/pypi/v/suiflex-suitest-sdk?style=for-the-badge&label=sdk%20(py)&color=4ade80" alt="suiflex-suitest-sdk on PyPI"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

- The `release` badge used `github/v/tag`, which resolves to whichever component tagged last (`mcp-v0.7.2`), reading as if it were a product version.
- This repo ships several independently versioned packages, so one repo-wide tag badge can never be correct.
- Badges now point at each package's own registry, so they always show that package's latest release with no maintenance.

## Changes

- `README.md`: drop the `github/v/tag` release badge.
- `README.md`: add a second centered badge row with four registry version badges — `launcher` (`@suiflex/suitest`), `mcp` (`@suiflex/suitest-mcp`), `sdk (ts)` (`@suiflex/suitest-sdk`) on npm, and `sdk (py)` (`suiflex-suitest-sdk`) on PyPI.
- Badge colors use the existing `accent` token (`4ade80`) to match the License and MCP badges; scoped npm names are URL-encoded as shields requires.

## Test plan

- [x] `grep -c "github/v/tag" README.md` returns 0.
- [x] Each badge endpoint resolves live: `launcher` → v0.6.7, `mcp` → v0.7.2, `sdk (ts)` → v0.1.1, `sdk (py)` → v0.1.1. No version string is hardcoded in the README.
- [x] pre-commit hooks pass.
- [ ] Visual check of the rendered README on GitHub (two centered badge rows).