### PR TITLE
feat: implement slint-mcp as a bundled desktop provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,10 +246,55 @@ MCP is the primary plugin layer. See [MCP_PLUGINS.md](./docs/MCP_PLUGINS.md).
 - Never invoke an MCP server directly from an API route — always go through `packages/mcp/client`
 - Every `Step` declares `mcp_provider` (TEXT) + `target_kind` (ENUM); if empty, default routing comes from the `target_kind` mapping
 - When adding a bundled MCP, update:
-  1. `packages/mcp/suitest_mcp/bundled/` config
-  2. `packages/mcp/suitest_mcp/registry.py` default routing
-  3. `docs/MCP_PLUGINS.md` (list + caveats)
-  4. `docs/DEPLOYMENT.md` (Docker image bundling)
+  1. `packages/mcp/src/suitest_mcp/bundled/<name>.py` — implement the
+     `BundledServer` protocol and call `register_bundled_builder` at module level
+  2. `bundled/in_process_runtime.py` — add the name to `_LAZY_MODULES`, or the
+     runtime cannot find it
+  3. `packages/mcp/src/suitest_mcp/providers/builtin_specs.py` — the spec
+     (`transport=IN_PROCESS`, tool catalog). The catalog here is the contract;
+     a provider test asserts the advertised tools match it
+  4. `packages/mcp/src/suitest_mcp/routing.py` — default routing, if it should be
+     the default for a `target_kind`
+  5. `docs/MCP_PLUGINS.md` (list + caveats) and `docs/DEPLOYMENT.md` (bundling)
+
+  Nothing else. A step may name any builtin because
+  `BUNDLED_MCP_PROVIDERS` derives from `BUILTIN_SPECS` — it used to be a literal
+  list duplicated in `run_service`, the two drifted, and a real provider was
+  rejected as unregistered. Do not reintroduce a hand-maintained copy.
+
+### Desktop targets
+
+`slint-mcp` is bundled and **in-process**, unlike `computer-use-mcp` and
+`electron-mcp` which stay external stdio binaries resolved by `command_pin`.
+Slint 1.17 embeds an MCP server inside the application under test, so there is
+no binary to install: the provider owns the app process and bridges Suitest's
+`slint.*` contract onto the app's own tools. The app must be built with
+`--features slint/mcp` and run with `SLINT_EMIT_DEBUG_INFO=1`.
+
+Selector grammar is id, then accessible label, then `index` — Slint ids are
+component-scoped, so one id matches every instance of that component. Element
+resolution polls until the target appears (`timeout_s`, default 15s): a UI
+settles after the call that changed it, so a single look is a race.
+
+### Running the platform locally
+
+`make dev` assumes the docker-compose stack. Without it, two settings in `.env`
+point at hostnames that do not resolve and the failure looks unrelated:
+
+- `SUITEST_REDIS_URL=redis://redis:6379` — the runner exits on startup. Override
+  with `redis://127.0.0.1:6379/0`.
+- artifacts default to S3/MinIO — step uploads fail *after* the step passed, so
+  the run hangs in RUNNING. Set `SUITEST_ARTIFACTS_BACKEND=local` and
+  `SUITEST_ARTIFACTS_DIR=<abs path>`.
+
+Two things that will waste an afternoon otherwise:
+
+- **The runner does not hot-reload.** Restart it after touching a bundled
+  provider. A stale runner reports the *previous* error text, which reads like a
+  genuine test failure rather than a stale process.
+- **An ad-hoc run of one test case executes the whole suite** in one MCP session.
+  Cases that share external state (a working directory, a database) leak into
+  each other in suite order. Give every case its own.
 - User-provided MCP commands are **untrusted** — sandbox per [MCP_PLUGINS.md § security](./docs/MCP_PLUGINS.md):
   - Run in a container with restricted capabilities
   - No host filesystem access unless explicitly mounted

--- a/apps/api/src/suitest_api/services/run_service.py
+++ b/apps/api/src/suitest_api/services/run_service.py
@@ -30,14 +30,14 @@ from suitest_shared.schemas.responses import ArtifactOut, RunOut, SignedUrlOut
 from suitest_api.deps.scope import TenantContext
 from suitest_api.deps.tier import require_tier
 from suitest_api.services.project_scope import project_belongs_to_workspace
+from suitest_api.services.test_case_validator import BUNDLED_MCP_PROVIDERS
 
 # Bundled MCP provider names always accepted by ``create_run`` even when the
 # workspace has not registered them in ``mcp_providers``. Kept here (vs.
 # importing from suitest_mcp) so the api service doesn't pull the runner-only
 # MCP package onto its import graph.
-_BUNDLED_MCP_PROVIDERS: frozenset[str] = frozenset(
-    {"api-http-mcp", "playwright-mcp", "postgres-mcp"}
-)
+# Single source of truth — see the note on ``BUNDLED_MCP_PROVIDERS``.
+_BUNDLED_MCP_PROVIDERS = BUNDLED_MCP_PROVIDERS
 
 # Default presigned-URL lifetime in seconds.
 DEFAULT_SIGNED_URL_TTL = 900

--- a/apps/api/src/suitest_api/services/test_case_validator.py
+++ b/apps/api/src/suitest_api/services/test_case_validator.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Protocol
 
+from suitest_mcp.providers.builtin_specs import BUILTIN_SPECS
 from suitest_shared.domain.enums import Tier
 
 
@@ -37,18 +38,19 @@ class _StepLike(Protocol):
     def mcp_provider(self) -> str: ...
 
 
-# Bundled MCP providers that are always available even when the workspace
-# has no rows in ``mcp_providers``. Kept aligned with the runner's
-# :data:`suitest_api.services.run_service._BUNDLED_MCP_PROVIDERS` (the only
-# two callers — keep both lists in sync).
+# MCP providers a step may name even when the workspace has no rows in
+# ``mcp_providers``: every builtin (the registry seeds those per workspace)
+# plus the integration servers that ship outside the spec list.
+#
+# Derived, not hand-listed. This used to be a literal frozenset duplicated in
+# ``run_service``, with a comment asking both copies to be kept in sync — by
+# the time the desktop providers landed the two had already drifted apart (5
+# names here, 3 there), so a step naming a real builtin was rejected as
+# unregistered. ``run_service`` imports this now; there is one list.
+_EXTRA_MCP_PROVIDERS: frozenset[str] = frozenset({"jirac-mcp", "github-mcp-server"})
+
 BUNDLED_MCP_PROVIDERS: frozenset[str] = frozenset(
-    {
-        "api-http-mcp",
-        "playwright-mcp",
-        "postgres-mcp",
-        "jirac-mcp",
-        "github-mcp-server",
-    }
+    {spec.name for spec in BUILTIN_SPECS} | _EXTRA_MCP_PROVIDERS
 )
 
 

--- a/docs/DESKTOP_TESTING.md
+++ b/docs/DESKTOP_TESTING.md
@@ -31,15 +31,30 @@ assert text/visibility/value — exactly as browser steps drive the DOM.
 ## 2. Three backends (M14-1 .. M14-3)
 
 Desktop automation is not one problem; it is three. Suitest ships **three
-provider configs** in `builtin_specs.py`, all resolved at runtime via
-`command_pin` (binaries stay **outside the image** — see
-[DEPLOYMENT.md](./DEPLOYMENT.md)).
+provider configs** in `builtin_specs.py`. Two are external binaries resolved at
+runtime via `command_pin` (they stay **outside the image** — see
+[DEPLOYMENT.md](./DEPLOYMENT.md)); `slint-mcp` needs no binary at all.
 
 | ID | M14 item | Driver | Transport | Best for |
 |----|----------|--------|-----------|----------|
-| `computer-use-mcp` | **M14-1** | Screen pixels + OS input | stdio | Any legacy/native app; last-resort fallback |
-| `electron-mcp` | **M14-2** | Chrome DevTools Protocol inside Electron (Playwright `_electron`) | stdio | Electron apps with real DOM |
-| `slint-mcp` | **M14-3** | Slint **accessible tree** | stdio | Slint apps (Rust, cross-platform, optionally headless) |
+| `computer-use-mcp` | **M14-1** | Screen pixels + OS input | stdio, `command_pin` | Any legacy/native app; last-resort fallback |
+| `electron-mcp` | **M14-2** | Chrome DevTools Protocol inside Electron (Playwright `_electron`) | stdio, `command_pin` | Electron apps with real DOM |
+| `slint-mcp` | **M14-3** | Slint's own embedded MCP server | **bundled, in-process** | Slint apps (Rust, cross-platform, optionally headless) |
+
+> **`slint-mcp` changed shape after this document was first written.** It was
+> specified as an external `slint-mcp` binary, and no such binary was ever
+> built. Slint 1.17 made one unnecessary: the framework embeds an MCP server
+> *inside the application under test*, reachable over HTTP when the app runs
+> with `SLINT_MCP_PORT` and is built with `--features slint/mcp`. The provider
+> is therefore a **bridge** — `suitest_mcp.bundled.slint` — that owns the app
+> process and maps the `slint.*` contract below onto the app's own tools
+> (`find_elements_by_id`, `click_element`, `set_element_value`,
+> `dispatch_key_event`, `take_screenshot`, …). The contract is what keeps test
+> steps stable when Slint renames its surface.
+>
+> `SLINT_EMIT_DEBUG_INFO=1` is required: it is what keeps element ids in the
+> compiled UI. `slint.screenshot` returns an MCP image block, which the runner
+> stores as a `SCREENSHOT` artifact.
 
 ### 2.1 Routing & default
 
@@ -59,9 +74,10 @@ DEFAULT_ROUTING = {
 
 ### 2.2 Residency rule (command_pin)
 
-None of the three desktop binaries are shipped in the image. `command_pin`
-maps the logical command name (`computer-use-mcp`, `electron-mcp`,
-`slint-mcp`) to an absolute host binary supplied by the operator/CI runner, so:
+`computer-use-mcp` and `electron-mcp` are not shipped in the image (`slint-mcp`
+is bundled and needs nothing — see the note above). `command_pin` maps the
+logical command name to an absolute host binary supplied by the operator/CI
+runner, so:
 - the image stays thin and the executor host owns its binaries/versions;
 - no native GUI/Chrome/OS-API deps leak into the Suitest image;
 - `examples/slint-demo` and tests never reach into the `rdb` repo (that repo is
@@ -77,20 +93,34 @@ renderer) no display server are required.
 
 Selectors are JSON objects. Priority when resolving:
 
-1. `accessible-id` (most explicit; the Slint equivalent of `data-testid`)
-2. `accessible-label` + `accessible-role` (stable, human-friendly)
+1. `id` — the **Slint element id**, written `Component::element-id`. The
+   compiler keeps these when the app is built with `SLINT_EMIT_DEBUG_INFO=1`,
+   so an app needs no accessibility annotations to be drivable at all.
+2. `label` — the accessible label, i.e. what the user reads. Needed more often
+   than it looks: ids are *component-scoped*, so `PrimaryButton::ta` matches
+   every instance of that component on screen.
+3. `index` — last resort when neither is unique.
 
 ```jsonc
-// by accessible-id
-{ "id": "btn-submit" }
-// CSS-ish shorthand accepted by the runner for convenience
-"[id=\"btn-submit\"]"
+// by element id
+{ "id": "ConnPicker::add-ta" }
 
-// by label + role pair
-{ "label": "Submit", "role": "button" }
-// role-only for uniqueness within a container
-{ "role": "button", "container": "login-form" }
+// by what the user sees — the only way to tell two PrimaryButtons apart
+{ "label": "New Query" }
+
+// narrow an id down by label, or failing that by position
+{ "id": "PrimaryButton::ta", "label": "Connect" }
+{ "id": "CodeEditor::focus-scope", "index": 1 }
 ```
+
+Resolution **polls** until the element appears — `timeout_s`, default 15s, `0`
+to fail immediately. A UI settles after the call that changed it (a click that
+opens a pane returns before the pane has rendered), so a single look makes every
+test a race. A malformed selector still fails immediately: naming no element at
+all is an authoring mistake, not a timing one.
+
+`find_elements_by_id` searches *descendants*, so a window's own root id never
+matches; reach the root through `get_window_properties` instead.
 
 ### 3.1 Tagging in the `.slint` source
 

--- a/packages/mcp-npx/lib/python.js
+++ b/packages/mcp-npx/lib/python.js
@@ -5,15 +5,41 @@
  * and the installer's prereq check.
  *
  * Resolution order:
- *   1. $SUITEST_PYTHON, then `python3` / `python` on PATH.
+ *   1. $SUITEST_PYTHON, then `python3` / `python`, then the versioned names
+ *      (`python3.14` … `python3.11`) on PATH.
  *   2. Fallback: a `uv`-managed Python. If the client has no system Python but
  *      has `uv` (a single static binary), we provision one automatically so
  *      "test my app" works without the user installing Python by hand.
+ *
+ * Both stages have to cope with a *short* PATH. An MCP client (or any GUI-
+ * launched process) spawns us with something close to `/usr/bin:/bin`, not the
+ * user's shell PATH, which breaks the naive lookups in two ways:
+ *   - `/usr/bin/python3` is frequently an old system build (3.9 on macOS) that
+ *     shadows a current `python3.13` sitting in the same or a later directory;
+ *   - `uv` installs itself to `~/.local/bin`, which is usually absent from that
+ *     PATH, so the fallback whose whole job is "no manual Python install
+ *     needed" would report uv missing on a machine that has it.
  */
 
 const { spawnSync } = require("node:child_process");
+const os = require("node:os");
+const path = require("node:path");
 
 const MIN_PY = [3, 11];
+
+// Tried after the bare names, newest first. A bare `python3` that is too old
+// must not end the search while a usable interpreter sits next to it.
+const VERSIONED = ["python3.14", "python3.13", "python3.12", "python3.11"];
+
+// uv's own installer targets ~/.local/bin; the cargo route lands in ~/.cargo/bin.
+function uvCandidates() {
+  const home = os.homedir();
+  return [
+    "uv",
+    path.join(home, ".local", "bin", "uv"),
+    path.join(home, ".cargo", "bin", "uv"),
+  ];
+}
 
 function probeVersion(cmd, args = []) {
   const probe = spawnSync(cmd, [
@@ -30,28 +56,36 @@ function probeVersion(cmd, args = []) {
   return null;
 }
 
+// First uv that answers `--version`, or null when none is installed.
+function findUv() {
+  for (const uv of uvCandidates()) {
+    if (spawnSync(uv, ["--version"]).status === 0) return uv;
+  }
+  return null;
+}
+
 // Provision/locate a uv-managed interpreter. Returns an absolute python path or
 // null when uv is absent or the install fails (offline, etc.).
 function findUvPython() {
-  const uv = spawnSync("uv", ["--version"]);
-  if (uv.status !== 0) return null;
+  const uv = findUv();
+  if (!uv) return null;
 
   const target = `${MIN_PY[0]}.${Math.max(MIN_PY[1], 12)}`; // 3.12
   // Install is idempotent and fast when the interpreter is already present.
-  spawnSync("uv", ["python", "install", target], { stdio: "ignore" });
+  spawnSync(uv, ["python", "install", target], { stdio: "ignore" });
 
-  const found = spawnSync("uv", ["python", "find", target], { encoding: "utf8" });
+  const found = spawnSync(uv, ["python", "find", target], { encoding: "utf8" });
   if (found.status !== 0) return null;
-  const path = String(found.stdout).trim().split("\n")[0].trim();
-  if (!path) return null;
-  const version = probeVersion(path);
-  return version ? { cmd: path, version, viaUv: true } : null;
+  const python = String(found.stdout).trim().split("\n")[0].trim();
+  if (!python) return null;
+  const version = probeVersion(python);
+  return version ? { cmd: python, version, viaUv: true } : null;
 }
 
 function findPython() {
   const candidates = process.env.SUITEST_PYTHON
     ? [process.env.SUITEST_PYTHON]
-    : ["python3", "python"];
+    : ["python3", "python", ...VERSIONED];
   for (const cmd of candidates) {
     const version = probeVersion(cmd);
     if (version) return { cmd, version };
@@ -59,4 +93,4 @@ function findPython() {
   return findUvPython();
 }
 
-module.exports = { MIN_PY, findPython, findUvPython, probeVersion };
+module.exports = { MIN_PY, VERSIONED, findPython, findUv, findUvPython, probeVersion };

--- a/packages/mcp-npx/test/python-resolve.test.js
+++ b/packages/mcp-npx/test/python-resolve.test.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Interpreter resolution under a *short* PATH — the environment an MCP client
+ * spawns us with, not a login shell.
+ *
+ * Both cases here are real failures seen in the field on macOS: `/usr/bin/python3`
+ * is 3.9 and shadows a current interpreter, and `uv` lives in `~/.local/bin`
+ * which that PATH does not contain. Fake interpreters keep the test hermetic —
+ * no real Python or uv is involved.
+ */
+
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+// A stand-in interpreter that answers the `-c "import sys; print(...)"` probe
+// with `version`, and nothing else.
+function fakePython(dir, name, version) {
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, `#!/bin/sh\necho "${version}"\n`, { mode: 0o755 });
+  return p;
+}
+
+function fakeUv(dir, name, pythonPath) {
+  const p = path.join(dir, name);
+  fs.writeFileSync(
+    p,
+    [
+      "#!/bin/sh",
+      'if [ "$1" = "--version" ]; then echo "uv 0.0.0-test"; exit 0; fi',
+      `if [ "$1" = "python" ] && [ "$2" = "find" ]; then echo "${pythonPath}"; exit 0; fi`,
+      "exit 0",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  return p;
+}
+
+// python.js reads process.env/os.homedir() at call time, so each case sets the
+// environment, requires a fresh copy of the module, and restores afterwards.
+function withEnv({ pathDirs, home }, fn) {
+  const origPath = process.env.PATH;
+  const origPin = process.env.SUITEST_PYTHON;
+  const origHome = os.homedir;
+  process.env.PATH = pathDirs.join(path.delimiter);
+  delete process.env.SUITEST_PYTHON;
+  if (home) os.homedir = () => home;
+  try {
+    delete require.cache[require.resolve("../lib/python.js")];
+    return fn(require("../lib/python.js"));
+  } finally {
+    process.env.PATH = origPath;
+    if (origPin === undefined) delete process.env.SUITEST_PYTHON;
+    else process.env.SUITEST_PYTHON = origPin;
+    os.homedir = origHome;
+  }
+}
+
+function tmpdir(name) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `suitest-${name}-`));
+}
+
+test("a too-old python3 does not end the search when a versioned one is next to it", () => {
+  const dir = tmpdir("pyver");
+  fakePython(dir, "python3", "3.9"); // what /usr/bin/python3 is on macOS
+  fakePython(dir, "python3.13", "3.13");
+
+  const found = withEnv({ pathDirs: [dir] }, (py) => py.findPython());
+
+  assert.ok(found, "expected an interpreter to be found");
+  assert.strictEqual(found.version, "3.13");
+  assert.ok(
+    found.cmd.endsWith("python3.13"),
+    `expected the versioned interpreter, got ${found.cmd}`,
+  );
+});
+
+test("uv is found in its own install dir when it is not on PATH", () => {
+  const dir = tmpdir("uvhome");
+  const home = tmpdir("uvhome-home");
+  const localBin = path.join(home, ".local", "bin");
+  fs.mkdirSync(localBin, { recursive: true });
+
+  fakePython(dir, "python3", "3.9"); // only an unusable interpreter on PATH
+  const managed = fakePython(dir, "managed-python", "3.12");
+  fakeUv(localBin, "uv", managed); // uv itself is NOT on PATH
+
+  const found = withEnv({ pathDirs: [dir], home }, (py) => py.findPython());
+
+  assert.ok(found, "expected uv to provide an interpreter");
+  assert.strictEqual(found.version, "3.12");
+  assert.strictEqual(found.viaUv, true);
+});
+
+test("nothing usable anywhere still reports failure", () => {
+  const dir = tmpdir("pynone");
+  const home = tmpdir("pynone-home");
+  fakePython(dir, "python3", "3.9");
+
+  const found = withEnv({ pathDirs: [dir], home }, (py) => py.findPython());
+
+  assert.strictEqual(found, null);
+});

--- a/packages/mcp/src/suitest_mcp/bundled/in_process_runtime.py
+++ b/packages/mcp/src/suitest_mcp/bundled/in_process_runtime.py
@@ -32,10 +32,10 @@ from typing import TYPE_CHECKING, Any, Protocol
 import anyio
 from mcp.server import Server
 from mcp.shared.memory import create_client_server_memory_streams
-from mcp.types import CallToolResult, ListToolsResult, TextContent
+from mcp.types import CallToolResult, ImageContent, ListToolsResult, TextContent
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Callable
+    from collections.abc import AsyncIterator, Callable, Sequence
 
     from mcp.server.context import ServerRequestContext
     from mcp.types import CallToolRequestParams, PaginatedRequestParams, Tool
@@ -55,8 +55,15 @@ class BundledServer(Protocol):
         """Return the tool catalog advertised over ``tools/list``."""
         ...
 
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> list[TextContent]:
-        """Dispatch a tool invocation and return MCP content blocks."""
+    async def call_tool(
+        self, name: str, arguments: dict[str, Any]
+    ) -> Sequence[TextContent | ImageContent]:
+        """Dispatch a tool invocation and return MCP content blocks.
+
+        Image blocks are carried through to ``CallToolResult`` unchanged, which
+        is how a provider produces a run artifact (the client decodes them in
+        ``suitest_mcp.client``).
+        """
         ...
 
     async def aclose(self) -> None:
@@ -84,6 +91,8 @@ _LAZY_MODULES: dict[str, str] = {
     "mongo-mcp": "suitest_mcp.bundled.mongo",
     "kubernetes-mcp": "suitest_mcp.bundled.kubernetes",
     "grpc-mcp": "suitest_mcp.bundled.grpc",
+    # M14 desktop.
+    "slint-mcp": "suitest_mcp.bundled.slint",
 }
 
 
@@ -149,7 +158,7 @@ def _adapt_server(server: BundledServer, label: str) -> Server[object]:
             content = await server.call_tool(params.name, params.arguments or {})
         except Exception as exc:
             return CallToolResult(content=[TextContent(type="text", text=str(exc))], is_error=True)
-        return CallToolResult(content=content, is_error=False)
+        return CallToolResult(content=list(content), is_error=False)
 
     app: Server[object] = Server(label, on_list_tools=_list_tools, on_call_tool=_call_tool)
     return app

--- a/packages/mcp/src/suitest_mcp/bundled/slint.py
+++ b/packages/mcp/src/suitest_mcp/bundled/slint.py
@@ -60,6 +60,10 @@ PROVIDER_NAME = "slint-mcp"
 
 _DEFAULT_READY_TIMEOUT = 60.0
 _RPC_TIMEOUT = 30.0
+# How long a step waits for its target to appear. A UI settles asynchronously —
+# a click that opens a pane returns before the pane has rendered — so resolving
+# an element has to be a poll, not a single look, or every test is a race.
+_DEFAULT_WAIT_SECONDS = 15.0
 # Slint's HTTP transport only accepts localhost origins, and binding the probe
 # socket to the same interface is what makes "is it up yet" meaningful.
 _HOST = "127.0.0.1"
@@ -221,6 +225,28 @@ class SlintServer:
         ]
 
     async def _element(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Resolve the addressed element, waiting for it to appear.
+
+        ``timeout_s: 0`` opts out, for a step that means to assert absence.
+        """
+        # Validate the selector once, up front: a step that names no element at
+        # all is an authoring mistake, and waiting 15s to say so helps nobody.
+        _selector(arguments)
+        raw_timeout = arguments.get("timeout_s", _DEFAULT_WAIT_SECONDS)
+        timeout = (
+            float(raw_timeout) if isinstance(raw_timeout, (int, float)) else _DEFAULT_WAIT_SECONDS
+        )
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        while True:
+            try:
+                return await self._resolve(arguments)
+            except AssertionError:
+                if loop.time() >= deadline:
+                    raise
+                await asyncio.sleep(0.25)
+
+    async def _resolve(self, arguments: dict[str, Any]) -> dict[str, Any]:
         element_id, label, index = _selector(arguments)
 
         if label is None:
@@ -379,6 +405,12 @@ class SlintServer:
             "index": {
                 "type": "integer",
                 "description": "Which match to use when several remain. Default 0.",
+            },
+            "timeout_s": {
+                "type": "number",
+                "description": (
+                    "Seconds to wait for the element to appear. Default 15; 0 fails immediately."
+                ),
             },
         }
 

--- a/packages/mcp/src/suitest_mcp/bundled/slint.py
+++ b/packages/mcp/src/suitest_mcp/bundled/slint.py
@@ -1,0 +1,501 @@
+"""Bundled slint-mcp provider — desktop testing for Slint applications (M14).
+
+Slint 1.17 embeds an MCP server *inside the application under test*: build with
+``--features slint/mcp`` and run with ``SLINT_EMIT_DEBUG_INFO=1`` and
+``SLINT_MCP_PORT=<port>``, and the process serves MCP over Streamable HTTP on
+``127.0.0.1:<port>/mcp``. Its tools are ``find_elements_by_id``,
+``get_element_properties``, ``click_element``, ``set_element_value``,
+``dispatch_key_event``, ``take_screenshot`` and friends.
+
+So this provider is a **bridge, not a driver**. It owns the app process and
+translates Suitest's stable ``slint.*`` step contract onto whatever the running
+Slint release calls its tools. Test steps therefore survive Slint renaming its
+own surface, which is the whole reason not to point the runner at the app's
+endpoint directly.
+
+Tool surface (mirrored in :mod:`suitest_mcp.providers.builtin_specs`):
+
+* ``slint.launch``         — start the app, wait for its MCP port, handshake.
+* ``slint.click``          — click the element with the given id.
+* ``slint.set_property``   — set an element's value (text inputs, sliders, ...).
+* ``slint.get_property``   — read an element's properties.
+* ``slint.press_key``      — send a key/text event to the focused element.
+* ``slint.assert_visible`` — element exists and is not fully transparent.
+* ``slint.assert_text``    — element's label/value equals or contains a string.
+* ``slint.assert_checked`` — element's checked state matches.
+* ``slint.assert_value``   — element's value equals a string.
+* ``slint.screenshot``     — PNG of the window, returned as an MCP image block
+  so the runner stores it as a ``SCREENSHOT`` artifact.
+* ``slint.close``          — stop the app.
+
+Assertion failures raise :class:`AssertionError`; the SDK's tool-call wrapper
+turns those into ``isError=true``, which the generic client surfaces as
+:class:`McpToolFailed`.
+
+Element addressing uses Slint's own ``Component::element-id`` ids, which the
+compiler keeps when ``SLINT_EMIT_DEBUG_INFO=1`` is set — no accessibility
+annotations are needed in the application. Note that ``find_elements_by_id``
+searches *descendants*, so a window's own root id never matches; the root is
+reached through ``get_window_properties`` instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import socket
+from typing import TYPE_CHECKING, Any, cast
+
+import httpx
+from mcp.types import ImageContent, TextContent, Tool
+
+from suitest_mcp.bundled.in_process_runtime import BundledServer, register_bundled_builder
+
+if TYPE_CHECKING:
+    from suitest_mcp.models import McpProviderConfig
+
+PROVIDER_NAME = "slint-mcp"
+
+_DEFAULT_READY_TIMEOUT = 60.0
+_RPC_TIMEOUT = 30.0
+# Slint's HTTP transport only accepts localhost origins, and binding the probe
+# socket to the same interface is what makes "is it up yet" meaningful.
+_HOST = "127.0.0.1"
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((_HOST, 0))
+        return cast("int", sock.getsockname()[1])
+
+
+def _selector(arguments: dict[str, Any]) -> str:
+    """The element id a step addressed, under any of the accepted key names."""
+    for key in ("id", "element_id", "elementId", "selector"):
+        value = arguments.get(key)
+        if isinstance(value, str) and value:
+            return value
+    raise AssertionError(
+        "no element id given — pass `id` as `Component::element-id`, e.g. `ConnPicker::add-ta`"
+    )
+
+
+class SlintServer:
+    """``BundledServer`` implementation for the bundled slint-mcp provider.
+
+    One instance owns at most one application process for the lifetime of the
+    session. ``slint.launch`` starts it, every other tool talks to it, and both
+    ``slint.close`` and session teardown stop it — a failed run must not leave a
+    window on the operator's screen or a port bound.
+    """
+
+    def __init__(self, provider: McpProviderConfig) -> None:
+        self._provider = provider
+        self._proc: asyncio.subprocess.Process | None = None
+        self._port: int | None = None
+        self._client: httpx.AsyncClient | None = None
+        self._rpc_id = 0
+        self._window: dict[str, Any] | None = None
+
+    # ---------------------------------------------------------------- plumbing
+
+    @property
+    def _url(self) -> str:
+        return f"http://{_HOST}:{self._port}/mcp"
+
+    async def _rpc(self, method: str, params: dict[str, Any] | None = None) -> Any:
+        """One JSON-RPC round trip to the app's embedded server.
+
+        The transport may answer as plain JSON or as a single SSE ``data:``
+        frame depending on negotiation, so both shapes are accepted.
+        """
+        if self._client is None or self._port is None:
+            raise AssertionError("no application running — call `slint.launch` first")
+        self._rpc_id += 1
+        response = await self._client.post(
+            self._url,
+            json={
+                "jsonrpc": "2.0",
+                "id": self._rpc_id,
+                "method": method,
+                "params": params or {},
+            },
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json, text/event-stream",
+            },
+            timeout=_RPC_TIMEOUT,
+        )
+        response.raise_for_status()
+        body = response.text
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            frame = next(
+                (line[6:] for line in body.splitlines() if line.startswith("data: ")),
+                None,
+            )
+            if frame is None:
+                raise AssertionError(f"unparseable response from the app: {body[:200]}") from None
+            payload = json.loads(frame)
+        if "error" in payload:
+            raise AssertionError(f"{method} failed: {payload['error']}")
+        return payload.get("result")
+
+    async def _call(self, tool: str, arguments: dict[str, Any]) -> list[dict[str, Any]]:
+        """Invoke a tool on the app and return its raw content blocks."""
+        result = await self._rpc("tools/call", {"name": tool, "arguments": arguments})
+        blocks = cast("list[dict[str, Any]]", (result or {}).get("content", []))
+        if (result or {}).get("isError"):
+            detail = next((b.get("text", "") for b in blocks if b.get("type") == "text"), "")
+            raise AssertionError(f"{tool} failed: {detail[:300]}")
+        # The server also reports argument errors as a plain text block.
+        for block in blocks:
+            text = block.get("text", "")
+            if block.get("type") == "text" and text.startswith("Error:"):
+                raise AssertionError(f"{tool} failed: {text[:300]}")
+        return blocks
+
+    async def _call_json(self, tool: str, arguments: dict[str, Any]) -> Any:
+        blocks = await self._call(tool, arguments)
+        for block in blocks:
+            if block.get("type") == "text":
+                try:
+                    return json.loads(block.get("text", ""))
+                except json.JSONDecodeError:
+                    return block.get("text")
+        return None
+
+    async def _window_handle(self) -> dict[str, Any]:
+        if self._window is None:
+            payload = await self._call_json("list_windows", {})
+            handles = (payload or {}).get("windowHandles") or []
+            if not handles:
+                raise AssertionError("the application reported no windows")
+            self._window = cast("dict[str, Any]", handles[0])
+        return self._window
+
+    async def _element(self, element_id: str) -> dict[str, Any]:
+        payload = await self._call_json(
+            "find_elements_by_id",
+            {"windowHandle": await self._window_handle(), "elementsId": element_id},
+        )
+        handles = (payload or {}).get("elementHandles") or []
+        if not handles:
+            raise AssertionError(
+                f"no element with id {element_id!r}. Ids are "
+                "`Component::element-id` and only exist when the app was built "
+                "with SLINT_EMIT_DEBUG_INFO=1"
+            )
+        return cast("dict[str, Any]", handles[0])
+
+    async def _properties(self, element_id: str) -> dict[str, Any]:
+        handle = await self._element(element_id)
+        payload = await self._call_json("get_element_properties", {"elementHandle": handle})
+        return cast("dict[str, Any]", payload or {})
+
+    # ------------------------------------------------------------------- tools
+
+    async def _launch(self, arguments: dict[str, Any]) -> str:
+        if self._proc is not None:
+            raise AssertionError("an application is already running in this session")
+
+        command = arguments.get("command") or self._provider.config_json.get("command")
+        if not command:
+            raise AssertionError("`command` is required — the app binary and its args")
+        if isinstance(command, str):
+            command = [command]
+        binary = shutil.which(command[0]) or command[0]
+        if not await asyncio.to_thread(os.path.exists, binary):
+            raise AssertionError(f"binary not found: {command[0]}")
+
+        port = int(arguments.get("port") or _free_port())
+        env = {
+            **os.environ,
+            **self._provider.env,
+            **(arguments.get("env") or {}),
+            # Both are what turn an ordinary Slint binary into a drivable one:
+            # the port starts the server, the debug info is what gives elements
+            # the ids this provider addresses them by.
+            "SLINT_MCP_PORT": str(port),
+            "SLINT_EMIT_DEBUG_INFO": "1",
+        }
+        self._proc = await asyncio.create_subprocess_exec(
+            binary,
+            *command[1:],
+            cwd=arguments.get("cwd") or None,
+            env=env,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        self._port = port
+        self._client = httpx.AsyncClient()
+
+        deadline = float(arguments.get("ready_timeout_s") or _DEFAULT_READY_TIMEOUT)
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        while loop.time() - started < deadline:
+            if self._proc.returncode is not None:
+                await self._stop()
+                raise AssertionError(
+                    f"the application exited with code {self._proc.returncode} "
+                    "before its MCP port opened"
+                )
+            try:
+                await self._rpc(
+                    "initialize",
+                    {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {},
+                        "clientInfo": {"name": "suitest-slint-mcp", "version": "1"},
+                    },
+                )
+                return f"application started on port {port}"
+            except Exception:  # not up yet; keep polling
+                await asyncio.sleep(0.25)
+
+        await self._stop()
+        raise AssertionError(
+            f"the application did not open its MCP port within {deadline:g}s. "
+            "Was it built with `--features slint/mcp`?"
+        )
+
+    async def _stop(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+        if self._proc is not None:
+            if self._proc.returncode is None:
+                self._proc.terminate()
+                try:
+                    await asyncio.wait_for(self._proc.wait(), timeout=5)
+                except TimeoutError:
+                    self._proc.kill()
+                    await self._proc.wait()
+            self._proc = None
+        self._port = None
+        self._window = None
+
+    @staticmethod
+    def _text_of(properties: dict[str, Any]) -> str:
+        for key in ("accessibleValue", "accessibleLabel", "accessibleDescription"):
+            value = properties.get(key)
+            if isinstance(value, str):
+                return value
+        raise AssertionError(
+            "element exposes no readable text "
+            f"(properties: {sorted(properties)}). Give it an accessible-label "
+            "or accessible-value in the .slint source."
+        )
+
+    # ---------------------------------------------------------- BundledServer
+
+    async def list_tools(self) -> list[Tool]:
+        element = {
+            "id": {
+                "type": "string",
+                "description": "Element id, `Component::element-id`.",
+            }
+        }
+
+        def tool(name: str, description: str, props: dict[str, Any], req: list[str]) -> Tool:
+            return Tool(
+                name=name,
+                description=description,
+                inputSchema={
+                    "type": "object",
+                    "properties": props,
+                    "required": req,
+                },
+            )
+
+        return [
+            tool(
+                "slint.launch",
+                "Start the Slint application and wait for its embedded MCP "
+                "server. The app must be built with `--features slint/mcp`.",
+                {
+                    "command": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Binary and arguments.",
+                    },
+                    "cwd": {"type": "string"},
+                    "env": {"type": "object"},
+                    "port": {"type": "integer", "description": "Default: free port."},
+                    "ready_timeout_s": {"type": "number"},
+                },
+                [],
+            ),
+            tool("slint.click", "Click an element.", dict(element), ["id"]),
+            tool(
+                "slint.set_property",
+                "Set an element's value.",
+                {**element, "value": {"type": "string"}},
+                ["id", "value"],
+            ),
+            tool(
+                "slint.get_property",
+                "Read an element's properties.",
+                dict(element),
+                ["id"],
+            ),
+            tool(
+                "slint.press_key",
+                "Send text or a key to the focused element. Use Slint key names "
+                "for non-printing keys, e.g. `Return`, `Tab`, `Backspace`.",
+                {"text": {"type": "string"}},
+                ["text"],
+            ),
+            tool(
+                "slint.assert_visible",
+                "Assert an element exists and is not fully transparent.",
+                dict(element),
+                ["id"],
+            ),
+            tool(
+                "slint.assert_text",
+                "Assert an element's text. `equals` by default, `contains` for a substring.",
+                {
+                    **element,
+                    "equals": {"type": "string"},
+                    "contains": {"type": "string"},
+                },
+                ["id"],
+            ),
+            tool(
+                "slint.assert_checked",
+                "Assert an element's checked state.",
+                {**element, "checked": {"type": "boolean"}},
+                ["id", "checked"],
+            ),
+            tool(
+                "slint.assert_value",
+                "Assert an element's value equals a string.",
+                {**element, "equals": {"type": "string"}},
+                ["id", "equals"],
+            ),
+            tool(
+                "slint.screenshot",
+                "PNG of the window, stored as a run artifact.",
+                {},
+                [],
+            ),
+            tool("slint.close", "Stop the application.", {}, []),
+        ]
+
+    async def call_tool(
+        self, name: str, arguments: dict[str, Any]
+    ) -> list[TextContent | ImageContent]:
+        if name == "slint.launch":
+            return [TextContent(type="text", text=await self._launch(arguments))]
+
+        if name == "slint.close":
+            await self._stop()
+            return [TextContent(type="text", text="application stopped")]
+
+        if name == "slint.screenshot":
+            blocks = await self._call(
+                "take_screenshot", {"windowHandle": await self._window_handle()}
+            )
+            # Passed through untouched: the runner turns image blocks into
+            # SCREENSHOT artifacts, which is what surfaces them in the web UI.
+            out: list[TextContent | ImageContent] = []
+            for block in blocks:
+                if block.get("type") == "image":
+                    out.append(
+                        ImageContent(
+                            type="image",
+                            data=block.get("data", ""),
+                            mimeType=block.get("mimeType", "image/png"),
+                        )
+                    )
+                elif block.get("type") == "text":
+                    out.append(TextContent(type="text", text=block.get("text", "")))
+            return out
+
+        if name == "slint.press_key":
+            text = arguments.get("text")
+            if not isinstance(text, str) or not text:
+                raise AssertionError("`text` is required")
+            await self._call(
+                "dispatch_key_event",
+                {"windowHandle": await self._window_handle(), "text": text},
+            )
+            return [TextContent(type="text", text=f"sent {text!r}")]
+
+        element_id = _selector(arguments)
+
+        if name == "slint.click":
+            await self._call("click_element", {"elementHandle": await self._element(element_id)})
+            return [TextContent(type="text", text=f"clicked {element_id}")]
+
+        if name == "slint.set_property":
+            value = arguments.get("value")
+            if not isinstance(value, str):
+                raise AssertionError("`value` is required")
+            await self._call(
+                "set_element_value",
+                {"elementHandle": await self._element(element_id), "value": value},
+            )
+            return [TextContent(type="text", text=f"set {element_id} to {value!r}")]
+
+        if name == "slint.get_property":
+            props = await self._properties(element_id)
+            return [TextContent(type="text", text=json.dumps(props, indent=2))]
+
+        if name == "slint.assert_visible":
+            props = await self._properties(element_id)
+            opacity = props.get("computedOpacity", 1.0)
+            if not isinstance(opacity, (int, float)) or opacity <= 0:
+                raise AssertionError(f"{element_id} is not visible (opacity {opacity})")
+            return [TextContent(type="text", text=f"{element_id} is visible")]
+
+        if name == "slint.assert_text":
+            actual = self._text_of(await self._properties(element_id))
+            if "contains" in arguments:
+                needle = str(arguments["contains"])
+                if needle not in actual:
+                    raise AssertionError(
+                        f"{element_id}: expected text containing {needle!r}, got {actual!r}"
+                    )
+            else:
+                expected = str(arguments.get("equals", ""))
+                if actual != expected:
+                    raise AssertionError(
+                        f"{element_id}: expected text {expected!r}, got {actual!r}"
+                    )
+            return [TextContent(type="text", text=f"{element_id} text matched")]
+
+        if name == "slint.assert_value":
+            actual = self._text_of(await self._properties(element_id))
+            expected = str(arguments.get("equals", ""))
+            if actual != expected:
+                raise AssertionError(f"{element_id}: expected value {expected!r}, got {actual!r}")
+            return [TextContent(type="text", text=f"{element_id} value matched")]
+
+        if name == "slint.assert_checked":
+            props = await self._properties(element_id)
+            if "accessibleChecked" not in props:
+                raise AssertionError(f"{element_id} exposes no checked state")
+            is_checked = bool(props["accessibleChecked"])
+            want_checked = bool(arguments.get("checked"))
+            if is_checked != want_checked:
+                raise AssertionError(
+                    f"{element_id}: expected checked={want_checked}, got {is_checked}"
+                )
+            return [TextContent(type="text", text=f"{element_id} checked matched")]
+
+        raise AssertionError(f"unknown tool: {name}")
+
+    async def aclose(self) -> None:
+        await self._stop()
+
+
+def build_slint_server(provider: McpProviderConfig) -> BundledServer:
+    return SlintServer(provider)
+
+
+register_bundled_builder(PROVIDER_NAME, build_slint_server)

--- a/packages/mcp/src/suitest_mcp/bundled/slint.py
+++ b/packages/mcp/src/suitest_mcp/bundled/slint.py
@@ -71,15 +71,38 @@ def _free_port() -> int:
         return cast("int", sock.getsockname()[1])
 
 
-def _selector(arguments: dict[str, Any]) -> str:
-    """The element id a step addressed, under any of the accepted key names."""
-    for key in ("id", "element_id", "elementId", "selector"):
-        value = arguments.get(key)
-        if isinstance(value, str) and value:
-            return value
-    raise AssertionError(
-        "no element id given — pass `id` as `Component::element-id`, e.g. `ConnPicker::add-ta`"
+def _selector(arguments: dict[str, Any]) -> tuple[str | None, str | None, int]:
+    """The element a step addressed: ``(id, label, index)``.
+
+    Follows the selector grammar in ``docs/DESKTOP_TESTING.md`` — id first,
+    then accessible label. Slint ids are component-scoped, so one id like
+    ``PrimaryButton::ta`` matches every instance of that component on screen;
+    ``label`` picks between them by what the user actually sees, and ``index``
+    is the blunt fallback when neither is unique.
+    """
+    element_id = next(
+        (
+            arguments[k]
+            for k in ("id", "element_id", "elementId", "selector")
+            if isinstance(arguments.get(k), str) and arguments[k]
+        ),
+        None,
     )
+    label = next(
+        (
+            arguments[k]
+            for k in ("label", "accessible_label", "accessibleLabel", "text")
+            if isinstance(arguments.get(k), str) and arguments[k]
+        ),
+        None,
+    )
+    if element_id is None and label is None:
+        raise AssertionError(
+            "no element given — pass `id` as `Component::element-id` "
+            "(e.g. `ConnPicker::add-ta`) and/or `label` as its visible text"
+        )
+    raw_index = arguments.get("index", 0)
+    return element_id, label, int(raw_index) if isinstance(raw_index, int) else 0
 
 
 class SlintServer:
@@ -177,22 +200,69 @@ class SlintServer:
             self._window = cast("dict[str, Any]", handles[0])
         return self._window
 
-    async def _element(self, element_id: str) -> dict[str, Any]:
+    async def _tree(self) -> list[dict[str, Any]]:
+        """Flat element list for the whole window, used for label lookups."""
+        window = await self._window_handle()
+        props = await self._call_json("get_window_properties", {"windowHandle": window})
+        root = (props or {}).get("rootElementHandle")
+        if root is None:
+            raise AssertionError("the window reported no root element")
         payload = await self._call_json(
-            "find_elements_by_id",
-            {"windowHandle": await self._window_handle(), "elementsId": element_id},
+            "get_element_tree", {"elementHandle": root, "maxElements": 10000}
         )
-        handles = (payload or {}).get("elementHandles") or []
-        if not handles:
-            raise AssertionError(
-                f"no element with id {element_id!r}. Ids are "
-                "`Component::element-id` and only exist when the app was built "
-                "with SLINT_EMIT_DEBUG_INFO=1"
-            )
-        return cast("dict[str, Any]", handles[0])
+        return cast("list[dict[str, Any]]", (payload or {}).get("elements") or [])
 
-    async def _properties(self, element_id: str) -> dict[str, Any]:
-        handle = await self._element(element_id)
+    @staticmethod
+    def _labels_of(element: dict[str, Any]) -> list[str]:
+        return [
+            v
+            for k in ("accessibleLabel", "accessibleValue", "accessibleDescription")
+            if isinstance(v := element.get(k), str) and v
+        ]
+
+    async def _element(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        element_id, label, index = _selector(arguments)
+
+        if label is None:
+            payload = await self._call_json(
+                "find_elements_by_id",
+                {"windowHandle": await self._window_handle(), "elementsId": element_id},
+            )
+            handles = (payload or {}).get("elementHandles") or []
+            if not handles:
+                raise AssertionError(
+                    f"no element with id {element_id!r}. Ids are "
+                    "`Component::element-id` and only exist when the app was built "
+                    "with SLINT_EMIT_DEBUG_INFO=1"
+                )
+            if index >= len(handles):
+                raise AssertionError(
+                    f"{element_id!r} matched {len(handles)} element(s), asked for #{index}"
+                )
+            return cast("dict[str, Any]", handles[index])
+
+        # Label lookup walks the tree, since Slint only indexes by id.
+        matches = [
+            el
+            for el in await self._tree()
+            if label in self._labels_of(el)
+            and (
+                element_id is None
+                or any(d.get("id") == element_id for d in el.get("typeNamesAndIds") or [])
+            )
+        ]
+        if not matches:
+            where = f" with id {element_id!r}" if element_id else ""
+            raise AssertionError(f"no element labelled {label!r}{where}")
+        if index >= len(matches):
+            raise AssertionError(f"{label!r} matched {len(matches)} element(s), asked for #{index}")
+        handle = matches[index].get("handle")
+        if handle is None:
+            raise AssertionError(f"element labelled {label!r} exposes no handle")
+        return cast("dict[str, Any]", handle)
+
+    async def _properties(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        handle = await self._element(arguments)
         payload = await self._call_json("get_element_properties", {"elementHandle": handle})
         return cast("dict[str, Any]", payload or {})
 
@@ -297,7 +367,19 @@ class SlintServer:
             "id": {
                 "type": "string",
                 "description": "Element id, `Component::element-id`.",
-            }
+            },
+            "label": {
+                "type": "string",
+                "description": (
+                    "Visible/accessible label. Ids are component-scoped, so one "
+                    "id matches every instance of that component — use this to "
+                    "pick between them."
+                ),
+            },
+            "index": {
+                "type": "integer",
+                "description": "Which match to use when several remain. Default 0.",
+            },
         }
 
         def tool(name: str, description: str, props: dict[str, Any], req: list[str]) -> Tool:
@@ -426,11 +508,11 @@ class SlintServer:
             )
             return [TextContent(type="text", text=f"sent {text!r}")]
 
-        element_id = _selector(arguments)
+        target = _selector(arguments)[0] or _selector(arguments)[1] or "element"
 
         if name == "slint.click":
-            await self._call("click_element", {"elementHandle": await self._element(element_id)})
-            return [TextContent(type="text", text=f"clicked {element_id}")]
+            await self._call("click_element", {"elementHandle": await self._element(arguments)})
+            return [TextContent(type="text", text=f"clicked {target}")]
 
         if name == "slint.set_property":
             value = arguments.get("value")
@@ -438,55 +520,51 @@ class SlintServer:
                 raise AssertionError("`value` is required")
             await self._call(
                 "set_element_value",
-                {"elementHandle": await self._element(element_id), "value": value},
+                {"elementHandle": await self._element(arguments), "value": value},
             )
-            return [TextContent(type="text", text=f"set {element_id} to {value!r}")]
+            return [TextContent(type="text", text=f"set {target} to {value!r}")]
 
         if name == "slint.get_property":
-            props = await self._properties(element_id)
+            props = await self._properties(arguments)
             return [TextContent(type="text", text=json.dumps(props, indent=2))]
 
         if name == "slint.assert_visible":
-            props = await self._properties(element_id)
+            props = await self._properties(arguments)
             opacity = props.get("computedOpacity", 1.0)
             if not isinstance(opacity, (int, float)) or opacity <= 0:
-                raise AssertionError(f"{element_id} is not visible (opacity {opacity})")
-            return [TextContent(type="text", text=f"{element_id} is visible")]
+                raise AssertionError(f"{target} is not visible (opacity {opacity})")
+            return [TextContent(type="text", text=f"{target} is visible")]
 
         if name == "slint.assert_text":
-            actual = self._text_of(await self._properties(element_id))
+            actual = self._text_of(await self._properties(arguments))
             if "contains" in arguments:
                 needle = str(arguments["contains"])
                 if needle not in actual:
                     raise AssertionError(
-                        f"{element_id}: expected text containing {needle!r}, got {actual!r}"
+                        f"{target}: expected text containing {needle!r}, got {actual!r}"
                     )
             else:
                 expected = str(arguments.get("equals", ""))
                 if actual != expected:
-                    raise AssertionError(
-                        f"{element_id}: expected text {expected!r}, got {actual!r}"
-                    )
-            return [TextContent(type="text", text=f"{element_id} text matched")]
+                    raise AssertionError(f"{target}: expected text {expected!r}, got {actual!r}")
+            return [TextContent(type="text", text=f"{target} text matched")]
 
         if name == "slint.assert_value":
-            actual = self._text_of(await self._properties(element_id))
+            actual = self._text_of(await self._properties(arguments))
             expected = str(arguments.get("equals", ""))
             if actual != expected:
-                raise AssertionError(f"{element_id}: expected value {expected!r}, got {actual!r}")
-            return [TextContent(type="text", text=f"{element_id} value matched")]
+                raise AssertionError(f"{target}: expected value {expected!r}, got {actual!r}")
+            return [TextContent(type="text", text=f"{target} value matched")]
 
         if name == "slint.assert_checked":
-            props = await self._properties(element_id)
+            props = await self._properties(arguments)
             if "accessibleChecked" not in props:
-                raise AssertionError(f"{element_id} exposes no checked state")
+                raise AssertionError(f"{target} exposes no checked state")
             is_checked = bool(props["accessibleChecked"])
             want_checked = bool(arguments.get("checked"))
             if is_checked != want_checked:
-                raise AssertionError(
-                    f"{element_id}: expected checked={want_checked}, got {is_checked}"
-                )
-            return [TextContent(type="text", text=f"{element_id} checked matched")]
+                raise AssertionError(f"{target}: expected checked={want_checked}, got {is_checked}")
+            return [TextContent(type="text", text=f"{target} checked matched")]
 
         raise AssertionError(f"unknown tool: {name}")
 

--- a/packages/mcp/src/suitest_mcp/providers/builtin_specs.py
+++ b/packages/mcp/src/suitest_mcp/providers/builtin_specs.py
@@ -129,11 +129,12 @@ BUILTIN_SPECS: list[McpProviderConfig] = [
         is_default_for_target={"BE_GRPC": True},
         max_sessions=4,
     ),
-    # M14 — desktop (FE_DESKTOP). All three are external stdio binaries that are
-    # NOT distributed in the runner image: each resolves its real path via
-    # registration / ``command_pin`` (e.g. ``command_pin = /opt/suitest/slint-mcp``).
-    # The ``command`` below is only a discoverability hint (a binary that must
-    # exist on PATH once installed).
+    # M14 — desktop (FE_DESKTOP). ``computer-use-mcp`` and ``electron-mcp`` are
+    # external stdio binaries that are NOT distributed in the runner image: each
+    # resolves its real path via registration / ``command_pin`` (e.g.
+    # ``command_pin = /opt/suitest/computer-use-mcp``). The ``command`` below is
+    # only a discoverability hint (a binary that must exist on PATH once
+    # installed). ``slint-mcp`` needs none of that — see its own note below.
     #
     # ``computer-use-mcp`` is the generic catch-all: OS-level screenshot+click
     # control, so it routes as the FE_DESKTOP default. ``slint-mcp`` and
@@ -187,19 +188,24 @@ BUILTIN_SPECS: list[McpProviderConfig] = [
         spawn_timeout_seconds=120.0,
         call_timeout_seconds=60.0,
     ),
+    # Bundled in-process, unlike its two neighbours: Slint 1.17 puts an MCP
+    # server *inside* the application under test, so there is no separate binary
+    # to install or pin. The provider is a bridge that owns the app process and
+    # maps these tools onto the app's own — see suitest_mcp.bundled.slint.
     McpProviderConfig(
         id="builtin:slint-mcp",
         workspace_id="_builtin_",
         name="slint-mcp",
         kind="desktop",
-        transport=McpTransport.STDIO,
-        command=["slint-mcp"],
+        transport=McpTransport.IN_PROCESS,
+        endpoint="in-process://slint",
         config_json={
             "tools": [
                 "slint.launch",
                 "slint.click",
                 "slint.set_property",
                 "slint.get_property",
+                "slint.press_key",
                 "slint.assert_visible",
                 "slint.assert_text",
                 "slint.assert_checked",

--- a/packages/mcp/tests/test_bundled_slint.py
+++ b/packages/mcp/tests/test_bundled_slint.py
@@ -1,0 +1,70 @@
+"""Bundled slint-mcp provider — contract checks that need no Slint app.
+
+Driving a real application is covered by the desktop suite; what matters here is
+that the provider is wired into the bundled registry, advertises exactly the
+catalog its builtin spec promises, and fails understandably when a step runs
+before anything was launched.
+"""
+
+from __future__ import annotations
+
+import pytest
+from suitest_mcp.bundled.in_process_runtime import get_bundled_builder
+from suitest_mcp.bundled.slint import PROVIDER_NAME, build_slint_server
+from suitest_mcp.models import McpProviderConfig, McpTransport
+from suitest_mcp.providers.builtin_specs import BUILTIN_SPECS
+
+
+def _config() -> McpProviderConfig:
+    return McpProviderConfig(
+        id="builtin:slint-mcp",
+        workspace_id="_builtin_",
+        name=PROVIDER_NAME,
+        kind="desktop",
+        transport=McpTransport.IN_PROCESS,
+        endpoint="in-process://slint",
+    )
+
+
+def test_provider_resolves_through_the_bundled_registry() -> None:
+    """The lazy-import entry is what lets the runtime find us without the
+    bundled package importing every provider eagerly."""
+    assert get_bundled_builder(PROVIDER_NAME) is not None
+
+
+@pytest.mark.asyncio
+async def test_tool_catalog_matches_the_builtin_spec() -> None:
+    """The advertised tools and the spec's `config_json` must not drift — the
+    spec is what routing and the docs are written against."""
+    spec = next(s for s in BUILTIN_SPECS if s.name == PROVIDER_NAME)
+    advertised = {t.name for t in await build_slint_server(_config()).list_tools()}
+    assert advertised == set(spec.config_json["tools"])
+
+
+@pytest.mark.asyncio
+async def test_tools_before_launch_say_so() -> None:
+    """A step that forgets `slint.launch` should name the missing step, not
+    fail somewhere deep in the HTTP client."""
+    server = build_slint_server(_config())
+    with pytest.raises(AssertionError, match=r"slint\.launch"):
+        await server.call_tool("slint.click", {"id": "Some::thing"})
+
+
+@pytest.mark.asyncio
+async def test_missing_element_id_is_reported_as_such() -> None:
+    server = build_slint_server(_config())
+    with pytest.raises(AssertionError, match="no element id given"):
+        await server.call_tool("slint.click", {})
+
+
+@pytest.mark.asyncio
+async def test_launch_without_a_command_is_rejected() -> None:
+    server = build_slint_server(_config())
+    with pytest.raises(AssertionError, match=r"`command` is required"):
+        await server.call_tool("slint.launch", {})
+
+
+@pytest.mark.asyncio
+async def test_aclose_is_safe_before_launch() -> None:
+    """Session teardown runs whether or not a step ever launched anything."""
+    await build_slint_server(_config()).aclose()

--- a/packages/mcp/tests/test_bundled_slint.py
+++ b/packages/mcp/tests/test_bundled_slint.py
@@ -51,10 +51,21 @@ async def test_tools_before_launch_say_so() -> None:
 
 
 @pytest.mark.asyncio
-async def test_missing_element_id_is_reported_as_such() -> None:
+async def test_missing_selector_is_reported_as_such() -> None:
     server = build_slint_server(_config())
-    with pytest.raises(AssertionError, match="no element id given"):
+    with pytest.raises(AssertionError, match="no element given"):
         await server.call_tool("slint.click", {})
+
+
+@pytest.mark.asyncio
+async def test_selector_accepts_id_label_and_index() -> None:
+    """Ids are component-scoped, so a step must be able to disambiguate by the
+    label the user sees, or failing that by position."""
+    from suitest_mcp.bundled.slint import _selector
+
+    assert _selector({"id": "A::b"}) == ("A::b", None, 0)
+    assert _selector({"label": "New Query"}) == (None, "New Query", 0)
+    assert _selector({"id": "A::b", "label": "Save", "index": 2}) == ("A::b", "Save", 2)
 
 
 @pytest.mark.asyncio

--- a/packages/mcp/tests/test_registry_routing.py
+++ b/packages/mcp/tests/test_registry_routing.py
@@ -100,21 +100,34 @@ def _desktop_config(name: str) -> McpProviderConfig:
     providers = {p.name: p for p in reg.list_for_workspace("ws-1")}
     cfg = providers[name]
     assert cfg.kind == "desktop"
-    assert cfg.transport is McpTransport.STDIO
     return cfg
 
 
-def test_desktop_provider_configs_are_desktop_stdio_residency() -> None:
-    """All three M14 providers are desktop-kind, stdio, and NOT shipped in the
-    image (they resolve via command_pin at runtime)."""
-    assert _desktop_config("computer-use-mcp").command == ["computer-use-mcp"]
-    assert _desktop_config("electron-mcp").command == ["electron-mcp"]
-    assert _desktop_config("slint-mcp").command == ["slint-mcp"]
+def test_external_desktop_providers_resolve_their_binary_at_runtime() -> None:
+    """computer-use and electron are stdio binaries NOT shipped in the image —
+    they resolve via command_pin at runtime, and `command` is only the hint."""
+    for name in ("computer-use-mcp", "electron-mcp"):
+        cfg = _desktop_config(name)
+        assert cfg.transport is McpTransport.STDIO
+        assert cfg.command == [name]
+
+
+def test_slint_provider_is_bundled_in_process() -> None:
+    """slint-mcp is the exception: Slint puts the MCP server inside the app
+    under test, so there is no external binary to install or pin."""
+    cfg = _desktop_config("slint-mcp")
+    assert cfg.transport is McpTransport.IN_PROCESS
+    assert cfg.command == []
+    assert cfg.endpoint == "in-process://slint"
 
 
 def test_desktop_provider_configs_expose_core_tools() -> None:
     """Each provider's config_json advertises its namespaced tool catalog."""
-    prefixes = {"computer-use-mcp": "desktop.", "electron-mcp": "electron.", "slint-mcp": "slint."}
+    prefixes = {
+        "computer-use-mcp": "desktop.",
+        "electron-mcp": "electron.",
+        "slint-mcp": "slint.",
+    }
     for name, prefix in prefixes.items():
         cfg = _desktop_config(name)
         tools = cfg.config_json.get("tools", [])


### PR DESCRIPTION
## Summary

- M14 registered a `slint-mcp` provider but nothing ever implemented it: the spec
  pointed at an external binary that exists in no repo and no image, so any
  FE_DESKTOP step routed to it could only fail.
- Slint 1.17 removes the need for that binary — it embeds an MCP server in the
  application under test — so the provider ships as a bundled in-process bridge.
- Verified against a real Slint app — [rdb](https://github.com/suiflex/rdb), the
  sample target `DESKTOP_TESTING.md` already names — end to end through the
  platform runner: launch, connect, drive the UI, restart, assert, screenshot,
  with the screenshot landing in the web UI as a run artifact. Driving it that
  way found two persistence bugs in that app, fixed in
  https://github.com/suiflex/rdb/pull/222.

## Changes

**The provider**
- `suitest_mcp.bundled.slint` owns the app process and maps Suitest's `slint.*`
  contract onto the app's own tools, so steps survive Slint renaming its surface.
  In-process, unlike `computer-use-mcp` and `electron-mcp`, because there is
  nothing left to install or `command_pin`.
- `slint.press_key` joins the catalog. Without a key event there is no way to
  drive an editor that owns its text buffer, which is most non-trivial apps.
- Elements resolve by id, then accessible label, then index. Slint ids are
  component-scoped, so one id matches every instance of that component — a
  button could not be reached at all without the label.
- Resolution polls until the element appears. A UI settles after the call that
  changed it, so a single look made every desktop test a race; steps that had
  worked by hand failed under the runner purely on timing.

**Platform**
- `BundledServer.call_tool` returns text **or image** blocks. Image blocks are
  what the runner turns into `SCREENSHOT` artifacts, so until now no bundled
  provider could produce one. `Sequence` keeps it covariant, so the six
  text-only providers needed no change.
- A step naming a real builtin was rejected as `MCP_PROVIDER_NOT_REGISTERED`.
  The check read a hand-written list that carried a comment asking for its copy
  in `run_service` to be kept in sync; the two had already drifted, five names
  against three. Both derive from `BUILTIN_SPECS` now.

**Launcher**
- An MCP client spawns the launcher with a short PATH. `/usr/bin/python3` is 3.9
  on macOS, and being too old it was rejected without ever trying the versioned
  names sitting beside it; `uv` was looked up on PATH only, though its own
  installer puts it in `~/.local/bin`. The fallback whose whole purpose is "no
  manual Python install needed" reported uv missing on machines that have it.

**Docs**
- `DESKTOP_TESTING.md` described the original plan, down to a selector grammar
  built on `accessible-id`. What exists resolves Slint element ids first, which
  is why an app needs no accessibility annotations to be drivable at all.
- The agent guide's "adding a bundled MCP" checklist named two files and missed
  the three that matter, and gained the local-dev settings that differ from the
  compose stack.

## Test plan

- [x] `ruff check`, `ruff format --check`, `mypy` clean across `packages/mcp/src`
- [x] `pytest packages/mcp` — 142 passed, 9 skipped
- [x] `pytest apps/api/tests/test_test_cases_adhoc_run.py apps/api/tests/test_mcp_providers.py` green
- [x] Launcher: 3 tests using stub interpreters, no real Python or uv needed.
      Confirmed they fail against the old implementation and pass against the new
- [x] End to end against `rdb`: a `FE_DESKTOP` test case routed to `slint-mcp`,
      executed by the platform runner, PASS with a SCREENSHOT artifact
      retrievable as `image/png`. `rdb` was built with `--features slint/mcp`;
      no change to that repo was needed for the provider itself
- [ ] Not covered: a graceful application quit. `slint.close` terminates the
      process, so an app's on-exit path cannot be exercised yet
