### PR TITLE
docs: release notes on the site, plus gray-box/white-box coverage and Suiflex branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,3 +345,14 @@ Apache License 2.0. See [LICENSE](./LICENSE).
 ## Acknowledgments
 
 Built on [Model Context Protocol](https://modelcontextprotocol.io) (Anthropic), [LiteLLM](https://github.com/BerriAI/litellm) (BerriAI), [LangGraph](https://langchain-ai.github.io/langgraph/) (LangChain), [`@ai-sdk/react`](https://sdk.vercel.ai/docs) + assistant-ui (Vercel), shadcn/ui, TanStack, and the FastAPI / SQLAlchemy / Pydantic ecosystems.
+
+---
+
+<p align="center">
+  <a href="https://suiflex.dev">
+    <img src="docs-site/public/assets/brand/suiflex-logo-mark.png" alt="Suiflex" width="40">
+  </a>
+</p>
+<p align="center">
+  <sub><strong>Suitest</strong> is a <a href="https://suiflex.dev">Suiflex</a> project — powered by Suiflex.</sub>
+</p>

--- a/README.md
+++ b/README.md
@@ -61,8 +61,25 @@ New install? Start at [Install](#install) below. `npx @suiflex/suitest onboard` 
 - ✅ **MCP server for IDE agents** (`npx -y @suiflex/suitest-mcp`) — analyze → generate → run → publish from Claude Code / Cursor / Codex, incl. a **blackbox DOM engine** that tests any web app from just a URL + credentials (no repo, no LLM key)
 - ✅ BYO LLM per workspace (Settings → LLM: Anthropic/OpenAI/Gemini/…, local Ollama/vLLM, or any OpenAI-compatible URL) — unlocks agent chat, PRD-driven test generation, LLM codegen
 - ✅ Local auth: super-admin bootstrap + invite-only onboarding (no OAuth required)
+- ✅ Desktop targets (`FE_DESKTOP`) — `slint-mcp` bundled in-process, plus `electron-mcp` and `computer-use-mcp` as pinned binaries ([DESKTOP_TESTING.md](./docs/DESKTOP_TESTING.md))
+- ✅ UAT sign-off export — branded PDF (cover, execution summary, per-case results with screenshot evidence, sign-off sheet) from any selection of cases
 
 See [docs/ROADMAP.md](./docs/ROADMAP.md) — the single source of truth for build status.
+
+---
+
+## Releases
+
+Suitest ships as two independently versioned packages. **Bumping one does not bump the other**, so pick the one that carries the change you want:
+
+| Package | Carries | Update with |
+|---------|---------|-------------|
+| [`@suiflex/suitest`](https://www.npmjs.com/package/@suiflex/suitest) (launcher) | The local platform: web dashboard + every Python wheel, so API, UI, and export changes (e.g. the UAT PDF) arrive here | `npx @suiflex/suitest@latest onboard` |
+| [`@suiflex/suitest-mcp`](https://www.npmjs.com/package/@suiflex/suitest-mcp) (MCP server) | The IDE tools and the lifecycle engine that generates and runs tests. Also on PyPI as [`suiflex-suitest-lifecycle`](https://pypi.org/project/suiflex-suitest-lifecycle/) | `npx -y @suiflex/suitest-mcp@latest` |
+
+The launcher rebuilds its Python venv whenever its version changes, so re-running the command above is all an upgrade takes.
+
+**Release notes:** [suitest.suiflex.dev/docs/changelog](https://suitest.suiflex.dev/docs/changelog/) — generated from [`packages/suitest-npx/CHANGELOG.md`](./packages/suitest-npx/CHANGELOG.md) and [`packages/mcp-npx/CHANGELOG.md`](./packages/mcp-npx/CHANGELOG.md), which release-please writes from conventional commits. Publishing a release is a tag (`launcher-v*` / `mcp-v*`); the docs site picks the notes up on its next build, with no page to edit by hand.
 
 ---
 
@@ -289,7 +306,9 @@ suitest/
 | [AUTONOMY.md](./docs/AUTONOMY.md) | Per-workspace autonomy dial |
 | [AI_AGENT.md](./docs/AI_AGENT.md) | Prompts + LangGraph + tool registry (spec, M3) |
 | [BLACKBOX_UI_TESTING.md](./docs/BLACKBOX_UI_TESTING.md) | Blackbox DOM engine — test any web app from a URL (Zero + MCP) |
+| [DESKTOP_TESTING.md](./docs/DESKTOP_TESTING.md) | Desktop targets — computer-use, Electron, Slint (bundled, in-process) |
 | [DEPLOYMENT.md](./docs/DEPLOYMENT.md) | Compose / Helm / air-gapped |
+| [docs-site/](./docs-site) | The public site (Astro + Starlight). `npm run dev` regenerates the release notes first |
 
 ---
 

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -11,3 +11,18 @@ npm run build    # static build → dist/
 
 Content lives in `src/content/docs/`. The API reference embeds the live
 OpenAPI schema served by the API at `/openapi.json`.
+
+## Release notes are generated
+
+`src/content/docs/docs/changelog.md` is **not** edited by hand:
+`scripts/sync-changelog.mjs` builds it from `packages/*/CHANGELOG.md` (the files
+release-please writes) plus the current version in each `package.json`. It runs
+from `predev` and `prebuild`, so a `npm run dev` or a deploy always picks up the
+newest release — shipping a release needs no docs change at all.
+
+The landing hero reads the same `package.json` versions, so it cannot advertise
+a version that was never published.
+
+```bash
+npm run sync:changelog   # regenerate on demand
+```

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -21,6 +21,10 @@ export default defineConfig({
       editLink: {
         baseUrl: "https://github.com/suiflex/suitest/edit/main/docs-site/",
       },
+      components: {
+        // Adds the "powered by Suiflex" endorsement under the stock footer.
+        Footer: "./src/components/DocsFooter.astro",
+      },
       lastUpdated: true,
       head: [
         {
@@ -55,6 +59,10 @@ export default defineConfig({
           label: "Concepts",
           items: [
             { label: "How Suitest works", link: "/docs/concepts/how-it-works/" },
+            {
+              label: "Black-box, gray-box, white-box",
+              link: "/docs/concepts/testing-approaches/",
+            },
             { label: "Projects, cases, and runs", link: "/docs/concepts/data-model/" },
             { label: "Evidence and artifacts", link: "/docs/concepts/evidence/" },
             { label: "Capability tiers", link: "/docs/reference/tiers/" },
@@ -65,6 +73,7 @@ export default defineConfig({
           items: [
             { label: "Testing from your IDE agent", link: "/docs/guides/agent-workflow/" },
             { label: "Blackbox testing from a URL", link: "/docs/guides/blackbox-testing/" },
+            { label: "White-box: run your own suite", link: "/docs/guides/whitebox-testing/" },
             { label: "The failure bundle", link: "/docs/guides/failure-context/" },
             { label: "Bring your own LLM", link: "/docs/guides/llm-setup/" },
             { label: "CI with the GitHub Action", link: "/docs/guides/ci-github-action/" },

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -88,6 +88,14 @@ export default defineConfig({
             { label: "FAQ", link: "/docs/help/faq/" },
           ],
         },
+        {
+          label: "Releases",
+          items: [
+            // Page is generated from packages/*/CHANGELOG.md by
+            // scripts/sync-changelog.mjs (predev/prebuild) — never edited by hand.
+            { label: "Release notes", link: "/docs/changelog/" },
+          ],
+        },
       ],
     }),
   ],

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "sync:changelog": "node scripts/sync-changelog.mjs",
+    "predev": "npm run sync:changelog",
     "dev": "astro dev",
+    "prebuild": "npm run sync:changelog",
     "build": "astro build",
     "preview": "astro preview"
   },
@@ -14,5 +17,6 @@
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@phosphor-icons/core": "^2.1.1",
     "astro": "^7.1.3"
-  }
+  },
+  "packageManager": "pnpm@11.5.1+sha512.93f7b57422ea7068257235b4c16eb60762eb68e1dc23723199cc739043ea9be2c4143274a399d8c6defa2b1176226d9ca1c4b63482d6200c1a8fbaa78c1d1485"
 }

--- a/docs-site/scripts/sync-changelog.mjs
+++ b/docs-site/scripts/sync-changelog.mjs
@@ -1,0 +1,83 @@
+// Build the docs-site "Release notes" page from the package CHANGELOGs.
+//
+// release-please already owns the changelogs (it writes them on every release
+// PR), so the docs must not keep a second hand-written copy — that copy is what
+// goes stale. This script is the only place the two are joined, and it runs
+// from `predev` / `prebuild`, so every dev server and every deploy regenerates
+// the page. Updating the site after a release is therefore: nothing.
+//
+// Run manually: node scripts/sync-changelog.mjs
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repo = resolve(here, "..", "..");
+const out = resolve(here, "..", "src/content/docs/docs/changelog.md");
+
+// Order = what a reader installs first. `npm` name is what the badge/link uses.
+const PACKAGES = [
+  {
+    dir: "packages/suitest-npx",
+    title: "Local bundle — `@suiflex/suitest`",
+    npm: "@suiflex/suitest",
+    tag: "launcher",
+    blurb: "The one-command local platform (`npx @suiflex/suitest onboard`). Ships the web dashboard and every Python wheel, so an API or renderer change reaches you through this package.",
+  },
+  {
+    dir: "packages/mcp-npx",
+    title: "MCP server — `@suiflex/suitest-mcp`",
+    npm: "@suiflex/suitest-mcp",
+    tag: "mcp",
+    blurb: "The MCP server your IDE agent talks to, and the lifecycle engine that generates and runs tests. Published to npm and to PyPI as `suiflex-suitest-lifecycle`.",
+  },
+];
+
+/** Drop the `# Changelog` title and demote every heading one level below ours. */
+function body(markdown) {
+  return markdown
+    .replace(/^#\s+Changelog\s*/, "")
+    .trim()
+    .replace(/^(#{2,5})\s/gm, "#$1 ");
+}
+
+const sections = PACKAGES.map((pkg) => {
+  const version = JSON.parse(
+    readFileSync(resolve(repo, pkg.dir, "package.json"), "utf8"),
+  ).version;
+  const changelog = body(readFileSync(resolve(repo, pkg.dir, "CHANGELOG.md"), "utf8"));
+  return `## ${pkg.title}
+
+Current: **${version}** · [npm](https://www.npmjs.com/package/${pkg.npm}) · [releases](https://github.com/suiflex/suitest/releases?q=${pkg.tag}-v)
+
+${pkg.blurb}
+
+${changelog}`;
+});
+
+const page = `---
+title: Release notes
+description: Every released version of the Suitest local bundle and MCP server, with the changes in each — generated from the package changelogs.
+editUrl: false
+---
+
+:::tip[Which package do I update?]
+A change to the API, the web dashboard, or the UAT export reaches you through the
+**local bundle** (\`npx @suiflex/suitest@latest onboard\`). A change to test
+generation, test execution, or the IDE tools reaches you through the **MCP
+server** (\`npx -y @suiflex/suitest-mcp@latest\`). Bumping one does not bump the
+other.
+:::
+
+${sections.join("\n\n")}
+
+---
+
+*This page is generated from \`packages/*/CHANGELOG.md\` by
+\`docs-site/scripts/sync-changelog.mjs\` on every build. Edit the changelogs (or
+let release-please write them), not this page.*
+`;
+
+writeFileSync(out, page);
+console.log(`sync-changelog: wrote ${out}`);

--- a/docs-site/src/components/DocsFooter.astro
+++ b/docs-site/src/components/DocsFooter.astro
@@ -1,0 +1,50 @@
+---
+// Starlight `Footer` override: keep the stock footer (prev/next, edit link,
+// last-updated) and append the parent-organisation endorsement, so every docs
+// page carries it — not just the landing page.
+import Default from "@astrojs/starlight/components/Footer.astro";
+---
+
+<Default><slot /></Default>
+
+<a class="suiflex-endorse" href="https://suiflex.dev" target="_blank" rel="noopener noreferrer">
+  <img src="/assets/brand/suiflex-logo-mark.png" alt="" aria-hidden="true" width="24" height="24" />
+  <span>
+    <small>powered by</small>
+    <strong>Suiflex</strong>
+  </span>
+</a>
+
+<style>
+  .suiflex-endorse {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 1.5rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid var(--sl-color-hairline);
+    width: 100%;
+    color: var(--sl-color-gray-3);
+    text-decoration: none;
+  }
+  .suiflex-endorse:hover {
+    color: var(--sl-color-white);
+  }
+  .suiflex-endorse img {
+    object-fit: contain;
+  }
+  .suiflex-endorse span {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.15;
+  }
+  .suiflex-endorse small {
+    font-size: 0.6875rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+  .suiflex-endorse strong {
+    font-size: 0.875rem;
+    font-weight: 600;
+  }
+</style>

--- a/docs-site/src/components/landing/AgentTools.astro
+++ b/docs-site/src/components/landing/AgentTools.astro
@@ -28,13 +28,17 @@ const blackboxTools = [
   "blackbox_summarize_findings",
 ];
 
+const whiteboxTools = ["whitebox_discover_tests", "whitebox_run_tests"];
+
+const toolCount = lifecycleTools.length + blackboxTools.length + whiteboxTools.length;
+
 const highlight = new Set(["run_tests", "get_failure_context", "generate_test_cases"]);
 ---
 
 <section class="section tools" id="mcp-tools">
   <div class="wrap">
     <div class="tools-head" data-reveal>
-      <h2 class="section-title">22 tools. One MCP server.</h2>
+      <h2 class="section-title">{toolCount} tools. One MCP server.</h2>
       <p class="section-sub">
         Everything the agent needs to take a test suite from first crawl to
         published report, exposed as plain MCP tools.
@@ -60,6 +64,16 @@ const highlight = new Set(["run_tests", "get_failure_context", "generate_test_ca
           {blackboxTools.map((tool) => <li>{tool}</li>)}
         </ul>
       </div>
+      <div class="tools-group tools-group-wide">
+        <h3>White-box</h3>
+        <p>
+          Run the pytest, Vitest, or Jest suite already in the repo and publish
+          it as cases, runs, and coverage.
+        </p>
+        <ul class="tools-list">
+          {whiteboxTools.map((tool) => <li>{tool}</li>)}
+        </ul>
+      </div>
     </div>
 
     <p class="tools-more" data-reveal>
@@ -81,6 +95,9 @@ const highlight = new Set(["run_tests", "get_failure_context", "generate_test_ca
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 18px;
+  }
+  .tools-group-wide {
+    grid-column: 1 / -1;
   }
   .tools-group {
     border: 1px solid var(--border);

--- a/docs-site/src/components/landing/Closing.astro
+++ b/docs-site/src/components/landing/Closing.astro
@@ -83,7 +83,10 @@ const footCols = [
         <div class="ph-badge" set:html={productHuntBadge} />
         <a class="suiflex-badge" href="https://suiflex.dev" target="_blank" rel="noopener noreferrer">
           <img src="/assets/brand/suiflex-logo-mark.png" alt="" aria-hidden="true" />
-          <span>Suiflex</span>
+          <span class="suiflex-badge-text">
+            <small>powered by</small>
+            <strong>Suiflex</strong>
+          </span>
         </a>
       </div>
 
@@ -109,7 +112,10 @@ const footCols = [
       }
     </div>
 
-    <p class="foot-copy">Copyright {year} Suitest contributors. Apache-2.0 License.</p>
+    <p class="foot-copy">
+      Suitest is a <a href="https://suiflex.dev" target="_blank" rel="noopener">Suiflex</a>
+      project. Copyright {year} Suitest contributors. Apache-2.0 License.
+    </p>
   </div>
 </footer>
 
@@ -190,6 +196,24 @@ const footCols = [
     width: 34px;
     height: 34px;
     object-fit: contain;
+  }
+  /* Endorsement lockup: "powered by" reads as the qualifier, the parent brand
+     carries the weight — so the two never look like one two-word name. */
+  .suiflex-badge-text {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.15;
+  }
+  .suiflex-badge-text small {
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-3);
+  }
+  .suiflex-badge-text strong {
+    font-size: 17px;
+    font-weight: 600;
   }
   .ph-badge {
     margin-top: 20px;

--- a/docs-site/src/components/landing/Features.astro
+++ b/docs-site/src/components/landing/Features.astro
@@ -39,10 +39,11 @@ const mcpConfig = `{
       <article class="cell" data-reveal style="--reveal-delay: 0.08s">
         <div class="cell-body">
           <span class="cell-icon"><Fragment set:html={detectiveIcon} /></span>
-          <h3>Blackbox from a URL</h3>
+          <h3>Black-box, gray-box, white-box</h3>
           <p>
-            No repo access needed. Point it at a URL plus credentials and the
-            DOM engine maps and tests the app.
+            Test a URL with no repo access, generate from your source, or run
+            the pytest, Vitest, or Jest suite you already have. One TCM, and
+            every case says which one it was.
           </p>
         </div>
       </article>

--- a/docs-site/src/components/landing/Hero.astro
+++ b/docs-site/src/components/landing/Hero.astro
@@ -1,6 +1,11 @@
 ---
 import githubIcon from "@phosphor-icons/core/assets/regular/github-logo.svg?raw";
 import arrowIcon from "@phosphor-icons/core/assets/regular/arrow-right.svg?raw";
+
+// Versions come from the packages themselves, so the landing page cannot claim
+// a release that was never published.
+import launcherPkg from "../../../../packages/suitest-npx/package.json";
+import mcpPkg from "../../../../packages/mcp-npx/package.json";
 ---
 
 <section class="hero">
@@ -29,6 +34,12 @@ import arrowIcon from "@phosphor-icons/core/assets/regular/arrow-right.svg?raw";
           GitHub
         </a>
       </div>
+      <p class="hero-versions">
+        <a href="/docs/changelog/">
+          <span>Latest: launcher <strong>{launcherPkg.version}</strong> · MCP server <strong>{mcpPkg.version}</strong> — release notes</span>
+          <Fragment set:html={arrowIcon} />
+        </a>
+      </p>
     </div>
 
     <div class="hero-term" data-reveal>
@@ -172,6 +183,28 @@ import arrowIcon from "@phosphor-icons/core/assets/regular/arrow-right.svg?raw";
     display: flex;
     gap: 14px;
     flex-wrap: wrap;
+  }
+  .hero-versions {
+    margin: 20px 0 0;
+    font-size: 14px;
+  }
+  .hero-versions a {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--text-2);
+    text-decoration: none;
+  }
+  .hero-versions a:hover {
+    color: var(--accent);
+  }
+  .hero-versions strong {
+    color: var(--text);
+    font-weight: 600;
+  }
+  .hero-versions :global(svg) {
+    width: 14px;
+    height: 14px;
   }
 
   .term {

--- a/docs-site/src/content/docs/docs/changelog.md
+++ b/docs-site/src/content/docs/docs/changelog.md
@@ -1,0 +1,280 @@
+---
+title: Release notes
+description: Every released version of the Suitest local bundle and MCP server, with the changes in each — generated from the package changelogs.
+editUrl: false
+---
+
+:::tip[Which package do I update?]
+A change to the API, the web dashboard, or the UAT export reaches you through the
+**local bundle** (`npx @suiflex/suitest@latest onboard`). A change to test
+generation, test execution, or the IDE tools reaches you through the **MCP
+server** (`npx -y @suiflex/suitest-mcp@latest`). Bumping one does not bump the
+other.
+:::
+
+## Local bundle — `@suiflex/suitest`
+
+Current: **0.6.8** · [npm](https://www.npmjs.com/package/@suiflex/suitest) · [releases](https://github.com/suiflex/suitest/releases?q=launcher-v)
+
+The one-command local platform (`npx @suiflex/suitest onboard`). Ships the web dashboard and every Python wheel, so an API or renderer change reaches you through this package.
+
+### [0.6.8](https://github.com/suiflex/suitest/compare/launcher-v0.6.7...launcher-v0.6.8) (2026-08-16)
+
+
+#### Features
+
+* ship the rebuilt API wheel, so the UAT export renders the branded four-part document (cover, execution summary, detailed results, sign-off) instead of the single navy table
+
+### [0.6.7](https://github.com/suiflex/suitest/compare/launcher-v0.6.6...launcher-v0.6.7) (2026-08-13)
+
+
+#### Bug Fixes
+
+* onboard with `@suiflex/suitest-mcp@0.7.2`, which runs on Python 3.11 and installs the backend test dependency itself
+
+### [0.6.6](https://github.com/suiflex/suitest/compare/launcher-v0.6.5...launcher-v0.6.6) (2026-08-13)
+
+
+#### Bug Fixes
+
+* sign session JWTs with a 32-byte secret generated per install, instead of the published default in `settings.py`. Existing installs are signed out once.
+* onboard with `@suiflex/suitest-mcp@0.7.1`, so publishing survives an uninstall/reinstall without hand-editing `suitest.config.json`
+
+### [0.6.5](https://github.com/suiflex/suitest/compare/launcher-v0.6.4...launcher-v0.6.5) (2026-08-13)
+
+
+#### Bug Fixes
+
+* **onboard:** export isFree from stack.js ([2da4c2f](https://github.com/suiflex/suitest/commit/2da4c2fca20acd261dd198ffe3e8b378cd11ee47))
+* **onboard:** export isFree from stack.js ([970c644](https://github.com/suiflex/suitest/commit/970c6449616d3099e25839ec237d7155ed6c824d))
+* **onboard:** reject already-in-use ports during setup ([e2ca20d](https://github.com/suiflex/suitest/commit/e2ca20d6ec7508654187fa409b1cc868011e3c72))
+
+### [0.6.4](https://github.com/suiflex/suitest/compare/launcher-v0.6.3...launcher-v0.6.4) (2026-08-13)
+
+#### Features
+
+* onboard with `@suiflex/suitest-mcp@0.7.0`, which detects more FE/BE frameworks in `init`
+
+### [0.6.3](https://github.com/suiflex/suitest/compare/launcher-v0.6.2...launcher-v0.6.3) (2026-08-12)
+
+#### Bug Fixes
+
+* publish the launcher with the released `@suiflex/suitest-mcp@0.6.1` dependency
+
+### [0.6.2](https://github.com/suiflex/suitest/compare/launcher-v0.6.1...launcher-v0.6.2) (2026-08-12)
+
+#### Bug Fixes
+
+* use the released MCP package containing the onboarding theme module
+* ship MCP onboarding and release safeguards ([32751de](https://github.com/suiflex/suitest/commit/32751deec12ae7765703ceea830f4fbb86b37ed1))
+* ship MCP onboarding theme and workspace updates ([9d48783](https://github.com/suiflex/suitest/commit/9d48783425dd01b93d1b24a92bb0ef6f09080f10))
+
+### [0.6.1](https://github.com/suiflex/suitest/compare/launcher-v0.6.0...launcher-v0.6.1) (2026-08-11)
+
+
+#### Bug Fixes
+
+* **suitest-npx:** correct license field to Apache-2.0 ([59fb3e2](https://github.com/suiflex/suitest/commit/59fb3e273cf0dc186482ffcb14dcddbc76acf011))
+* **suitest-npx:** correct license field to Apache-2.0 ([6cb0624](https://github.com/suiflex/suitest/commit/6cb062478617503b492d14c622775b21446ba179))
+
+### [0.6.0](https://github.com/suiflex/suitest/compare/launcher-v0.5.1...launcher-v0.6.0) (2026-08-06)
+
+
+#### Features
+
+* **cli:** brand suitest/suitest-mcp with a connected onboarding wizard ([1f90b29](https://github.com/suiflex/suitest/commit/1f90b299dee5a0baa094381ac8ed9765b4aee4fa))
+* **cli:** brand suitest/suitest-mcp with a connected onboarding wizard ([0e67907](https://github.com/suiflex/suitest/commit/0e67907ca62e0dfaaf8acfb1f06e71e6fe415b56))
+
+### [0.5.1](https://github.com/suiflex/suitest/compare/launcher-v0.5.0...launcher-v0.5.1) (2026-08-04)
+
+
+#### Bug Fixes
+
+* **release:** add launcher provenance metadata ([e8369d3](https://github.com/suiflex/suitest/commit/e8369d3aa59c5d16b2e73d7d382ecb516df441b7))
+* **release:** declare launcher repository metadata ([b44cf86](https://github.com/suiflex/suitest/commit/b44cf86a221f31e093654fd1b4ecd374fbfa52a7))
+
+### [0.5.0] (unreleased)
+
+Includes the post-0.4.0 launcher updates currently on `main`.
+
+### [0.4.0](https://github.com/suiflex/suitest/compare/launcher-v0.3.0...launcher-v0.4.0) (2026-07-25)
+
+
+#### Features
+
+* choosable dashboard port, dark/light toggle, fixed Connect-IDE modal ([6412b88](https://github.com/suiflex/suitest/commit/6412b88e2ef981320e994375bc12d684078501ba))
+* CLI onboard hardening — cross-OS transport, secret masking, settings TUI ([6bad9f5](https://github.com/suiflex/suitest/commit/6bad9f52f5e87a6d63bc78a8f0cb9b10cf37b909))
+* **cli:** consent-based uv preflight with auto-install for onboard ([#25](https://github.com/suiflex/suitest/issues/25)) ([c5901c3](https://github.com/suiflex/suitest/commit/c5901c395879544222bdcc8f201e0df6e6c72e00))
+* **launcher:** .suitest project layout + superadmin credentials store ([5f13861](https://github.com/suiflex/suitest/commit/5f138615babe1e476cc1c96a59b2b91d824102b2))
+* **launcher:** 0.1.1 — ship bundle assets inside the npm package ([afe38ee](https://github.com/suiflex/suitest/commit/afe38ee8d32da0437abe7503390542ba6251e6c1))
+* **launcher:** layman-proof restart, status, and upgrade flow ([128d6ad](https://github.com/suiflex/suitest/commit/128d6adadaa2822c34382863d2e529e8623365fb))
+* **launcher:** mint local API key via superadmin cookie login ([05e4947](https://github.com/suiflex/suitest/commit/05e49471c68568182e189e99ce8e5c3d8275b1c3))
+* **launcher:** onboard orchestration + command wiring (reuse suitest-mcp init) ([a0c324f](https://github.com/suiflex/suitest/commit/a0c324f7ac74680227d386d18e59a308d97a897d))
+* **launcher:** per-project venv provisioning from release wheels via uv ([c5eb866](https://github.com/suiflex/suitest/commit/c5eb866d6e50568c0a19185a1cd7e9cb3cca43e8))
+* **launcher:** require user-set admin account on onboard ([046f0a5](https://github.com/suiflex/suitest/commit/046f0a5800b1a90550818f8ded2b5c9d2207f574))
+* **launcher:** scaffold @suiflex/suitest package + CLI skeleton ([b160bff](https://github.com/suiflex/suitest/commit/b160bffdac83af29e81b04c47c4e12272e4af095))
+* **launcher:** up/down — uvicorn + local supervisor with shared sqlite env ([e16d5b4](https://github.com/suiflex/suitest/commit/e16d5b4d7e37e5a79922f7a92b606ea70a6f173a))
+* **launcher:** versioned asset fetch from GitHub Releases with local overrides ([12b7c32](https://github.com/suiflex/suitest/commit/12b7c32bb5c83eb5b74a4f2f14c1aa8121fd9b70))
+* **suitest-npx:** add settings TUI to manage API key without a browser ([64a8b29](https://github.com/suiflex/suitest/commit/64a8b29bd3852f5d8bfad317096d319127cfe6be))
+* **suitest-npx:** let settings and onboard choose the dashboard port ([5b5e9e8](https://github.com/suiflex/suitest/commit/5b5e9e8d871cd651336a2614c7518d39e507269a))
+
+
+#### Bug Fixes
+
+* **api:** serve /files from disk in local mode instead of S3 ([5ca9907](https://github.com/suiflex/suitest/commit/5ca9907af78d7815c43199b5a0e73852fb1f8a4e))
+* **api:** serve local artifacts to browser img/video via workspaceId query param ([b1aba1b](https://github.com/suiflex/suitest/commit/b1aba1b30a1805aaa70a6ca130e1a1bc4b175f08))
+* **db:** generate public IDs on SQLite in local mode ([f59a4af](https://github.com/suiflex/suitest/commit/f59a4af5d1c919b346013a7fdebf94bf844701d8))
+* **launcher:** --help/--version pre-parse + test tightening ([cdea838](https://github.com/suiflex/suitest/commit/cdea838f5795b8b507397512a46ae2617666330d))
+* **launcher:** avoid AssignProcessToJobObject error on Windows ([79659d5](https://github.com/suiflex/suitest/commit/79659d54d3655ef8dc852f17f283f1966263d107))
+* **launcher:** mint and pass SUITEST_ENCRYPTION_KEY to the local stack ([ac006c1](https://github.com/suiflex/suitest/commit/ac006c1775eea1e3d443078da6fd153a9450cd53))
+* **launcher:** re-assert 600 on credentials overwrite ([18aff6a](https://github.com/suiflex/suitest/commit/18aff6a7b41bf1175ef00be3e47c90168a04e731))
+* **launcher:** unbuffered python logs + supervisor startup line ([7a932e1](https://github.com/suiflex/suitest/commit/7a932e15b53ebc7abcd9d91f5f32182d2174ecd3))
+* **suitest-npx:** mask admin password prompts during onboard ([9953446](https://github.com/suiflex/suitest/commit/9953446df104325a7e616365adda8890e2038686))
+
+### [0.2.0](https://github.com/suiflex/suitest/compare/launcher-v0.1.8...launcher-v0.2.0) (2026-07-13)
+
+
+#### Features
+
+* choosable dashboard port, dark/light toggle, fixed Connect-IDE modal ([6412b88](https://github.com/suiflex/suitest/commit/6412b88e2ef981320e994375bc12d684078501ba))
+* CLI onboard hardening — cross-OS transport, secret masking, settings TUI ([6bad9f5](https://github.com/suiflex/suitest/commit/6bad9f52f5e87a6d63bc78a8f0cb9b10cf37b909))
+* **cli:** consent-based uv preflight with auto-install for onboard ([#25](https://github.com/suiflex/suitest/issues/25)) ([c5901c3](https://github.com/suiflex/suitest/commit/c5901c395879544222bdcc8f201e0df6e6c72e00))
+* **suitest-npx:** add settings TUI to manage API key without a browser ([64a8b29](https://github.com/suiflex/suitest/commit/64a8b29bd3852f5d8bfad317096d319127cfe6be))
+* **suitest-npx:** let settings and onboard choose the dashboard port ([5b5e9e8](https://github.com/suiflex/suitest/commit/5b5e9e8d871cd651336a2614c7518d39e507269a))
+
+
+#### Bug Fixes
+
+* **suitest-npx:** mask admin password prompts during onboard ([9953446](https://github.com/suiflex/suitest/commit/9953446df104325a7e616365adda8890e2038686))
+
+### [0.1.8](https://github.com/suiflex/suitest/compare/launcher-v0.1.7...launcher-v0.1.8) (2026-07-09)
+
+
+#### Bug Fixes
+
+* **launcher:** avoid AssignProcessToJobObject error on Windows ([79659d5](https://github.com/suiflex/suitest/commit/79659d54d3655ef8dc852f17f283f1966263d107))
+
+## MCP server — `@suiflex/suitest-mcp`
+
+Current: **0.8.0** · [npm](https://www.npmjs.com/package/@suiflex/suitest-mcp) · [releases](https://github.com/suiflex/suitest/releases?q=mcp-v)
+
+The MCP server your IDE agent talks to, and the lifecycle engine that generates and runs tests. Published to npm and to PyPI as `suiflex-suitest-lifecycle`.
+
+### [0.8.0](https://github.com/suiflex/suitest/compare/mcp-v0.7.3...mcp-v0.8.0) (2026-08-15)
+
+
+#### Features
+
+* implement slint-mcp as a bundled desktop provider ([d5645c9](https://github.com/suiflex/suitest/commit/d5645c9a0e93b289c04fe73169fb568b55e65bd1))
+
+
+#### Bug Fixes
+
+* **mcp-npx:** find Python when the launcher gets a short PATH ([b8aff17](https://github.com/suiflex/suitest/commit/b8aff174f00a7905b1f15165b456c29d6373bb75))
+
+### [0.7.3](https://github.com/suiflex/suitest/compare/mcp-v0.7.2...mcp-v0.7.3) (2026-08-15)
+
+
+#### Bug Fixes
+
+* keep per-step screenshots after a durable publish, so a later sidecar-based publish still carries evidence instead of blanking the web preview and the UAT PDF
+* refuse to publish blackbox results whose sidecar screenshots are gone, instead of silently committing an evidence-less run over every case's last run
+
+### [0.7.2](https://github.com/suiflex/suitest/compare/mcp-v0.7.1...mcp-v0.7.2) (2026-08-13)
+
+
+#### Bug Fixes
+
+* run on the Python 3.11 the package advertises — a PEP 695 `type` alias in `http_client.py` made every tool crash with `SyntaxError` on 3.11 hosts
+* provision `requests` on demand for backend runs, matching how playwright is already provisioned for frontend runs
+* run white-box pytest with the project's own interpreter, so the user's tests can import the user's dependencies
+
+### [0.7.1](https://github.com/suiflex/suitest/compare/mcp-v0.7.0...mcp-v0.7.1) (2026-08-13)
+
+
+#### Bug Fixes
+
+* publish against the workspace the API key belongs to, ignoring a stale `publish.workspaceId`
+* rebind a dead `publish.projectId` by slug when nothing ambiguous matches, instead of blocking the run
+
+### [0.7.0](https://github.com/suiflex/suitest/compare/mcp-v0.6.2...mcp-v0.7.0) (2026-08-13)
+
+
+#### Features
+
+* detect more FE/BE frameworks in `init` ([553e62c](https://github.com/suiflex/suitest/commit/553e62c))
+
+
+#### Bug Fixes
+
+* ship the terminal theme module required by `@suiflex/suitest` onboarding
+
+### [0.6.2](https://github.com/suiflex/suitest/compare/mcp-v0.6.1...mcp-v0.6.2) (2026-08-12)
+
+
+#### Bug Fixes
+
+* ship MCP onboarding and release safeguards ([32751de](https://github.com/suiflex/suitest/commit/32751deec12ae7765703ceea830f4fbb86b37ed1))
+
+### [0.6.1](https://github.com/suiflex/suitest/compare/mcp-v0.6.0...mcp-v0.6.1) (2026-08-12)
+
+
+#### Bug Fixes
+
+* ship MCP onboarding and release safeguards ([32751de](https://github.com/suiflex/suitest/commit/32751deec12ae7765703ceea830f4fbb86b37ed1))
+* ship MCP onboarding theme and workspace updates ([9d48783](https://github.com/suiflex/suitest/commit/9d48783425dd01b93d1b24a92bb0ef6f09080f10))
+
+### [0.4.0](https://github.com/suiflex/suitest/compare/mcp-v0.3.2...mcp-v0.4.0) (2026-07-19)
+
+
+#### Features
+
+* detect nuxt/sveltekit/vue and trim evidence video blank frames ([#47](https://github.com/suiflex/suitest/issues/47)) ([34cd703](https://github.com/suiflex/suitest/commit/34cd703647f2772c1c052611bb78a08a0aa67c5c))
+
+### [0.3.2](https://github.com/suiflex/suitest/compare/mcp-v0.3.1...mcp-v0.3.2) (2026-07-13)
+
+
+#### Bug Fixes
+
+* **mcp:** ship lifecycle 0.1.5 in bundled package ([#30](https://github.com/suiflex/suitest/issues/30)) ([4495606](https://github.com/suiflex/suitest/commit/4495606c67464ade8566ff169fc9584d8989ef7e))
+
+### [0.3.1](https://github.com/suiflex/suitest/compare/mcp-v0.3.0...mcp-v0.3.1) (2026-07-13)
+
+
+#### Bug Fixes
+
+* **mcp:** guard cross-client protocol compatibility ([#27](https://github.com/suiflex/suitest/issues/27)) ([cbf5190](https://github.com/suiflex/suitest/commit/cbf519068c56b6066031fe2a3847180057204791))
+
+### [0.3.0](https://github.com/suiflex/suitest/compare/mcp-v0.2.1...mcp-v0.3.0) (2026-07-10)
+
+
+#### Features
+
+* CLI onboard hardening — cross-OS transport, secret masking, settings TUI ([6bad9f5](https://github.com/suiflex/suitest/commit/6bad9f52f5e87a6d63bc78a8f0cb9b10cf37b909))
+* **mcp-npx:** mask secret input in CLI prompts ([714eb3e](https://github.com/suiflex/suitest/commit/714eb3e38c0a304b787a2eaf00a1cd71a69fca37))
+
+### [0.2.1](https://github.com/suiflex/suitest/compare/mcp-v0.2.0...mcp-v0.2.1) (2026-07-10)
+
+
+#### Bug Fixes
+
+* local-runtime + MCP client compatibility (heatmap, eval, Playwright, Codex/Copilot) ([d6a2e8e](https://github.com/suiflex/suitest/commit/d6a2e8ec7fd581018e4e8c0d185444a3ef7127dd))
+* **mcp:** auto-provision Playwright on demand for blackbox tools ([5a32d09](https://github.com/suiflex/suitest/commit/5a32d0919715e2f0344bab846dfe87028024f487))
+
+### [0.2.0](https://github.com/suiflex/suitest/compare/mcp-v0.1.5...mcp-v0.2.0) (2026-07-09)
+
+
+#### Features
+
+* **mcp:** log in before picking a client in install flow ([007bad2](https://github.com/suiflex/suitest/commit/007bad253ef01983f7d169763d98570b7bfc6b7d))
+
+
+#### Bug Fixes
+
+* **mcp:** clearer error when a delegated client CLI fails ([20c05a5](https://github.com/suiflex/suitest/commit/20c05a5ad61b57b3ccb5937213bd21e78b377439))
+
+---
+
+*This page is generated from `packages/*/CHANGELOG.md` by
+`docs-site/scripts/sync-changelog.mjs` on every build. Edit the changelogs (or
+let release-please write them), not this page.*

--- a/docs-site/src/content/docs/docs/concepts/testing-approaches.md
+++ b/docs-site/src/content/docs/docs/concepts/testing-approaches.md
@@ -1,0 +1,121 @@
+---
+title: Black-box, gray-box, white-box
+description: How Suitest separates what the tester can observe (black-box, gray-box, white-box) from test scope (unit to E2E), how the approach is resolved, and what each one changes in generation and reporting.
+---
+
+Suitest treats **what the tester can observe** and **how much of the system a
+test covers** as two separate dimensions. Mixing them is what produces the
+familiar lie of "we have repo access, so these are white-box tests" — access is
+not observation.
+
+| Dimension | Values |
+|-----------|--------|
+| Testing approach | `BLACK_BOX`, `GRAY_BOX`, `WHITE_BOX` |
+| Test level | `UNIT`, `COMPONENT`, `INTEGRATION`, `SYSTEM`, `E2E` |
+
+Every case and every result carries `testingApproach`, `testLevel`,
+`framework`, and `strategyRef`, so a report never has to guess which one it is
+looking at. The web UI shows approach badges and filters on the case list.
+
+## What each approach means here
+
+### Black-box — drive the running app, no source
+
+You have a URL and test credentials; you may have no repository at all. The
+crawler discovers routes, forms and auth flows from the DOM, and the generated
+Playwright tests assert only what a user can observe.
+
+Use it for staging environments, third-party or legacy apps, and acceptance
+testing where the source deliberately stays out of scope.
+
+→ [Blackbox testing from a URL](/docs/guides/blackbox-testing/)
+
+### Gray-box — read the source, still test through the seams
+
+The default when Suitest analyses a repository. Suitest reads your routes,
+handlers, models and pages to decide **what is worth testing and where the risk
+is**, then still drives the system through its public seams: HTTP requests,
+the DOM, the database. Internals inform the plan; they are not the oracle.
+
+This is the approach behind the normal agent workflow — `analyze_project` →
+`generate_backend_tests` / `generate_frontend_tests` → `run_*`.
+
+→ [Testing from your IDE agent](/docs/guides/agent-workflow/)
+
+### White-box — run the repository's own tests
+
+Suitest executes the unit and component tests that already live in your
+repository, through a framework adapter, and normalizes their results and
+coverage into the same cases, runs and evidence as everything else. Suitest
+does not write these tests or impose a coverage percentage; it discovers,
+executes and reports them.
+
+→ [White-box testing with your own suite](/docs/guides/whitebox-testing/)
+
+## How the approach is chosen
+
+`testing.approach` in `suitest.config.json` accepts `auto`, `black-box`,
+`gray-box`, or `white-box`.
+
+With `auto` (the default), the resolution follows the **analysis source**:
+
+| Analysis source | `auto` resolves to |
+|-----------------|--------------------|
+| `repo` (default) | `GRAY_BOX` |
+| `openapi`, `postman`, `blackbox` / crawl, live UI | `BLACK_BOX` |
+
+`WHITE_BOX` is never inferred — it is explicit, and it requires a compatible
+local test framework. That asymmetry is deliberate: source availability must
+not silently upgrade every test to "white-box", and repository access must not
+silently claim coverage the tests do not have.
+
+Precedence for a stored case is: **case override → suite default →
+`BLACK_BOX`**.
+
+```json
+{
+  "mode": "backend",
+  "testing": {
+    "approach": "gray-box",
+    "level": "INTEGRATION"
+  }
+}
+```
+
+See [`suitest.config.json`](/docs/reference/configuration/#testing) for the full
+block.
+
+## The risk strategy behind every generation
+
+Whatever the approach, generation writes a deterministic strategy file next to
+the plan before anything runs:
+
+```text
+suitest-output/
+└── backend|frontend/
+    ├── standard_prd.json
+    ├── suitest_<mode>_test_strategy.json
+    ├── suitest_<mode>_test_plan.json
+    └── ...
+```
+
+The strategy records access signals, risks and failure modes, assumptions,
+oracles, coverage dimensions, exclusions, and QA checks — and each risk names
+the approach recommended for it. At ZERO tier it is built deterministically;
+with an LLM configured it can be enriched, but a human approves a version
+before it becomes the project's approved strategy.
+
+The QA checks encode the posture the generated suite is held to: question
+unstated assumptions, prioritise impact over case count, require an observable
+oracle per case, cover negative, boundary, permission, state, concurrency,
+dependency, recovery and accessibility risks where relevant, reject duplicate
+or brittle assertions, and record what was excluded and what risk remains.
+
+## Choosing
+
+| Situation | Approach |
+|-----------|----------|
+| No repository, only a URL and credentials | Black-box |
+| You own the repo and want E2E/API coverage that survives refactors | Gray-box |
+| You already have pytest / Vitest / Jest suites and want them in the TCM with coverage | White-box |
+| Acceptance sign-off with a customer | Black-box, exported as a [UAT document](/docs/concepts/evidence/) |

--- a/docs-site/src/content/docs/docs/guides/whitebox-testing.md
+++ b/docs-site/src/content/docs/docs/guides/whitebox-testing.md
@@ -1,0 +1,118 @@
+---
+title: White-box testing with your own suite
+description: Run the pytest, Vitest or Jest tests that already live in your repository through Suitest, and publish their results and coverage as normal cases and runs.
+---
+
+White-box mode does not generate tests. It **runs the suite you already have**
+— pytest, Vitest or Jest — and publishes each native test as a case, with its
+result, its source, and normalized coverage, into the same TCM as your
+generated black-box and gray-box tests.
+
+That gets your unit and component layer onto the same dashboard, traceability
+matrix and reports as your E2E layer, without rewriting anything or adopting a
+new runner.
+
+The local contract is `suitest.whitebox.v1`.
+
+## What you need
+
+- A repository with tests the framework can already run on its own
+- One of the reference adapters: **pytest**, **Vitest**, **Jest**
+- No LLM, no API key — this is ZERO tier
+
+If `<repo>/.venv` exists, the pytest adapter runs your tests with **that**
+interpreter, so they import your dependencies. Suitest only provisions pytest
+into its own environment when there is no project interpreter to use — it will
+not install packages into your venv uninvited. The Node adapters shell out to
+`npm exec`, which resolves your `node_modules`.
+
+## Configure
+
+```json
+{
+  "mode": "backend",
+  "projectName": "example",
+  "projectPath": ".",
+  "baseUrl": "http://localhost",
+  "server": { "autostart": false },
+  "testing": {
+    "approach": "white-box",
+    "level": "UNIT",
+    "framework": "pytest",
+    "coverageFile": "coverage.json"
+  },
+  "output": "suitest-output"
+}
+```
+
+`approach` must be `white-box` explicitly — it is never inferred from the fact
+that Suitest can see your source. See
+[Black-box, gray-box, white-box](/docs/concepts/testing-approaches/).
+
+`framework` may be omitted; detection then falls back to the repository's own
+signals:
+
+| Detected from | Adapter |
+|---------------|---------|
+| `pyproject.toml` or `pytest.ini` | `pytest` |
+| `vitest` in `package.json` | `vitest` |
+| `jest` in `package.json` | `jest` |
+
+If nothing matches, the run fails with `no white-box adapter detected; set
+testing.framework to pytest, vitest, or jest` rather than guessing.
+
+## Run it
+
+From the CLI:
+
+```bash
+suitest test --config suitest.config.json
+```
+
+From an IDE agent, the same config drives two MCP tools:
+
+| Tool | Does |
+|------|------|
+| `whitebox_discover_tests` | Lists the framework, the command it will run, the discovered test files and the coverage file — without executing anything |
+| `whitebox_run_tests` | Executes them and publishes the run (forces `approach: white-box` regardless of the config) |
+
+Discovery is the safe first call: it tells you exactly what would execute.
+
+## What gets discovered
+
+| Adapter | Test file patterns | Default coverage file |
+|---------|--------------------|-----------------------|
+| pytest | `test_*.py`, `*_test.py` | `coverage.json` |
+| Vitest / Jest | `*.test.ts(x)`, `*.spec.ts(x)`, `*.test.js`, `*.spec.js` | `coverage/coverage-final.json` |
+
+`.git`, `.venv`, `node_modules`, `dist`, `build` and `suitest-output` are
+skipped. Each target is executed directly, without a shell.
+
+Set `testing.coverageFile` to override the default path (relative paths resolve
+against `projectPath`).
+
+## What lands in Suitest
+
+- One **case per native test target**, carrying the native source as its
+  automation code, so the code is readable in the case detail view
+- `testingApproach: WHITE_BOX`, plus `testLevel`, `framework` and `strategyRef`
+  on every case and result — the case list can filter on the approach badge
+- A **run** with per-test outcomes, published through the same
+  `PublishSession` as every other run
+- The coverage JSON uploaded as an artifact and its normalized summary stored
+  on the run — coverage.py and Istanbul shapes are both understood
+
+Coverage thresholds stay where they belong: in your repository's own
+configuration. Suitest reports the number, it does not impose one.
+
+## Mixing approaches in one project
+
+Nothing stops a project from holding all three. A common split:
+
+- white-box `UNIT` cases from your existing pytest suite
+- gray-box `INTEGRATION` / `E2E` cases generated from the repo
+- black-box `E2E` cases against staging, exported as the UAT document for
+  sign-off
+
+They share one traceability matrix, and every case says which approach it is,
+so a coverage claim can always be traced back to what was actually observed.

--- a/docs-site/src/content/docs/docs/index.md
+++ b/docs-site/src/content/docs/docs/index.md
@@ -10,6 +10,7 @@ Suitest is a self-hostable, open-source QA platform (Apache-2.0, pre-v1.0). It w
 - **Optional BYO-LLM AI.** Configure any provider per workspace from the web UI (Anthropic, OpenAI, Gemini, local Ollama or vLLM, or any OpenAI-compatible URL) to unlock agent chat, PRD-driven generation, and LLM codegen. No key is ever required.
 - **MCP server for IDE agents.** `npx -y @suiflex/suitest-mcp` gives Claude Code, Cursor, or Codex a full testing lifecycle: analyze, generate, run, report, publish.
 - **Blackbox DOM engine.** Test any web app from just a URL and test credentials: login detection, safe crawling, deterministic Playwright generation, evidence. No repo access needed.
+- **All three testing approaches.** Black-box from a URL, gray-box from your repository, and white-box by running the pytest/Vitest/Jest suite you already have — one TCM, one traceability matrix, each case labelled with what it actually observed. See [black-box, gray-box, white-box](/docs/concepts/testing-approaches/).
 
 ## Who it is for
 
@@ -41,6 +42,7 @@ npx -y @suiflex/suitest-mcp init
 - [Install the MCP server](/docs/install/mcp-server/)
 - [Agent workflow](/docs/guides/agent-workflow/)
 - [Blackbox testing from a URL](/docs/guides/blackbox-testing/)
+- [White-box: run your own pytest/Vitest/Jest suite](/docs/guides/whitebox-testing/)
 - [MCP tool reference](/docs/reference/mcp-tools/)
 
 ### I want the full platform on a server

--- a/docs-site/src/content/docs/docs/reference/configuration.md
+++ b/docs-site/src/content/docs/docs/reference/configuration.md
@@ -29,6 +29,7 @@ The fastest way to create one is the setup wizard (`bootstrap_project` MCP tool)
 | `prdFile` | string | `""` | Markdown product spec; when set and an LLM bridge is reachable, the plan is PRD-driven on top of the deterministic baseline. |
 | `codegen` | string | `"auto"` | Frontend codegen strategy: `auto` (deterministic archetypes first, LLM fills the rest), `llm` (LLM writes every frontend test body), `deterministic` (archetypes only; unknown cases fail loud). |
 | `output` | string | `"suitest-output"` | Output directory for generated tests, reports, and evidence, relative to the config. |
+| `testing` | object | see below | Testing approach, level, and white-box framework. |
 | `auth` | object | see below | How generated tests authenticate against the target. |
 | `server` | object | see below | How Suitest starts and stops the target. |
 | `dependencies` | object[] | `[]` | Supporting services to start before the target. |
@@ -38,6 +39,30 @@ The fastest way to create one is the setup wizard (`bootstrap_project` MCP tool)
 :::caution
 A no-repo backend (`analysisSource` other than `repo` in `backend` mode) **must** bring an API contract: set one of `openapiUrl`, `openapiFile`, or `postmanFile`, otherwise loading the config fails. Blackbox-from-URL alone is not enough to generate reliable backend tests.
 :::
+
+## `testing`
+
+Declares what the tester is allowed to observe and how deep the tests reach. See [Black-box, gray-box, white-box](/docs/concepts/testing-approaches/).
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `approach` | string | `"auto"` | `auto`, `black-box`, `gray-box`, or `white-box`. Any other value fails config loading. |
+| `level` | string | `"E2E"` | `UNIT`, `COMPONENT`, `INTEGRATION`, `SYSTEM`, or `E2E`. |
+| `framework` | string | `""` | White-box adapter: `pytest`, `vitest`, or `jest`. Empty means detect from the repository. |
+| `coverageFile` | string | `""` | Coverage JSON to publish, relative to `projectPath`. Empty uses the adapter default (`coverage.json` for pytest, `coverage/coverage-final.json` for Vitest/Jest). |
+
+With `approach: "auto"`, the value resolves from `analysisSource`: `repo` gives `GRAY_BOX`, every other source gives `BLACK_BOX`. `white-box` is never inferred — set it explicitly, and see the [white-box guide](/docs/guides/whitebox-testing/).
+
+```json
+{
+  "testing": {
+    "approach": "white-box",
+    "level": "UNIT",
+    "framework": "pytest",
+    "coverageFile": "coverage.json"
+  }
+}
+```
 
 ## `auth`
 

--- a/docs-site/src/content/docs/docs/reference/mcp-tools.md
+++ b/docs-site/src/content/docs/docs/reference/mcp-tools.md
@@ -116,6 +116,22 @@ Fails with `no prior run found` when `reports/summary.json` is missing. Otherwis
 
 Reads the stored `reports/summary.json`; never re-runs. Returns `data.failure_context` (the markdown bundle) and `data.failed_cases`. With no prior run it fails; with a prior all-green run it succeeds with an empty context. See [Failure context guide](/docs/guides/failure-context/).
 
+## White-box tools
+
+Run the test suite the repository already owns (pytest, Vitest, Jest) and publish it as normal cases and runs. Both tools take a single `config_path` argument and read the [`testing` block](/docs/reference/configuration/#testing). See the [white-box guide](/docs/guides/whitebox-testing/).
+
+### whitebox_discover_tests
+
+> List what would run: framework, command, test targets, coverage file — without executing anything.
+
+Detects the adapter from `testing.framework`, or from the repository (`pyproject.toml` / `pytest.ini` → pytest; `vitest` or `jest` in `package.json` → that runner). Fails with `no white-box adapter detected` rather than guessing. Returns `data.framework`, `data.command`, `data.targets`, and `data.coverageFile`.
+
+### whitebox_run_tests
+
+> Execute the repository's own tests and publish the run.
+
+Forces `approach: white-box` regardless of what the config says, executes each discovered target directly (no shell), and publishes through the normal ingest path: one case per native test carrying its source, `testingApproach: WHITE_BOX` on every case and result, and the coverage JSON uploaded as an artifact with its normalized summary stored on the run.
+
 ## Blackbox tools
 
 The blackbox engine tests any web app from a URL, with no repo access. Tools chain through JSON state files saved under the output directory (`suitest-output/` by default), so every stage can also be called independently in a fresh session: discover, graph, generate, run, summarize.

--- a/uv.lock
+++ b/uv.lock
@@ -2648,7 +2648,7 @@ wheels = [
 
 [[package]]
 name = "suiflex-suitest-lifecycle"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "packages/lifecycle" }
 
 [package.optional-dependencies]


### PR DESCRIPTION
Two commits, both docs-only.

## 1. Release notes are now published, and generated

Neither the site nor the README said what had shipped. After `mcp-v0.8.0` that was actively misleading: updating the MCP package still left the old UAT export in place, because the renderer lives in `apps/api` and reaches users through the **launcher** bundle.

- `docs-site/scripts/sync-changelog.mjs` builds `/docs/changelog/` from `packages/*/CHANGELOG.md` (written by release-please) plus the current version in each `package.json`. Wired to `predev`/`prebuild`, so a release needs **no docs edit**; `editUrl: false` marks the page as generated.
- New "Releases" sidebar group.
- Landing hero shows `Latest: launcher X · MCP server Y` imported from the packages, so the site cannot advertise an unpublished version.
- README gains a Releases section: which package carries which change, how to upgrade each, and that bumping one does not bump the other. Status list gains the desktop targets and the UAT export, both built but undocumented. `uv.lock` records the lifecycle 0.1.9 bump.

## 2. Gray-box and white-box exist in the docs now

The site only described black-box. Nothing anywhere mentioned the other two approaches, and the landing tool section claimed **22 tools** while the lifecycle registry exposes **24** — the two white-box tools were never listed.

- **New** `concepts/testing-approaches.md`: approach vs level as separate dimensions, how `auto` resolves from `analysisSource` (`repo` → `GRAY_BOX`, everything else → `BLACK_BOX`), why `WHITE_BOX` is never inferred, case → suite → `BLACK_BOX` precedence, and the risk-strategy file.
- **New** `guides/whitebox-testing.md`: adapters (pytest/Vitest/Jest), framework detection, discovered file patterns, default coverage paths, `suitest test`, both MCP tools, and what lands in the TCM.
- `reference/configuration.md`: the `testing` block (`approach`, `level`, `framework`, `coverageFile`) was **entirely undocumented**.
- `reference/mcp-tools.md`: new White-box section for `whitebox_discover_tests` and `whitebox_run_tests`.
- Landing: the feature card now covers all three approaches; the tool count is computed from the arrays so it cannot drift again.

Every claim was checked against `config.py`, `strategy.py`, `whitebox.py`, and `tools.py` — not against the older spec docs.

## 3. Suiflex as the parent organisation

- Landing footer badge became a "powered by Suiflex" lockup (qualifier above, brand below, so it does not read as one two-word name), and the copyright line states Suitest is a Suiflex project.
- New `DocsFooter.astro` overrides the Starlight `Footer` so **every docs page** carries the same endorsement under the stock prev/next block.
- README closes with the mark and the same line.

Uses the existing `docs-site/public/assets/brand/suiflex-logo-mark.png`; no new asset.

## Verification

- `npm run build` in `docs-site`: **30 pages** (27 before this branch)
- `dist/index.html`, `dist/docs/index.html`, and a deep guide page all contain the "powered by" text, the Suiflex mark, and the `suiflex.dev` link
- landing contains `24 tools` and `whitebox_discover_tests`
- config reference exposes the `#testing` anchor
- scanning every `dist/**/*.html`: **zero broken internal `/docs/...` links**
- the `Entry docs → 404 was not found` build notice is pre-existing — it appears on an unmodified tree too