### PR TITLE
fix: execute the run's selected cases and stop empty runs reporting PASS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,9 +292,11 @@ Two things that will waste an afternoon otherwise:
 - **The runner does not hot-reload.** Restart it after touching a bundled
   provider. A stale runner reports the *previous* error text, which reads like a
   genuine test failure rather than a stale process.
-- **An ad-hoc run of one test case executes the whole suite** in one MCP session.
-  Cases that share external state (a working directory, a database) leak into
-  each other in suite order. Give every case its own.
+- **A run executes its cases in one MCP session.** Cases that share external
+  state (a working directory, a database) leak into each other in selection
+  order. Give every case its own. (An ad-hoc run of one case used to execute
+  the *whole project* — the runner ignored the persisted selection. Fixed;
+  runs created before that fix still fall back to project-wide.)
 - User-provided MCP commands are **untrusted** — sandbox per [MCP_PLUGINS.md § security](./docs/MCP_PLUGINS.md):
   - Run in a container with restricted capabilities
   - No host filesystem access unless explicitly mounted

--- a/apps/api/src/suitest_api/routers/test_cases.py
+++ b/apps/api/src/suitest_api/routers/test_cases.py
@@ -47,6 +47,7 @@ from suitest_shared.schemas.pagination import Page, PageMeta
 from suitest_api.auth.db import get_async_session
 from suitest_api.deps.arq import get_arq
 from suitest_api.deps.role import require_role
+from suitest_api.deps.run_dispatch import dispatch_run
 from suitest_api.deps.scope import TenantContext, require_workspace_membership
 from suitest_api.deps.tier import require_autonomy, require_tier
 from suitest_api.routers._pagination import decode_cursor_or_400, encode_next
@@ -83,6 +84,7 @@ from suitest_api.services.test_case_service import (
     StepsRequireCodeError,
     TestCaseService,
 )
+from suitest_api.settings import get_settings
 from suitest_api.ws.publisher import publish_event
 
 # ARQ queue name shared with :mod:`suitest_api.routers.runs` — must match the
@@ -871,10 +873,15 @@ async def run_test_case_now(
     if run is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="test case not found")
 
-    job = await arq.enqueue_job("run_test_case", run.id, _queue_name=_RUNS_QUEUE)
-    if job is not None:
+    # Same dispatch seam as POST /runs: in local mode there is no ARQ consumer
+    # (the supervisor drains QUEUED rows from the DB), so enqueuing here both
+    # failed without a broker and risked a double execution with one.
+    job_id = await dispatch_run(
+        mode=get_settings().mode, arq=arq, run_id=run.id, queue_name=_RUNS_QUEUE
+    )
+    if job_id is not None:
         run_service = RunService(ctx, RunRepo(session), ProjectRepo(session))
-        await run_service.attach_arq_job_id(run.id, job.job_id)
+        await run_service.attach_arq_job_id(run.id, job_id)
     await session.commit()
     await session.refresh(run)
     return AdHocRunResponse(

--- a/apps/runner/src/suitest_runner/jobs/run_test_case.py
+++ b/apps/runner/src/suitest_runner/jobs/run_test_case.py
@@ -510,7 +510,15 @@ async def run_test_case(ctx: dict[str, object], run_id: str) -> dict[str, object
         # --- finalize -----------------------------------------------------
         duration_ms = int((time.perf_counter() - t0) * 1000)
         failed_total = summary["failed"] + summary["errored"]
-        final_status = RunStatus.FAIL if failed_total > 0 else RunStatus.PASS
+        if summary["total"] == 0:
+            # A run that executed nothing is not a green run — reporting PASS
+            # here hid empty selections behind a passing badge (issue #109).
+            log.warning("runner.run.empty_selection", run_id=run_id)
+            final_status = RunStatus.ERROR
+        elif failed_total > 0:
+            final_status = RunStatus.FAIL
+        else:
+            final_status = RunStatus.PASS
 
         async with factory() as session:
             await RunRepo(session).update_status(

--- a/apps/runner/tests/conftest.py
+++ b/apps/runner/tests/conftest.py
@@ -323,6 +323,13 @@ def stub_ctx_all_pass(
 
 
 @pytest.fixture()
+def stub_ctx_no_steps(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    """A real run whose selection resolved to zero steps — the issue-#109 shape."""
+    ctx, _, _ = _build_ctx(monkeypatch, outcomes=[], steps=[])
+    return ctx
+
+
+@pytest.fixture()
 def stub_ctx_empty(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
     """``RunRepo.get_with_selection`` returns ``(None, [])`` — missing-run path."""
     ctx, _, _ = _build_ctx(

--- a/apps/runner/tests/test_run_orchestrator.py
+++ b/apps/runner/tests/test_run_orchestrator.py
@@ -107,3 +107,10 @@ async def test_selector_failure_is_classified_without_auto_repair(
     inserted = ctx["_inserted_steps"]
     assert isinstance(inserted, list)
     assert inserted[0]["state_snapshot"] == {"failureKind": "selector_changed"}
+
+
+async def test_zero_steps_marks_run_error(stub_ctx_no_steps: dict[str, object]) -> None:
+    """An empty selection must not report a green run (issue #109)."""
+    out = await run_test_case(stub_ctx_no_steps, "run-1")
+    assert out["status"] == "ERROR"
+    assert out["total"] == 0

--- a/apps/web/src/components/runs/RunCaseExplorer.tsx
+++ b/apps/web/src/components/runs/RunCaseExplorer.tsx
@@ -7,11 +7,23 @@ import { CaseList } from "@/components/runs/CaseList";
 import { groupStepsByCase } from "@/components/runs/case-grouping";
 import { EmptyState } from "@/components/shared/EmptyState";
 import { fetchRunArtifacts, fetchRunSteps } from "@/lib/api-client";
+import type { components } from "@/lib/api-types";
 import { useRunStream } from "@/lib/ws-client";
+
+type RunStatus = components["schemas"]["RunStatus"];
 
 interface RunCaseExplorerProps {
   /** Run id OR public_id — the endpoints resolve either. */
   runId: string;
+  /** Run status, when the caller already has it — drives polling + empty copy. */
+  status?: RunStatus | undefined;
+}
+
+/** Once a run reaches one of these, no further steps can appear. */
+function isTerminal(status: RunStatus | undefined): boolean {
+  return (
+    status === "PASS" || status === "FAIL" || status === "ERROR" || status === "CANCELLED"
+  );
 }
 
 /**
@@ -21,14 +33,20 @@ interface RunCaseExplorerProps {
  * dump. Shared by the full-page run route AND the /runs side panel so both give
  * the same video/code/screenshot experience.
  */
-export function RunCaseExplorer({ runId }: RunCaseExplorerProps): React.ReactElement {
+export function RunCaseExplorer({ runId, status }: RunCaseExplorerProps): React.ReactElement {
+  // Poll until the run is terminal. The WS refetch below is the fast path, but
+  // local mode publishes to a NullPublisher — no event ever reaches the browser,
+  // so without polling the panel stayed empty until a manual reload (issue #109).
+  const refetchInterval = isTerminal(status) ? false : 2000;
   const { data: stepsData, refetch: refetchSteps } = useQuery({
     queryKey: ["run-steps", runId] as const,
     queryFn: () => fetchRunSteps(runId),
+    refetchInterval,
   });
   const { data: artifactsData, refetch: refetchArtifacts } = useQuery({
     queryKey: ["run-artifacts", runId] as const,
     queryFn: () => fetchRunArtifacts(runId),
+    refetchInterval,
   });
 
   const steps = useMemo(() => stepsData?.items ?? [], [stepsData]);
@@ -70,11 +88,31 @@ export function RunCaseExplorer({ runId }: RunCaseExplorerProps): React.ReactEle
   );
 
   if (groups.length === 0) {
+    // Distinguish "hasn't run yet" from "ran and produced nothing" — the old
+    // single message read as data loss whenever a run was merely queued.
+    if (status === "QUEUED") {
+      return (
+        <EmptyState
+          icon={ListChecks}
+          title="Queued"
+          subtitle="Waiting for a runner to pick this run up."
+        />
+      );
+    }
+    if (status === "RUNNING") {
+      return (
+        <EmptyState
+          icon={ListChecks}
+          title="Running"
+          subtitle="Test cases appear here as their steps complete."
+        />
+      );
+    }
     return (
       <EmptyState
         icon={ListChecks}
         title="No test cases recorded"
-        subtitle="This run has no recorded steps yet."
+        subtitle="This run finished without executing any steps."
       />
     );
   }

--- a/apps/web/src/routes/_app/runs.tsx
+++ b/apps/web/src/routes/_app/runs.tsx
@@ -245,7 +245,7 @@ function RunDetailPanel({
 
       {/* Case-first evidence view (test cases → steps + Preview/Code/Logs/
           Artifacts), shared with the full-page run route. */}
-      <RunCaseExplorer runId={run.id} />
+      <RunCaseExplorer runId={run.id} status={run.status} />
 
       <footer className="flex justify-end" data-testid="run-cost-footer">
         <Gated

--- a/apps/web/src/routes/_app/runs_.$runId.tsx
+++ b/apps/web/src/routes/_app/runs_.$runId.tsx
@@ -40,7 +40,7 @@ export function RunDetailPage(): React.ReactElement {
       <RunSummaryCard run={run} />
 
       {/* TEST CASE master-detail — the primary run view (shared with the panel). */}
-      <RunCaseExplorer runId={runId} />
+      <RunCaseExplorer runId={runId} status={run?.status} />
     </section>
   );
 }

--- a/packages/db/src/suitest_db/repositories/runs.py
+++ b/packages/db/src/suitest_db/repositories/runs.py
@@ -254,18 +254,32 @@ class RunRepo(AsyncRepository[Run, RunCreate, RunUpdate]):
     ) -> tuple[Run | None, list[tuple[str, int, TestStep]]]:
         """Return the run plus the ordered ``(case_id, step_order, TestStep)`` selection.
 
-        The M1c runner does not yet have a first-class ``run_cases`` join table
-        — selection is implicit "every active case in the project's suites,
-        ordered by ``(suite.order, case.created_at, step.order)``". ``step_order``
-        is a per-run counter (0-indexed across all steps in the selection) so
-        the orchestrator can index events / RunStep rows by a stable monotonic
-        position even when steps span multiple cases. M2 will swap this for a
-        persisted selection set when suite/tag filters arrive at run-create
-        time.
+        The case set comes from the selection ``RunService.create_run`` validated
+        and persisted in ``runs.metadata_json["selection"]`` — so running one case
+        runs that case, not its whole project. Runs created before that payload
+        existed (or whose metadata lost it) fall back to the old implicit set:
+        every active case in the run's project.
+
+        Ordering is always ``(suite.order, case.created_at, case.id, step.order)``
+        and ``step_order`` is a per-run counter (0-indexed across all steps in the
+        selection) so the orchestrator can index events / RunStep rows by a stable
+        monotonic position even when steps span multiple cases. There is still no
+        first-class ``run_cases`` join table — that is M2.
         """
         run = await self.get_by_id(run_id)
         if run is None:
             return None, []
+        metadata = run.metadata_json if isinstance(run.metadata_json, dict) else {}
+        raw_selection = metadata.get("selection")
+        case_ids = (
+            [
+                item["case_id"]
+                for item in raw_selection
+                if isinstance(item, dict) and isinstance(item.get("case_id"), str)
+            ]
+            if isinstance(raw_selection, list)
+            else []
+        )
         stmt = (
             select(TestCase.id, TestStep)
             .join(Suite, Suite.id == TestCase.suite_id)
@@ -281,6 +295,8 @@ class RunRepo(AsyncRepository[Run, RunCreate, RunUpdate]):
                 TestStep.order.asc(),
             )
         )
+        if case_ids:
+            stmt = stmt.where(TestCase.id.in_(case_ids))
         rows = (await self.session.execute(stmt)).all()
         selection: list[tuple[str, int, TestStep]] = [
             (case_id, idx, step) for idx, (case_id, step) in enumerate(rows)

--- a/packages/db/tests/repositories/test_run_repo.py
+++ b/packages/db/tests/repositories/test_run_repo.py
@@ -12,6 +12,7 @@ from factories import (
     make_workspace,
 )
 from sqlalchemy.ext.asyncio import AsyncSession
+from suitest_db.models.case import TestStep
 from suitest_db.models.run import Artifact
 from suitest_db.repositories.runs import RunRepo
 from suitest_shared.domain.enums import ArtifactKind, RunStatus, StepOutcome
@@ -101,3 +102,44 @@ async def test_get_steps_and_artifacts(session: AsyncSession) -> None:
     artifacts = await repo.get_artifacts(run.id)
     assert len(artifacts) == 1
     assert artifacts[0].run_step_id == rs.id
+
+
+async def _two_cases_with_one_step_each(session: AsyncSession, project):  # type: ignore[no-untyped-def]
+    """Two cases in one suite, one step each. Returns ``(case_a, case_b)``."""
+    suite = await make_suite(session, project=project)
+    cases = []
+    for name in ("A", "B"):
+        case = await make_test_case(session, suite=suite, name=name)
+        session.add(
+            TestStep(case_id=case.id, order=1, action=f"act {name}", expected=f"exp {name}")
+        )
+        cases.append(case)
+    await session.flush()
+    return cases[0], cases[1]
+
+
+@pytest.mark.asyncio
+async def test_get_with_selection_honors_persisted_selection(session: AsyncSession) -> None:
+    """A run that selected one case executes that case only — not its whole project."""
+    project = await _project(session)
+    case_a, _case_b = await _two_cases_with_one_step_each(session, project)
+    run = await make_run(session, project=project)
+    run.metadata_json = {"selection": [{"case_id": case_a.id}]}
+    await session.flush()
+
+    loaded, selection = await RunRepo(session).get_with_selection(run.id)
+
+    assert loaded is not None
+    assert [case_id for case_id, _order, _step in selection] == [case_a.id]
+
+
+@pytest.mark.asyncio
+async def test_get_with_selection_falls_back_to_project_wide(session: AsyncSession) -> None:
+    """Runs predating the persisted selection keep the old project-wide behavior."""
+    project = await _project(session)
+    case_a, case_b = await _two_cases_with_one_step_each(session, project)
+    run = await make_run(session, project=project)
+
+    _loaded, selection = await RunRepo(session).get_with_selection(run.id)
+
+    assert sorted(case_id for case_id, _order, _step in selection) == sorted([case_a.id, case_b.id])


### PR DESCRIPTION
## Summary

- Fixes #109. The reported symptom is an empty run detail, but the root causes go deeper: the runner ignored the run's persisted case selection, so a run that selected one case executed **other** cases and reported `PASS`. This is silent wrong execution, not only a UI bug.
- Four independent defects on the run path, one commit each, plus a docs correction.

### The severity finding

A run selecting a case with zero steps did not simply record nothing — it executed 4 steps belonging to unrelated cases and finished green. Reproduced against a live Postgres:

```
pre-fix    run A (selects case A): status=PASS steps=4 distinct_cases={case_A, case_B}
           run C (selects case C, 0 steps): status=PASS steps=4

post-fix   run A: status=PASS steps=2 distinct_cases={case_A}
           run C: status=ERROR steps=0
```

## Changes

**`packages/db` — execute the run's persisted case selection**
`RunService.create_run` validated and stored the requested case ids in `runs.metadata_json["selection"]`, but `get_with_selection` ignored them and rebuilt the set as every active case in the run's project. Now constrained to the persisted selection; runs whose metadata predates that payload keep the project-wide fallback so historical runs and reruns still resolve.

**`apps/runner` — a zero-step run reports ERROR, not PASS**
An empty selection skipped the dispatch loop and fell through to the `PASS` branch, landing a green run with `total_steps=0` and no evidence. Now terminates `ERROR` and logs `runner.run.empty_selection`.

**`apps/api` — ad-hoc run goes through the local-aware dispatch seam**
`POST /test-cases/{id}/run` enqueued straight onto the ARQ queue instead of `dispatch_run`, ignoring local mode: with no broker the request failed, and with one the run could execute twice — once by the ARQ worker, once by the supervisor draining `QUEUED` rows, which has no claim fencing.

**`apps/web` — poll run steps, and tell a queued run apart from an empty one**
The case explorer only refetched on WS `run.step.*` events. Local mode publishes through `NullPublisher`, so no event ever reaches the browser and the panel stayed on "No test cases recorded" even after the run passed, until a manual reload. Now polls until the run is terminal, and the empty state splits three ways (queued / running / finished with no steps).

## Test plan

- [x] `packages/db/tests/repositories/test_run_repo.py` — 6 passed, 0 skipped, against a live Postgres 16 + pgvector. Two new cases: `test_get_with_selection_honors_persisted_selection`, `test_get_with_selection_falls_back_to_project_wide`
- [x] `apps/runner/tests` — 75 passed, including the new `test_zero_steps_marks_run_error`
- [x] `apps/api/tests` — 825 passed, 0 failed (against a live DB; without one, 557 of these skip themselves)
- [x] `packages/db/tests` 135 passed; `core` + `mcp` + `shared` + `agent` 384 passed, 1 opt-in skip
- [x] Live E2E driving `local_supervisor.drain_once` against a real Postgres, asserting selection scoping and the zero-step `ERROR` status
- [x] **Negative control** — the same E2E against `main`'s `runs.py` + `run_test_case.py` fails with `AssertionError: selection leaked`, so the check is load-bearing rather than passing by accident
- [x] `mypy` clean (140 files api, 74 files db); `ruff check` + `ruff format` clean; `pnpm typecheck` + `pnpm lint` clean

### Not verified — please weigh before merging

- **The web commit has no passing automated coverage.** `runs.test.tsx`, `runs_.$runId.test.tsx` and `runs-cancel-rerun.test.tsx` are red on `main` already: the harness renders an auth screen instead of the runs route (`Unable to find [data-testid="runs-skeleton"]`). A file-level A/B on the three touched files gives 6 failed / 10 passed both with and without this branch — identical, so no regression, but the change itself is only covered by typecheck and lint.
- No browser/Playwright E2E was run, so "the panel fills without a reload" is unverified in a real browser.

## Follow-ups (not in this PR)

- The broken auth mock behind the 64 failing web route tests
- `webhooks.py:254` / `:423` bypass `dispatch_run` the same way `test_cases.py` did
- No reaper for runs stuck in `RUNNING` / `QUEUED`
- `RunStepRepo.create_step` is not idempotent, so an ARQ retry duplicates step rows
- The inner join on `TestCase` in `get_steps_with_case_public_id` drops steps whose case was hard-deleted
- A first-class `run_cases` table (M2)
