### PR TITLE
fix(ci): store CLA signatures on unprotected branch

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           path-to-signatures: signatures/version1/cla.json
           path-to-document: https://github.com/suiflex/suitest/blob/main/CLA.md
-          branch: main
+          branch: cla-signatures
           allowlist: badrus123,mulhamna,*[bot]
           custom-notsigned-comment: >
             Thanks for your contribution! Before we can merge, please read our

--- a/signatures/version1/cla.json
+++ b/signatures/version1/cla.json
@@ -1,1 +1,0 @@
-{"signedContributors":[]}


### PR DESCRIPTION
## Summary
- CLA Assistant's direct commit to `main` was rejected by the new branch ruleset, which requires all changes go through a pull request
- Storing signature data outside `main` keeps it working without weakening branch protection

## Changes
- `.github/workflows/cla.yml`: point `branch` input at the dedicated `cla-signatures` branch
- Remove the now-unused `signatures/version1/cla.json` from `main`

## Test plan
- [ ] Re-run the `cla` check on an open PR and confirm it passes
- [ ] Confirm the CLA sign comment flow still writes to `cla-signatures` without errors