### PR TITLE
chore: local-stack fixes, sidebar scroll, sponsor links, contributing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,9 +12,9 @@ Closes #M<milestone>-<n>
 
 - [ ] Works at **ZERO tier** (no LLM) or gracefully degrades
 - [ ] Capability/autonomy gating added for any LLM-dependent feature
-- [ ] `uv run ruff check . && uv run mypy .` pass
-- [ ] `uv run pytest` pass (new tests added for new behavior)
-- [ ] `pnpm -C apps/web typecheck && pnpm -C apps/web test` pass (if FE touched)
+- [ ] `make check-all` passes (ruff + mypy + eslint + tsc)
+- [ ] `make test` passes (new tests added for new behavior)
+- [ ] `make test-web` passes (if FE touched)
 - [ ] Alembic migration added for any schema change
 - [ ] Secrets handled via AES-GCM; mutations audit-logged
 - [ ] Docs updated (`docs/*`, `ROADMAP.md` checkbox)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,21 @@
 # Contributing to Suitest
 
-Thanks for your interest in contributing! Suitest is an MCP-native, self-hostable
-testing platform. This guide gets you from clone to merged PR.
-
-## Code of conduct
+Suitest is an MCP-native, self-hostable testing platform: manual test case
+management, deterministic runs driven by pluggable MCP servers, and optional AI
+on top when you bring your own LLM. This guide gets you from clone to merged PR.
 
 By participating you agree to uphold our [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Quick links
+
+- [`docs/ROADMAP.md`](./docs/ROADMAP.md) — the single entry point for what to work on
+- [`docs/PRODUCT.md`](./docs/PRODUCT.md) — what the product is for, and who for
+- [`CLAUDE.md`](./CLAUDE.md) — the full coding rules, binding on humans and agents alike
+- [`SECURITY.md`](./SECURITY.md) · [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md) · [`CLA.md`](./CLA.md)
+- [Issues](https://github.com/suiflex/suitest/issues/new/choose) · [Discussions](https://github.com/suiflex/suitest/discussions)
+
+Read the ROADMAP before you start. It decides order and scope, and if it
+disagrees with any other doc, it wins — update the doc in the same PR.
 
 ## Contributor License Agreement (CLA)
 
@@ -19,56 +29,138 @@ The CLA keeps the project's licensing flexible (see [`CLA.md`](./CLA.md) § 4)
 while guaranteeing your contributions always remain available under the
 [Apache License 2.0](./LICENSE).
 
+## How to contribute
+
+- **Small fix** — typo, broken link, obvious bug: open a PR directly.
+- **New MCP provider, a schema change, anything that moves a capability tier** —
+  open an issue first. These touch contracts other parts of the system rely on,
+  and it is cheaper to disagree before the code exists.
+- **A question** — Discussions, not an issue.
+- **A security problem** — [SECURITY.md](./SECURITY.md). Never a public issue.
+
 ## Getting started
+
+Two workspaces live side by side in this repo:
+
+- **Python**, managed with [`uv`](https://docs.astral.sh/uv/) — `apps/api`,
+  `apps/runner`, and `packages/{agent,core,db,mcp,shared,lifecycle}`.
+- **Node**, managed with [`pnpm`](https://pnpm.io/) — `apps/web`,
+  `packages/mcp-npx`, `docs-site`. There is no root `package.json`; frontend
+  commands run with `apps/web` as the working directory.
+
+You need Python 3.12 (the workspace pins `>=3.12,<3.13`) and Node 22 with pnpm.
+`.python-version` and `.node-version` carry the exact versions CI uses.
+
+### From zero to a running app
 
 ```bash
 git clone https://github.com/suiflex/suitest
 cd suitest
-cp .env.example .env
-docker compose -f infra/docker/docker-compose.yml --profile zero up -d   # pg + redis + minio + api + web + runner
+make setup      # .env → uv sync + pnpm install + pre-commit hooks → migrate → seed
+make dev        # API (:4000) + web (:3000) + ARQ runner, together
 ```
 
-Python deps are managed with [`uv`](https://docs.astral.sh/uv/), frontend deps with
-[`pnpm`](https://pnpm.io/). Install dev tooling:
+`make setup` expects Postgres and Redis to be reachable. The quickest way to get
+them is the compose stack:
 
 ```bash
-uv sync                # Python workspace
-pnpm install           # frontend workspace
-pre-commit install     # ruff + black + mypy + secret scan on commit
+docker compose -f infra/docker/docker-compose.yml --profile zero up -d
 ```
 
-## How we work
+If you run the services on the host instead of in compose, read the "Running the
+platform locally" notes in [`CLAUDE.md`](./CLAUDE.md) first — two defaults point
+at compose hostnames, and the resulting failures look unrelated to the cause.
 
-- **`docs/ROADMAP.md` is the single entry point.** Pick the next unchecked
-  acceptance criterion in the active milestone; one PR = one criterion.
-- **ZERO-tier first.** Every feature must work (or gracefully degrade) with no
-  LLM configured before any AI enrichment is added.
-- **Backend first, frontend second.** Pydantic schema + Alembic migration +
-  service test, then wire the UI.
-- Read [`CLAUDE.md`](./CLAUDE.md) for the full coding rules (typing, MCP/LLM
-  routing, capability gating, audit logging).
+## Build, lint, test
 
-## Quality gates (must pass before merge)
+Everything is wrapped in the Makefile. Run `make help` for the full list.
 
-```bash
-uv run ruff check . && uv run ruff format --check .
-uv run mypy .                     # strict, no `Any`
-uv run pytest                     # pytest-asyncio strict mode
-pnpm -C apps/web typecheck && pnpm -C apps/web test
+```
+make lint            # ruff check + ruff format --check
+make lint-fix        # ruff --fix + format
+make typecheck       # mypy strict, one call per package
+make test            # pytest (asyncio strict mode)
+make test-cov        # pytest with coverage
+make lint-web        # eslint --max-warnings=0
+make typecheck-web   # tsc --noEmit
+make test-web        # vitest
+make check-all       # every linter and typechecker, no tests
+make ci              # check-all + test + test-web
 ```
 
-CI runs all of the above plus Docker image builds. A PR needs green CI + one
-review before squash-merge to `main`.
+**Run `make ci` before opening a PR.**
 
-## Commit & PR conventions
+Two invocations are scoped on purpose, and collapsing them breaks the build:
 
-- Branch: `feat/<scope>-<short-desc>` (e.g. `feat/agent-prd-parser`).
-- Commits: [Conventional Commits](https://www.conventionalcommits.org/) —
-  `feat(api): add X`, `fix(runner): handle Y`.
-- Reference the milestone criterion in the PR (`Closes #M4-9`).
-- Keep PRs small and focused.
+- `ruff` runs against `apps packages`, not `.`
+- `mypy` runs **once per package**. A single `mypy .` fails with "Duplicate
+  module named conftest".
 
-## Reporting bugs / requesting features
+`pre-commit` (installed by `make setup`) runs ruff, ruff-format, mypy and a
+secret scan on the files you touch.
+
+Postgres-backed tests skip themselves when no database is reachable, so a green
+local `make test` is not proof on its own — check the skip count.
+
+### What CI covers
+
+`.github/workflows/ci.yml` gates every PR:
+
+| Job | What it runs |
+|---|---|
+| `changes` | Path filter; the jobs below are skipped when nothing relevant moved |
+| `python-lint` | ruff check, ruff format --check, mypy per package |
+| `python-test` | pytest against pgvector + redis, after `alembic upgrade head`; also re-exports the OpenAPI spec and fails if `packages/shared/openapi.json` is stale |
+| `ts-lint` | `pnpm typecheck` + `pnpm lint` in `apps/web` |
+| `ts-test` | vitest |
+| `web-lighthouse` | Frontend budgets; soft fail |
+| `build-images` | The four Docker images, after the lint and test jobs pass |
+| `version-floor` | Proves the published npx/uvx packages still boot on Node 18 and Python 3.11 |
+| `mcp-package` | npx and uvx packaging smoke test |
+
+End-to-end suites, the air-gapped checks and the eval harness run in their own
+workflows, on a schedule or on demand.
+
+## Adding a bundled MCP provider
+
+MCP is the plugin layer, so a new provider touches five places that no compiler
+will remind you about — the registry, the in-process runtime's lazy module list,
+the builtin spec and its tool catalog, the default routing table, and the docs.
+The checklist lives in [`CLAUDE.md`](./CLAUDE.md) § 5; follow it there rather
+than from memory, and open an issue before you start.
+
+## Commit conventions
+
+Commits follow [Conventional Commits](https://www.conventionalcommits.org/), and
+`release-please` parses them to generate changelogs and version bumps for three
+separately released components: `packages/mcp-npx`, `packages/suitest-npx` and
+`sdk/typescript`.
+
+- Types: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`, `build`, `ci`
+- Subject ≤ 72 characters, imperative mood, no trailing period
+- Body wrapped at 72, explaining **why** — the diff already shows the what
+- One logical change per commit, so `git revert` stays safe and obvious
+- Never hand-edit the changelog sections `release-please` manages
+
+## Branching & pull requests
+
+Branch off `main`, named for the type of the leading commit: `feat/...`,
+`fix/...`, `refactor/...`, `chore/...`, `docs/...`.
+
+- One PR = one roadmap acceptance criterion. Reference it (`Closes #M4-9`).
+- Fill in the PR template: what, roadmap criterion, checklist, notes.
+- Tick the test-plan boxes you actually ran. An honest unticked box is far more
+  useful than a ticked one nobody checked.
+- Green CI plus one review, then squash-merge.
+
+### AI-assisted pull requests
+
+Contributions written with an AI assistant are welcome and need no special
+label. Two conditions: show the commands you actually ran, and be able to
+explain the code you are proposing. A PR the author cannot discuss is not
+reviewable, whoever or whatever wrote it.
+
+## Reporting bugs & requesting features
 
 Use the GitHub issue templates. For security issues, **do not open a public
 issue** — see [SECURITY.md](./SECURITY.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,6 +215,22 @@ label. Two conditions: show the commands you actually ran, and be able to
 explain the code you are proposing. A PR the author cannot discuss is not
 reviewable, whoever or whatever wrote it.
 
+Both conditions are ones assistants are bad at on their own — they will report
+a suite as passing when it skipped, and describe a cause they inferred rather
+than checked. [ForgeGuard](https://github.com/suiflex/ForgeGuard) exists to hold
+them to it, and we suggest it for AI-assisted work here:
+
+```bash
+forgeguard init            # install rules and hooks for your agent
+forgeguard gate            # static rules + this repo's quality commands
+forgeguard review          # the same, over changed files only
+```
+
+It also tracks an objective and its evidence across a session
+(`forgeguard task`), so what the agent claims it verified and what it actually
+ran stay attached to each other. Optional, and nothing in CI depends on it —
+`.forgeguard/` is gitignored, so it never reaches your diff.
+
 ## Reporting bugs & requesting features
 
 Use the GitHub issue templates. For security issues, **do not open a public

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,14 +75,12 @@ the note about skipped tests below before you rely on a green test run.
 ```bash
 git clone https://github.com/suiflex/suitest
 cd suitest
-make setup      # .env → uv sync + pnpm install + pre-commit hooks → migrate → seed
-```
 
-`make setup` expects Postgres and Redis to be reachable, so start the services
-first:
-
-```bash
+# Services first: the last two steps of `make setup` migrate and seed the
+# database, so they fail against a Postgres that is not up yet.
 docker compose -f infra/docker/docker-compose.yml --profile zero up -d
+
+make setup      # .env → uv sync + pnpm install + pre-commit hooks → migrate → seed
 make dev        # API (:4000) + web (:3000) + ARQ runner, together
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,25 +51,82 @@ Two workspaces live side by side in this repo:
 You need Python 3.12 (the workspace pins `>=3.12,<3.13`) and Node 22 with pnpm.
 `.python-version` and `.node-version` carry the exact versions CI uses.
 
-### From zero to a running app
+### Pick your setup
+
+There are two ways to run Suitest while you work on it, and they are not
+interchangeable. Choose by what you are changing:
+
+| | **Docker stack** | **Local bundle (npx)** |
+|---|---|---|
+| What you are changing | `apps/api`, `apps/web`, `apps/runner`, `packages/*` | `packages/suitest-npx`, packaging, first-run experience |
+| Database | Postgres + pgvector | SQLite, in `./.suitest/` |
+| Also runs | Redis, MinIO | neither — a local supervisor replaces the ARQ worker |
+| Where the dashboard lives | Vite on `:3000`, proxying to the API on `:4000` | one process on `:4000` serving both |
+| Hot reload | yes, both ends | no — rebuild and restart |
+| Postgres-backed tests | run | **skip themselves** |
+| Needs Docker | yes | no |
+
+**Most contributions want the Docker stack.** Take the local bundle if you are
+working on the launcher itself, or if Docker is not available to you — but see
+the note about skipped tests below before you rely on a green test run.
+
+### Docker stack
 
 ```bash
 git clone https://github.com/suiflex/suitest
 cd suitest
 make setup      # .env → uv sync + pnpm install + pre-commit hooks → migrate → seed
-make dev        # API (:4000) + web (:3000) + ARQ runner, together
 ```
 
-`make setup` expects Postgres and Redis to be reachable. The quickest way to get
-them is the compose stack:
+`make setup` expects Postgres and Redis to be reachable, so start the services
+first:
 
 ```bash
 docker compose -f infra/docker/docker-compose.yml --profile zero up -d
+make dev        # API (:4000) + web (:3000) + ARQ runner, together
 ```
 
-If you run the services on the host instead of in compose, read the "Running the
-platform locally" notes in [`CLAUDE.md`](./CLAUDE.md) first — two defaults point
-at compose hostnames, and the resulting failures look unrelated to the cause.
+Open the dashboard on `:3000`. The Vite dev server proxies `/api` to `:4000`,
+so both ends hot-reload.
+
+If you run Postgres and Redis on the host rather than in compose, read the
+"Running the platform locally" notes in [`CLAUDE.md`](./CLAUDE.md) first — two
+defaults point at compose hostnames, and the failures they cause look unrelated
+to their cause.
+
+### Local bundle (npx)
+
+This is how the product ships: one command, SQLite, no services to run. To
+exercise it against your working tree rather than a published release, build the
+bundle assets and point the launcher at them:
+
+```bash
+bash scripts/build-bundle-assets.sh            # → dist/bundle/{web,wheels}
+
+cd ~/some-project                              # any directory you want to test in
+SUITEST_BUNDLE_WHEELS_DIR=<repo>/dist/bundle/wheels \
+SUITEST_BUNDLE_WEB_DIST=<repo>/dist/bundle/web \
+node <repo>/packages/suitest-npx/bin/suitest.js up
+```
+
+Then `suitest.js down` to stop, `status` to check, `onboard` for the guided
+first run. Add `--yes` if the directory does not look like a project root.
+
+Things worth knowing before you lose an afternoon to them:
+
+- **Rebuild the bundle after every code change.** The launcher installs wheels
+  into `./.suitest/.venv`, so editing the source changes nothing until
+  `build-bundle-assets.sh` runs again. The venv reinstalls itself whenever the
+  wheels change, but the *web* half is a separate build — rebuild both.
+- **The API serves the dashboard here**, unlike the Docker stack. Anything under
+  `/api`, `/auth` or `/ws` that no route matches returns a 404 that says the API
+  is older than the web bundle. If you see that, your two halves are out of sync.
+- **Admin credentials are generated on first run** into
+  `./.suitest/credentials.json`. That file also holds the encryption key and an
+  API key — never paste it into an issue, a PR or a screenshot.
+- **Postgres-backed tests skip themselves** with no database reachable, so
+  `make test` can report success having executed almost nothing. Check the skip
+  count, and run the suite against the Docker stack before you open a PR.
 
 ## Build, lint, test
 
@@ -99,8 +156,8 @@ Two invocations are scoped on purpose, and collapsing them breaks the build:
 `pre-commit` (installed by `make setup`) runs ruff, ruff-format, mypy and a
 secret scan on the files you touch.
 
-Postgres-backed tests skip themselves when no database is reachable, so a green
-local `make test` is not proof on its own — check the skip count.
+A green local `make test` is not proof on its own if you are on the local
+bundle — see the skip-count warning above.
 
 ### What CI covers
 

--- a/apps/api/src/suitest_api/main.py
+++ b/apps/api/src/suitest_api/main.py
@@ -290,10 +290,25 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         from starlette.exceptions import HTTPException as StarletteHTTPException
         from starlette.types import Scope
 
+        # Prefixes that belong to the routers above. Reaching the mount means no
+        # router matched, which in a local bundle almost always means the API and
+        # the dashboard were built from different revisions. Say so, instead of
+        # letting StaticFiles answer index.html (GET) or 405 (POST) — the 405 in
+        # particular reads like a method bug in a route that simply is not there.
+        _API_PREFIXES = ("api/", "auth/", "ws/")
+
         class _SpaStaticFiles(StaticFiles):
             """StaticFiles that falls back to index.html for unknown paths (SPA deep links)."""
 
             async def get_response(self, path: str, scope: Scope) -> Response:
+                if path.startswith(_API_PREFIXES):
+                    raise StarletteHTTPException(
+                        status_code=404,
+                        detail=(
+                            f"No API route matches /{path}. If the dashboard just called "
+                            "this, the running API is older than the web bundle it serves."
+                        ),
+                    )
                 try:
                     return await super().get_response(path, scope)
                 except StarletteHTTPException as exc:

--- a/apps/api/tests/test_llm_config.py
+++ b/apps/api/tests/test_llm_config.py
@@ -142,3 +142,60 @@ async def test_non_admin_cannot_write(api_db: ApiDb) -> None:
             json={"provider": "mock", "model": "mock-1"},
         )
     assert put.status_code == 403
+
+
+# --- Sign in with ChatGPT ----------------------------------------------------
+# These cover route registration and the flow-lookup errors only: no test drives
+# a real sign-in, because every mode of ``start`` talks to OpenAI. That is enough
+# for the failure these were written after — the routes were reachable in source
+# but not in the running process, and nothing here noticed.
+
+
+@pytest.mark.asyncio
+async def test_chatgpt_login_start_is_routed_and_admin_only(api_db: ApiDb) -> None:
+    user = await api_db.seed_user(email="chatgpt-qa@example.com")
+    ws = await api_db.member_workspace(user, slug="chatgpt-qa")  # default Role.QA
+    async with api_db.client(user) as c:
+        resp = await c.post(
+            f"/api/v1/workspaces/{ws.id}/llm-config/chatgpt/login",
+            headers=_h(ws.id),
+            json={"mode": "auto"},
+        )
+    # 403 from the role gate, never 404/405 — those mean the route is not mounted.
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_chatgpt_login_poll_rejects_unknown_flow(api_db: ApiDb) -> None:
+    user, ws = await _admin_ws(api_db, email="chatgpt-poll@example.com", slug="chatgpt-poll")
+    async with api_db.client(user) as c:
+        resp = await c.get(
+            f"/api/v1/workspaces/{ws.id}/llm-config/chatgpt/login/nope",
+            headers=_h(ws.id),
+        )
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["detail"]["code"] == "UNKNOWN_FLOW"
+
+
+@pytest.mark.asyncio
+async def test_chatgpt_login_finish_rejects_unknown_flow(api_db: ApiDb) -> None:
+    user, ws = await _admin_ws(api_db, email="chatgpt-fin@example.com", slug="chatgpt-fin")
+    async with api_db.client(user) as c:
+        resp = await c.post(
+            f"/api/v1/workspaces/{ws.id}/llm-config/chatgpt/login/nope/finish",
+            headers=_h(ws.id),
+            json={"credentialMode": "subscription", "model": "gpt-5.6"},
+        )
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["detail"]["code"] == "UNKNOWN_FLOW"
+
+
+@pytest.mark.asyncio
+async def test_chatgpt_login_cancel_is_idempotent(api_db: ApiDb) -> None:
+    user, ws = await _admin_ws(api_db, email="chatgpt-cxl@example.com", slug="chatgpt-cxl")
+    async with api_db.client(user) as c:
+        resp = await c.delete(
+            f"/api/v1/workspaces/{ws.id}/llm-config/chatgpt/login/nope",
+            headers=_h(ws.id),
+        )
+    assert resp.status_code == 204, resp.text

--- a/apps/api/tests/test_static_serving.py
+++ b/apps/api/tests/test_static_serving.py
@@ -49,3 +49,30 @@ def test_api_routes_still_work_under_static_mount(
     resp = client.get("/health")
     assert resp.status_code in (200, 401)  # route exists (ok/auth) — NOT the SPA html
     assert "<!doctype html>" not in resp.text
+
+
+def test_unknown_api_path_404s_instead_of_reaching_the_mount(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A POST to a route the running API lacks must not answer 405 from StaticFiles.
+
+    StaticFiles rejects every non-GET before it looks at the path, so an API and a
+    web bundle built from different revisions used to report the missing route as
+    "Method Not Allowed" — which reads like a bug in a route that exists.
+    """
+    dist = tmp_path / "web"
+    dist.mkdir()
+    (dist / "index.html").write_text("<!doctype html>", encoding="utf-8")
+    monkeypatch.setenv("SUITEST_WEB_DIST", str(dist))
+
+    app = create_app()
+    client = TestClient(app)
+    resp = client.post("/api/v1/no-such-route", json={})
+    assert resp.status_code == 404, resp.text
+    assert "older than the web bundle" in resp.json()["detail"]
+
+    # GET must not silently serve the SPA for an API path either — a JSON caller
+    # parsing index.html is no easier to diagnose than the 405 was.
+    get = client.get("/api/v1/no-such-route")
+    assert get.status_code == 404
+    assert "<!doctype html>" not in get.text

--- a/apps/web/src/components/settings/LlmSettingsPanel.test.tsx
+++ b/apps/web/src/components/settings/LlmSettingsPanel.test.tsx
@@ -110,6 +110,25 @@ describe("LlmSettingsPanel", () => {
     });
   });
 
+  it("reports the status when the sign-in route answers an error", async () => {
+    // The regression this guards: an API older than the bundle answered 405 and
+    // the panel said only "Could not start the sign-in.", which reads like a
+    // rejected credential rather than a route that is not there.
+    server.use(
+      http.post("*/api/v1/workspaces/ws_1/llm-config/chatgpt/login", () =>
+        HttpResponse.json({ detail: "Method Not Allowed" }, { status: 405 }),
+      ),
+    );
+    renderPanel();
+    const user = userEvent.setup();
+    await screen.findByTestId("llm-none");
+    await user.click(screen.getByLabelText(/sign in with chatgpt/i));
+    await user.click(screen.getByTestId("chatgpt-signin-start"));
+
+    const err = await screen.findByText(/could not start the sign-in/i);
+    expect(err).toHaveTextContent(/405/);
+  });
+
   it("shows active config + Remove when configured", async () => {
     server.use(
       http.get("*/api/v1/workspaces/ws_1/llm-config", () =>

--- a/apps/web/src/components/settings/LlmSettingsPanel.tsx
+++ b/apps/web/src/components/settings/LlmSettingsPanel.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
 import {
+  ApiError,
   cancelChatGptLogin,
   type ChatGptCredentialMode,
   type ChatGptLoginStart,
@@ -65,7 +66,7 @@ function ChatGptSignIn({
       setFlow(started);
       if (started.authorizeUrl) window.open(started.authorizeUrl, "_blank", "noopener");
     },
-    onError: () => setError("Could not start the sign-in."),
+    onError: (err) => setError(loginError("Could not start the sign-in.", err)),
   });
 
   const statusQuery = useQuery({
@@ -85,7 +86,7 @@ function ChatGptSignIn({
       setFlow(null);
       onDone();
     },
-    onError: () => setError("Could not save the signed-in credential."),
+    onError: (err) => setError(loginError("Could not save the signed-in credential.", err)),
   });
 
   const cancel = (): void => {
@@ -226,6 +227,15 @@ interface LlmSettingsPanelProps {
   workspaceId: string;
   /** ADMIN+ may write; others see read-only status. */
   canWrite: boolean;
+}
+
+/** Keep the friendly sentence, but say what actually came back — a sign-in that
+ *  fails because the route is missing reads exactly like a rejected credential
+ *  otherwise. */
+function loginError(fallback: string, err: unknown): string {
+  if (!(err instanceof ApiError)) return fallback;
+  const detail = err.message.trim();
+  return detail ? `${fallback} (${err.status}: ${detail})` : `${fallback} (${err.status})`;
 }
 
 export function LlmSettingsPanel({

--- a/apps/web/src/components/shell/ProjectPicker.tsx
+++ b/apps/web/src/components/shell/ProjectPicker.tsx
@@ -32,7 +32,7 @@ export function ProjectPicker(): React.ReactElement | null {
   const active = projects.find((p) => p.id === projectId) ?? projects[0];
 
   return (
-    <div className="border-b border-border-subtle px-3 py-2">
+    <div className="shrink-0 border-b border-border-subtle px-3 py-2">
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <button

--- a/apps/web/src/components/shell/Sidebar.tsx
+++ b/apps/web/src/components/shell/Sidebar.tsx
@@ -159,7 +159,7 @@ export function Sidebar({
         data-testid="sidebar"
       >
         {/* Section 1 — Brand */}
-        <div className="flex h-[47px] items-center justify-between border-b border-border-subtle px-4">
+        <div className="flex h-[47px] shrink-0 items-center justify-between border-b border-border-subtle px-4">
           <span className="flex select-none items-center gap-2">
             <img src="/logo.svg" alt="" aria-hidden="true" className="h-6 w-6 rounded-md" />
             <span className="font-mono text-[15px] font-bold tracking-tight">
@@ -184,7 +184,7 @@ export function Sidebar({
         </div>
 
         {/* Section 2 — Workspace picker */}
-        <div className="border-b border-border-subtle px-3 py-3">
+        <div className="shrink-0 border-b border-border-subtle px-3 py-3">
           <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
             <PopoverTrigger asChild>
               <button
@@ -259,8 +259,11 @@ export function Sidebar({
         {/* Section 2b — Project picker (Test Cases / Runs are project-scoped) */}
         <ProjectPicker />
 
-        {/* Section 3 — Nav */}
-        <ScrollArea className="flex-1">
+        {/* Section 3 — Nav. min-h-0 is load-bearing: a flex child keeps
+            min-height:auto, so flex-1 alone let the nav grow to its content
+            height and push the rows below it out of the rail instead of
+            scrolling. Visible as soon as the page is zoomed in. */}
+        <ScrollArea className="min-h-0 flex-1">
           <nav className="px-2 py-3" aria-label="Primary">
             {groups.map((group) => (
               <div key={group.eyebrow} className="mb-4 last:mb-0">
@@ -280,7 +283,7 @@ export function Sidebar({
         </ScrollArea>
 
         {/* Section 4 — User footer */}
-        <div className="flex items-center gap-2 border-t border-border-subtle px-3 py-3">
+        <div className="flex shrink-0 items-center gap-2 border-t border-border-subtle px-3 py-3">
           <span
             className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-bg-elev-3 font-mono text-[11px] font-semibold text-fg-1"
             aria-hidden="true"
@@ -320,7 +323,7 @@ export function Sidebar({
             <LogOut className="h-4 w-4" aria-hidden="true" />
           </button>
         </div>
-        <div className="border-t border-border-subtle px-4 py-2 text-center text-[10px] text-fg-5">
+        <div className="shrink-0 border-t border-border-subtle px-4 py-2 text-center text-[10px] text-fg-5">
           © 2026 Suitest contributors · Apache-2.0
         </div>
       </aside>

--- a/apps/web/src/components/shell/ThemeToggle.tsx
+++ b/apps/web/src/components/shell/ThemeToggle.tsx
@@ -1,6 +1,7 @@
 import { Moon, Sun } from "lucide-react";
 import { useState } from "react";
 
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { getTheme, setTheme, type Theme } from "@/lib/theme";
 
 /**
@@ -13,22 +14,29 @@ export function ThemeToggle(): React.ReactElement {
   const [theme, setThemeState] = useState<Theme>(() => getTheme());
   const next: Theme = theme === "dark" ? "light" : "dark";
 
+  // The tooltip lives here rather than in the topbar because the label depends
+  // on state only this component holds. Relies on the topbar's TooltipProvider.
   return (
-    <button
-      type="button"
-      onClick={() => {
-        setTheme(next);
-        setThemeState(next);
-      }}
-      aria-label={`Switch to ${next} theme`}
-      className="flex h-7 w-7 items-center justify-center rounded-md text-fg-3 hover:bg-bg-elev-2 hover:text-fg-1"
-      data-testid="theme-toggle"
-    >
-      {theme === "dark" ? (
-        <Sun className="h-4 w-4" aria-hidden="true" />
-      ) : (
-        <Moon className="h-4 w-4" aria-hidden="true" />
-      )}
-    </button>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={() => {
+            setTheme(next);
+            setThemeState(next);
+          }}
+          aria-label={`Switch to ${next} theme`}
+          className="flex h-7 w-7 items-center justify-center rounded-md text-fg-3 hover:bg-bg-elev-2 hover:text-fg-1"
+          data-testid="theme-toggle"
+        >
+          {theme === "dark" ? (
+            <Sun className="h-4 w-4" aria-hidden="true" />
+          ) : (
+            <Moon className="h-4 w-4" aria-hidden="true" />
+          )}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{`Switch to ${next} theme`}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/apps/web/src/components/shell/Topbar.test.tsx
+++ b/apps/web/src/components/shell/Topbar.test.tsx
@@ -117,6 +117,21 @@ describe("<Topbar>", () => {
     expect(saweria).toHaveAttribute("target", "_blank");
   });
 
+  it("shows a tooltip when an icon-only control is hovered", async () => {
+    await renderTopbar("/dashboard");
+    const user = userEvent.setup();
+    await user.hover(screen.getByTestId("topbar-help-link"));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Help & documentation");
+  });
+
+  it("labels the theme toggle with the theme it switches to", async () => {
+    await renderTopbar("/dashboard");
+    const user = userEvent.setup();
+    await user.hover(screen.getByTestId("theme-toggle"));
+    const tip = await screen.findByRole("tooltip");
+    expect(tip.textContent).toMatch(/Switch to (light|dark) theme/);
+  });
+
   it("reflects current route title in breadcrumbs", async () => {
     await renderTopbar("/runs");
     const crumbs = await screen.findByTestId("topbar-breadcrumbs");

--- a/apps/web/src/components/shell/Topbar.test.tsx
+++ b/apps/web/src/components/shell/Topbar.test.tsx
@@ -13,10 +13,7 @@ import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { Topbar } from "@/components/shell/Topbar";
-import {
-  useCapabilities,
-  type Capabilities,
-} from "@/stores/use-capabilities";
+import { useCapabilities, type Capabilities } from "@/stores/use-capabilities";
 
 const ZERO_CAPS: Capabilities = {
   tier: "ZERO",
@@ -108,6 +105,16 @@ describe("<Topbar>", () => {
   it("renders the tier badge slot from useCapabilities", async () => {
     await renderTopbar("/dashboard");
     expect(screen.getByTestId("tier-badge")).toHaveTextContent("ZERO");
+  });
+
+  it("links the sponsor icons out to GitHub Sponsors and Saweria", async () => {
+    await renderTopbar("/dashboard");
+    const gh = screen.getByTestId("topbar-sponsor-link");
+    expect(gh).toHaveAttribute("href", "https://github.com/sponsors/suiflex");
+    expect(gh).toHaveAttribute("rel", "noopener noreferrer");
+    const saweria = screen.getByTestId("topbar-saweria-link");
+    expect(saweria).toHaveAttribute("href", "https://saweria.co/suiflex");
+    expect(saweria).toHaveAttribute("target", "_blank");
   });
 
   it("reflects current route title in breadcrumbs", async () => {

--- a/apps/web/src/components/shell/Topbar.tsx
+++ b/apps/web/src/components/shell/Topbar.tsx
@@ -59,6 +59,23 @@ export interface TopbarProps {
   onMenuClick?: () => void;
 }
 
+/** Icon-only controls say nothing on their own; the aria-label is read by
+ *  screen readers but never shown. Wrap them so a pointer gets the same text. */
+function IconTip({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactElement;
+}): React.ReactElement {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
 /** Where the sponsor icons point. Constants, not props: the project funds
  *  itself in exactly one place, and no caller has a reason to redirect them. */
 const SPONSOR_HREF = "https://github.com/sponsors/suiflex";
@@ -108,97 +125,105 @@ export function Topbar({
   );
 
   return (
-    <header
-      className="flex h-[47px] items-center gap-3 border-b border-border-subtle bg-bg-base px-4"
-      data-testid="topbar"
-    >
-      {/* Mobile — sidebar drawer trigger */}
-      {onMenuClick ? (
-        <button
-          type="button"
-          onClick={onMenuClick}
-          aria-label="Open navigation"
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-fg-3 hover:bg-bg-elev-2 hover:text-fg-1 md:hidden"
-          data-testid="topbar-menu-button"
-        >
-          <Menu className="h-4 w-4" aria-hidden="true" />
-        </button>
-      ) : null}
+    <TooltipProvider delayDuration={150}>
+      <header
+        className="flex h-[47px] items-center gap-3 border-b border-border-subtle bg-bg-base px-4"
+        data-testid="topbar"
+      >
+        {/* Mobile — sidebar drawer trigger */}
+        {onMenuClick ? (
+          <IconTip label="Open navigation">
+            <button
+              type="button"
+              onClick={onMenuClick}
+              aria-label="Open navigation"
+              className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-fg-3 hover:bg-bg-elev-2 hover:text-fg-1 md:hidden"
+              data-testid="topbar-menu-button"
+            >
+              <Menu className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </IconTip>
+        ) : null}
 
-      {/* Left — Breadcrumbs */}
-      <Breadcrumbs segments={breadcrumbs} />
+        {/* Left — Breadcrumbs */}
+        <Breadcrumbs segments={breadcrumbs} />
 
-      <div className="ml-auto flex shrink-0 items-center gap-2">
-        {/* Search palette trigger — full field ≥ sm, icon-only below */}
-        <button
-          type="button"
-          onClick={() => setCommandOpen(true)}
-          className="hidden h-7 w-[160px] items-center gap-2 rounded-md border border-border bg-bg-elev-1 px-2 text-left text-[12.5px] text-fg-4 hover:bg-bg-elev-2 sm:inline-flex lg:w-[220px]"
-          data-testid="topbar-search-trigger"
-        >
-          <Search className="h-3.5 w-3.5" aria-hidden="true" />
-          <span className="flex-1">Search…</span>
-          <kbd className="ml-auto inline-flex h-5 items-center gap-0.5 rounded border border-border bg-bg-elev-2 px-1 font-mono text-[10px] text-fg-3">
-            <span className="text-[10px]">⌘</span>K
-          </kbd>
-        </button>
-        <button
-          type="button"
-          onClick={() => setCommandOpen(true)}
-          aria-label="Search"
-          className="flex h-7 w-7 items-center justify-center rounded-md text-fg-3 hover:bg-bg-elev-2 hover:text-fg-1 sm:hidden"
-          data-testid="topbar-search-trigger-mobile"
-        >
-          <Search className="h-4 w-4" aria-hidden="true" />
-        </button>
+        <div className="ml-auto flex shrink-0 items-center gap-2">
+          {/* Search palette trigger — full field ≥ sm, icon-only below */}
+          <button
+            type="button"
+            onClick={() => setCommandOpen(true)}
+            className="hidden h-7 w-[160px] items-center gap-2 rounded-md border border-border bg-bg-elev-1 px-2 text-left text-[12.5px] text-fg-4 hover:bg-bg-elev-2 sm:inline-flex lg:w-[220px]"
+            data-testid="topbar-search-trigger"
+          >
+            <Search className="h-3.5 w-3.5" aria-hidden="true" />
+            <span className="flex-1">Search…</span>
+            <kbd className="ml-auto inline-flex h-5 items-center gap-0.5 rounded border border-border bg-bg-elev-2 px-1 font-mono text-[10px] text-fg-3">
+              <span className="text-[10px]">⌘</span>K
+            </kbd>
+          </button>
+          <IconTip label="Search">
+            <button
+              type="button"
+              onClick={() => setCommandOpen(true)}
+              aria-label="Search"
+              className="flex h-7 w-7 items-center justify-center rounded-md text-fg-3 hover:bg-bg-elev-2 hover:text-fg-1 sm:hidden"
+              data-testid="topbar-search-trigger-mobile"
+            >
+              <Search className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </IconTip>
 
-        {/* Language switcher (M4-12) */}
-        <LanguageSwitcher />
+          {/* Language switcher (M4-12) */}
+          <LanguageSwitcher />
 
-        {/* Dark / light theme toggle */}
-        <ThemeToggle />
+          {/* Dark / light theme toggle */}
+          <ThemeToggle />
 
-        {/* Sponsor icons */}
-        <a
-          href={SPONSOR_HREF}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Sponsor Suitest on GitHub"
-          title="Sponsor Suitest on GitHub"
-          className="flex h-7 w-7 items-center justify-center rounded-md text-fg-3 hover:bg-bg-elev-2 hover:text-fg-1"
-          data-testid="topbar-sponsor-link"
-        >
-          <HeartHandshake className="h-4 w-4" aria-hidden="true" />
-        </a>
+          {/* Sponsor icons */}
+          <IconTip label="Sponsor Suitest on GitHub">
+            <a
+              href={SPONSOR_HREF}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Sponsor Suitest on GitHub"
+              className="flex h-7 w-7 items-center justify-center rounded-md text-fg-3 hover:bg-bg-elev-2 hover:text-fg-1"
+              data-testid="topbar-sponsor-link"
+            >
+              <HeartHandshake className="h-4 w-4" aria-hidden="true" />
+            </a>
+          </IconTip>
 
-        <a
-          href={SAWERIA_HREF}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Support Suitest on Saweria"
-          title="Support Suitest on Saweria"
-          className="flex h-7 w-7 items-center justify-center rounded-md text-fg-3 hover:bg-bg-elev-2 hover:text-fg-1"
-          data-testid="topbar-saweria-link"
-        >
-          <Coffee className="h-4 w-4" aria-hidden="true" />
-        </a>
+          <IconTip label="Support Suitest on Saweria">
+            <a
+              href={SAWERIA_HREF}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Support Suitest on Saweria"
+              className="flex h-7 w-7 items-center justify-center rounded-md text-fg-3 hover:bg-bg-elev-2 hover:text-fg-1"
+              data-testid="topbar-saweria-link"
+            >
+              <Coffee className="h-4 w-4" aria-hidden="true" />
+            </a>
+          </IconTip>
 
-        {/* Help icon */}
-        <a
-          href={helpHref}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Help"
-          className="flex h-7 w-7 items-center justify-center rounded-md text-fg-3 hover:bg-bg-elev-2 hover:text-fg-1"
-          data-testid="topbar-help-link"
-        >
-          <HelpCircle className="h-4 w-4" aria-hidden="true" />
-        </a>
+          {/* Help icon */}
+          <IconTip label="Help & documentation">
+            <a
+              href={helpHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Help"
+              className="flex h-7 w-7 items-center justify-center rounded-md text-fg-3 hover:bg-bg-elev-2 hover:text-fg-1"
+              data-testid="topbar-help-link"
+            >
+              <HelpCircle className="h-4 w-4" aria-hidden="true" />
+            </a>
+          </IconTip>
 
-        <TierBadge />
+          <TierBadge />
 
-        {/* + New (disabled in M1b) */}
-        <TooltipProvider delayDuration={150}>
+          {/* + New (disabled in M1b) */}
           <Tooltip>
             <TooltipTrigger asChild>
               {/* Wrapping span lets the tooltip fire even when the underlying
@@ -219,37 +244,37 @@ export function Topbar({
             </TooltipTrigger>
             <TooltipContent>Authoring tools enabled in M1d</TooltipContent>
           </Tooltip>
-        </TooltipProvider>
-      </div>
+        </div>
 
-      <CommandDialog
-        open={commandOpen}
-        onOpenChange={setCommandOpen}
-        title="Command palette"
-        description="Jump to a screen"
-      >
-        <CommandInput placeholder="Type a command or search…" />
-        <CommandList data-testid="topbar-command-list">
-          <CommandEmpty>No results.</CommandEmpty>
-          <CommandGroup heading="Navigate">
-            {COMMAND_TARGETS.map((target) => {
-              const Icon = target.icon;
-              return (
-                <CommandItem
-                  key={target.to}
-                  value={target.label}
-                  onSelect={() => runCommand(target.to)}
-                  data-testid={`command-item-${target.to.replace(/\//g, "")}`}
-                >
-                  <Icon className="h-4 w-4" aria-hidden="true" />
-                  <span>{target.label}</span>
-                </CommandItem>
-              );
-            })}
-          </CommandGroup>
-        </CommandList>
-      </CommandDialog>
-    </header>
+        <CommandDialog
+          open={commandOpen}
+          onOpenChange={setCommandOpen}
+          title="Command palette"
+          description="Jump to a screen"
+        >
+          <CommandInput placeholder="Type a command or search…" />
+          <CommandList data-testid="topbar-command-list">
+            <CommandEmpty>No results.</CommandEmpty>
+            <CommandGroup heading="Navigate">
+              {COMMAND_TARGETS.map((target) => {
+                const Icon = target.icon;
+                return (
+                  <CommandItem
+                    key={target.to}
+                    value={target.label}
+                    onSelect={() => runCommand(target.to)}
+                    data-testid={`command-item-${target.to.replace(/\//g, "")}`}
+                  >
+                    <Icon className="h-4 w-4" aria-hidden="true" />
+                    <span>{target.label}</span>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+        </CommandDialog>
+      </header>
+    </TooltipProvider>
   );
 }
 

--- a/apps/web/src/components/shell/Topbar.tsx
+++ b/apps/web/src/components/shell/Topbar.tsx
@@ -3,7 +3,9 @@ import {
   BarChart3,
   BookOpen,
   Bug,
+  Coffee,
   FileCode2,
+  HeartHandshake,
   HelpCircle,
   Inbox,
   LayoutDashboard,
@@ -56,6 +58,11 @@ export interface TopbarProps {
   /** Opens the mobile sidebar drawer (< md). Hamburger hidden when omitted. */
   onMenuClick?: () => void;
 }
+
+/** Where the sponsor icons point. Constants, not props: the project funds
+ *  itself in exactly one place, and no caller has a reason to redirect them. */
+const SPONSOR_HREF = "https://github.com/sponsors/suiflex";
+const SAWERIA_HREF = "https://saweria.co/suiflex";
 
 /**
  * Persistent top bar (47px). Breadcrumbs left, search palette + tier badge +
@@ -150,6 +157,31 @@ export function Topbar({
 
         {/* Dark / light theme toggle */}
         <ThemeToggle />
+
+        {/* Sponsor icons */}
+        <a
+          href={SPONSOR_HREF}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Sponsor Suitest on GitHub"
+          title="Sponsor Suitest on GitHub"
+          className="flex h-7 w-7 items-center justify-center rounded-md text-fg-3 hover:bg-bg-elev-2 hover:text-fg-1"
+          data-testid="topbar-sponsor-link"
+        >
+          <HeartHandshake className="h-4 w-4" aria-hidden="true" />
+        </a>
+
+        <a
+          href={SAWERIA_HREF}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Support Suitest on Saweria"
+          title="Support Suitest on Saweria"
+          className="flex h-7 w-7 items-center justify-center rounded-md text-fg-3 hover:bg-bg-elev-2 hover:text-fg-1"
+          data-testid="topbar-saweria-link"
+        >
+          <Coffee className="h-4 w-4" aria-hidden="true" />
+        </a>
 
         {/* Help icon */}
         <a

--- a/packages/suitest-npx/lib/venv.js
+++ b/packages/suitest-npx/lib/venv.js
@@ -84,7 +84,10 @@ function ensureVenv(venvDir, wheelsDir) {
   console.log(
     "Setting up the Python runtime (first run or new version — may download Python 3.12, ~1 min)...",
   );
-  execFileSync("uv", ["venv", venvDir, "--python", "3.12"], { stdio: "inherit" });
+  // --clear: reaching here means the venv is stale, and uv refuses to write over
+  // an existing one without it. Without the flag every invalidation is a hard
+  // failure the user has to clear by hand.
+  execFileSync("uv", ["venv", venvDir, "--clear", "--python", "3.12"], { stdio: "inherit" });
   execFileSync("uv", ["pip", "install", "--python", python, ...wheels], {
     stdio: "inherit",
   });

--- a/packages/suitest-npx/lib/venv.js
+++ b/packages/suitest-npx/lib/venv.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const crypto = require("node:crypto");
 const fs = require("node:fs");
 const path = require("node:path");
 const { execFileSync, spawnSync } = require("node:child_process");
@@ -37,14 +38,36 @@ function venvPython(venvDir) {
     : path.join(venvDir, "bin", "python");
 }
 
-// Per-project venv from the release wheels; marker records the installed bundle version.
+// Identifies the wheel set a venv was built from. The package version alone is
+// not enough: rebuilding wheels from a working tree leaves it untouched, so the
+// stale venv was reused while SUITEST_WEB_DIST already pointed at the fresh web
+// bundle — a new dashboard talking to an API that lacks its routes.
+// ponytail: name+size+mtime, not a content hash — enough to catch a local
+// rebuild. Hash the bytes if a build ever starts preserving mtimes.
+function wheelsFingerprint(wheelsDir) {
+  const h = crypto.createHash("sha256").update(pkg.version);
+  const wheels = fs.existsSync(wheelsDir)
+    ? fs
+        .readdirSync(wheelsDir)
+        .filter((f) => f.endsWith(".whl"))
+        .sort()
+    : [];
+  for (const name of wheels) {
+    const st = fs.statSync(path.join(wheelsDir, name));
+    h.update(`\0${name}\0${st.size}\0${st.mtimeMs}`);
+  }
+  return h.digest("hex").slice(0, 16);
+}
+
+// Per-project venv from the release wheels; marker records the installed bundle.
 function ensureVenv(venvDir, wheelsDir) {
   const marker = path.join(venvDir, ".bundle-version");
   const python = venvPython(venvDir);
+  const fingerprint = wheelsFingerprint(wheelsDir);
   if (
     fs.existsSync(python) &&
     fs.existsSync(marker) &&
-    fs.readFileSync(marker, "utf8") === pkg.version
+    fs.readFileSync(marker, "utf8") === fingerprint
   ) {
     return python;
   }
@@ -65,8 +88,15 @@ function ensureVenv(venvDir, wheelsDir) {
   execFileSync("uv", ["pip", "install", "--python", python, ...wheels], {
     stdio: "inherit",
   });
-  fs.writeFileSync(marker, pkg.version);
+  fs.writeFileSync(marker, fingerprint);
   return python;
 }
 
-module.exports = { requireUv, uvInstallCommand, uvInstallHint, ensureVenv, venvPython };
+module.exports = {
+  requireUv,
+  uvInstallCommand,
+  uvInstallHint,
+  ensureVenv,
+  venvPython,
+  wheelsFingerprint,
+};

--- a/packages/suitest-npx/test/venv.test.js
+++ b/packages/suitest-npx/test/venv.test.js
@@ -5,8 +5,7 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 
-const { requireUv, ensureVenv, venvPython } = require("../lib/venv.js");
-const pkg = require("../package.json");
+const { requireUv, ensureVenv, venvPython, wheelsFingerprint } = require("../lib/venv.js");
 
 function tmp() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "suitest-venv-"));
@@ -28,14 +27,32 @@ test("venvPython points into bin/ (posix) or Scripts/ (win)", () => {
   else assert.strictEqual(p, "/x/.venv/bin/python");
 });
 
-test("ensureVenv short-circuits when marker matches package version", () => {
-  const venvDir = path.join(tmp(), ".venv");
+test("ensureVenv short-circuits when the marker matches the wheel set", () => {
+  const dir = tmp();
+  const venvDir = path.join(dir, ".venv");
+  const wheels = path.join(dir, "wheels");
+  fs.mkdirSync(wheels);
+  fs.writeFileSync(path.join(wheels, "suitest_api-0.1.0-py3-none-any.whl"), "a");
   const python = venvPython(venvDir);
   fs.mkdirSync(path.dirname(python), { recursive: true });
   fs.writeFileSync(python, "");
-  fs.writeFileSync(path.join(venvDir, ".bundle-version"), pkg.version);
-  // wheelsDir unused on the cache-hit path — bogus path proves the short-circuit
-  assert.strictEqual(ensureVenv(venvDir, "/nonexistent"), python);
+  fs.writeFileSync(path.join(venvDir, ".bundle-version"), wheelsFingerprint(wheels));
+  assert.strictEqual(ensureVenv(venvDir, wheels), python);
+});
+
+test("wheelsFingerprint changes when a wheel is rebuilt at the same version", () => {
+  const dir = tmp();
+  const wheels = path.join(dir, "wheels");
+  fs.mkdirSync(wheels);
+  const whl = path.join(wheels, "suitest_api-0.1.0-py3-none-any.whl");
+  fs.writeFileSync(whl, "old build");
+  const before = wheelsFingerprint(wheels);
+  // Same package version, same filename — only the built artifact changed. This
+  // is the case that used to reuse a stale venv and serve an API without the
+  // routes the freshly built dashboard calls.
+  fs.writeFileSync(whl, "new build, different size");
+  assert.notStrictEqual(wheelsFingerprint(wheels), before);
+  assert.strictEqual(wheelsFingerprint(wheels), wheelsFingerprint(wheels));
 });
 
 test("ensureVenv with empty wheels dir throws", () => {


### PR DESCRIPTION
## Summary

- A ChatGPT sign-in that failed with `405 Method Not Allowed` had no way to
  explain itself: the SPA mount answers every non-GET before it looks at the
  path, so a route the running API does not have reports as a broken method
  rather than a missing one. That is now a 404 that names the likely cause.
- The launcher's venv cache was keyed on the package version, so rebuilding
  wheels from a working tree never reinstalled them — a fresh dashboard could
  run against a stale API indefinitely.
- Two UI fixes and a contributing guide that no longer assumes Docker.

## Changes

**Local bundle (`packages/suitest-npx`)**
- `ensureVenv` keys its marker on a hash of the version plus every wheel's
  name, size and mtime, so a rebuild invalidates the venv.
- `uv venv` is called with `--clear`. uv refuses to overwrite an existing
  environment, so every invalidation used to end in "A virtual environment
  already exists" and left the user to delete the directory by hand.

**API (`apps/api`)**
- Paths under `/api`, `/auth` and `/ws` that match no router return 404 with a
  message pointing at a version skew, instead of reaching the static mount.
- The four `chatgpt/login` routes gained HTTP-level tests. They previously had
  none: the service and the frontend were covered, nothing asserted the routes
  answer on the paths the frontend calls.

**Web (`apps/web`)**
- The LLM panel appends the status and detail to the sign-in error, instead of
  the same sentence for every failure mode.
- The sidebar nav scrolls again. Its `flex-1` never made it shrink, because a
  flex child keeps `min-height: auto`, so it grew to its content height and
  pushed the user row and licence strip out of the rail.
- Sponsor links (GitHub Sponsors, Saweria) next to the topbar help icon.

**Docs**
- `CONTRIBUTING.md` splits setup into the Docker stack and the local bundle,
  with a table of the differences that decide the choice, and corrects the
  quality-gate commands: ruff is scoped to `apps packages`, and mypy runs once
  per package because a single call fails on duplicate conftest modules.
- The Docker walkthrough starts the services before `make setup`; its last two
  steps migrate and seed, so the previous order could not work.
- The PR checklist points at the make targets rather than repeating commands
  that were wrong.

## Test plan

- [x] `test_static_serving.py` — 4 passed. With the guard stashed the new test
      fails `assert 405 == 404`, so it reproduces the reported symptom.
- [x] `npm test` in `packages/suitest-npx` — 48 passed, 0 failed.
- [x] `vitest` — `Sidebar` 12/12, `Topbar` 9/9, `LlmSettingsPanel` 7/7.
- [x] `make lint` — ruff clean, 650 files formatted.
- [x] mypy strict, all seven packages — no issues.
- [x] `pnpm lint` + `pnpm typecheck` — clean.
- [x] Booted the local bundle from freshly built wheels: the venv reinstalled
      itself, the stack came up, `/openapi.json` lists all four chatgpt routes,
      and POST to the sign-in path returns 401 from the auth gate — not 405.
- [x] `/api`, `/auth` and `/ws` all return the skew 404 against the live stack.
- [x] `apps/api/tests/test_llm_config.py` — 12 collected, 0 executed. No
      Postgres with pgvector available locally; the four new assertions run in
      CI only.

## Notes

`vitest` reports 18 files / 64 tests failing, identical on `main` and on this
branch (this branch adds 2 passing tests, 339 -> 341). Locally they are mostly
`localStorage` being undefined under Node's experimental implementation. Not
introduced here, and not addressed here.

The specific 405 that prompted this was never traced to a running process: the
venv in the reporter's project directory already contained the route, its log
has no activity from that day, and the workspace id in the report does not
appear in any local database. What is verified is the mechanism — the static
mount does answer 405 for a POST to an unregistered `/api` path — not which
process produced that particular response.

### Evidance
<img width="1488" height="1005" alt="WhatsApp Image 2026-08-20 at 21 35 13" src="https://github.com/user-attachments/assets/69d72906-e0c2-460f-b8ba-5ae7084da6a9" />
