### PR TITLE
fix(ci): use the input name the CLA action actually reads

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -26,7 +26,10 @@ jobs:
           path-to-document: https://github.com/suiflex/suitest/blob/main/CLA.md
           branch: cla-signatures
           allowlist: badrus123,mulhamna,*[bot]
-          custom-notsigned-comment: >
+          # `custom-notsigned-prcomment`, not `custom-notsigned-comment`. The
+          # action ignores an unknown input with only a warning, so the wrong
+          # name silently fell back to the default text instead of failing.
+          custom-notsigned-prcomment: >
             Thanks for your contribution! Before we can merge, please read our
             [Contributor License Agreement](https://github.com/suiflex/suitest/blob/main/CLA.md)
             and sign it by posting the comment below.


### PR DESCRIPTION
## Summary

- The CLA workflow's custom "please sign" message has never been shown. It is passed as `custom-notsigned-comment`, but the action's input is `custom-notsigned-prcomment`.
- The action ignores an unknown input with a **warning, not an error**, so the run stays green and the wording silently falls back to the action's default text. Nothing ever pointed at it.

## Changes

- `.github/workflows/cla.yml` — rename the input to `custom-notsigned-prcomment`, and note in a comment why the wrong name failed quietly.

## Test plan

- [x] Every input in the step checked against the valid list the action prints in its run log — all eight now match
- [x] `check yaml` and the rest of pre-commit pass
- [ ] Confirmed on the next pull request from an unsigned contributor: the bot's comment should carry this repo's wording instead of the default

## Notes for reviewers

Found from a warning line in a run log on `suiflex/rdb`, which inherited this workflow file and therefore the same typo. The identical fix has been applied there.

The warning is easy to miss — it sits above the `Run contributor-assistant/...` group in the log and the job still reports success:

```
##[warning]Unexpected input(s) 'custom-notsigned-comment', valid inputs are
['path-to-signatures', 'branch', 'allowlist', ..., 'custom-notsigned-prcomment', ...]
```

Unrelated but noticed while checking, and worth someone's attention separately: `signatures/version1/cla.json` on the `cla-signatures` branch is still `{"signedContributors":[]}`, while `Manan-byte` and `SeptianEPN` both landed commits in August, after the CLA existed. That is consistent with the storage branch being misconfigured between `72db4cf` and `48bdae5`, and suggests no signature has ever actually been recorded here.