### PR TITLE
feat(mcp): drag, video and event recording for slint desktop tests

### DIFF
--- a/apps/api/src/suitest_api/routers/runs.py
+++ b/apps/api/src/suitest_api/routers/runs.py
@@ -178,6 +178,20 @@ async def get_run(
     )
 
 
+#: A step's output rides along in the list response, so it is capped: a tree
+#: dump can run to megabytes, and the whole thing belongs in the log stream
+#: rather than in every row of a run's step table.
+_MAX_STEP_OUTPUT = 8000
+
+
+def _step_output(stdout: str | None) -> str | None:
+    if not stdout:
+        return None
+    if len(stdout) <= _MAX_STEP_OUTPUT:
+        return stdout
+    return stdout[:_MAX_STEP_OUTPUT] + "\n… truncated; see the run log for the rest"
+
+
 @router.get("/runs/{run_id}/steps", response_model=list[RunStepPublic])
 async def get_run_steps(
     run_id: str,
@@ -206,6 +220,7 @@ async def get_run_steps(
                 completed_at=step.completed_at,
                 duration_ms=step.duration_ms,
                 error_message=step.error_message,
+                stdout=_step_output(step.stdout),
             )
         )
     return out

--- a/apps/api/src/suitest_api/schemas/ingest.py
+++ b/apps/api/src/suitest_api/schemas/ingest.py
@@ -63,7 +63,11 @@ class BulkImportBody(_Camel):
     project_slug: str = Field(default="", alias="projectSlug")
     project_name: str = Field(default="", alias="projectName")
     suite_name: str = Field(alias="suiteName")
-    mode: str = "backend"  # backend | frontend -> target_kind / mcp_provider defaults
+    mode: str = "backend"  # backend | frontend | desktop -> target_kind / provider defaults
+    # Overrides the mode's default provider. A desktop suite needs it: FE_DESKTOP
+    # defaults to screen-level automation, while a Slint or Electron app is
+    # driven through its own bridge.
+    mcp_provider: str = Field(default="", alias="mcpProvider")
     cases: list[IngestCase] = Field(default_factory=list)
     # Retest change-detection: mark MCP-sourced cases in this suite that the
     # current generation no longer produced as STALE (re-import reactivates).

--- a/apps/api/src/suitest_api/schemas/run.py
+++ b/apps/api/src/suitest_api/schemas/run.py
@@ -57,6 +57,10 @@ class RunStepPublic(BaseModel):
     completed_at: datetime | None = None
     duration_ms: int | None = None
     error_message: str | None = None
+    # What the step's tool returned. A diagnostic step (an event recording, a
+    # tree dump) carries its whole answer here, so leaving it out of the
+    # response made the step look like it had done nothing at all.
+    stdout: str | None = None
 
 
 class StateChangePublic(BaseModel):

--- a/apps/api/src/suitest_api/services/ingest_service.py
+++ b/apps/api/src/suitest_api/services/ingest_service.py
@@ -270,8 +270,16 @@ async def _find_case(
 
 
 def _target(mode: str) -> tuple[TargetKind, str]:
+    """Target kind and default provider for a publisher's `mode`.
+
+    Desktop suites default to screen-level automation; an app with its own
+    bridge (`slint-mcp`, `electron-mcp`) names it via `mcpProvider`, since the
+    mode alone cannot tell a Slint window from an Electron one.
+    """
     if mode == "frontend":
         return TargetKind.FE_WEB, "playwright-mcp"
+    if mode == "desktop":
+        return TargetKind.FE_DESKTOP, "computer-use-mcp"
     return TargetKind.BE_REST, "api-http-mcp"
 
 
@@ -287,7 +295,8 @@ async def bulk_import_cases(
     )
     suite_id = await _ensure_suite(session, project_id, body.suite_name)
     case_repo = TestCaseRepo(session)
-    target_kind, mcp_provider = _target(body.mode)
+    target_kind, default_provider = _target(body.mode)
+    mcp_provider = body.mcp_provider or default_provider
     imported: list[ImportedCase] = []
     strategy_ids = {case.strategy_id for case in body.cases if case.strategy_id}
     if strategy_ids:

--- a/apps/api/tests/services/test_ingest_service.py
+++ b/apps/api/tests/services/test_ingest_service.py
@@ -23,16 +23,26 @@ from suitest_api.schemas.ingest import (
 from suitest_api.services.ingest_service import (
     ProjectNotFoundError,
     _sanitize_automation_code,
+    _target,
     bulk_import_cases,
     ingest_run,
     resolve_project,
 )
 from suitest_db.models.case import TestCase
 from suitest_db.models.run import Run, RunStep
-from suitest_shared.domain.enums import CaseStatus, RunStatus
+from suitest_shared.domain.enums import CaseStatus, RunStatus, TargetKind
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from api_harness import ApiDb
+
+
+def test_target_routes_desktop_away_from_the_rest_default() -> None:
+    """A desktop suite used to land on BE_REST + the HTTP provider, because
+    anything that was not "frontend" fell through to the backend default — so
+    its steps were dispatched to a provider that cannot drive a window."""
+    assert _target("frontend") == (TargetKind.FE_WEB, "playwright-mcp")
+    assert _target("backend") == (TargetKind.BE_REST, "api-http-mcp")
+    assert _target("desktop") == (TargetKind.FE_DESKTOP, "computer-use-mcp")
 
 
 def test_ingest_sanitizes_legacy_inline_credentials() -> None:

--- a/apps/web/src/components/runs/StepTable.test.tsx
+++ b/apps/web/src/components/runs/StepTable.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { StepTable } from "@/components/runs/StepTable";
+import type { components } from "@/lib/api-types";
+
+type RunStepPublic = components["schemas"]["RunStepPublic"];
+
+function step(overrides: Partial<RunStepPublic> = {}): RunStepPublic {
+  return {
+    id: "rs_01",
+    run_id: "run_1",
+    case_id: "tc_1",
+    case_public_id: "TC-1004",
+    step_order: 0,
+    outcome: "PASS",
+    ...overrides,
+  } as RunStepPublic;
+}
+
+describe("<StepTable>", () => {
+  it("shows what a step's tool returned", () => {
+    // A diagnostic step — an event recording, a tree dump — carries its whole
+    // answer in stdout, so a table that only renders errors makes a passing
+    // step look like it did nothing.
+    render(<StepTable steps={[step({ stdout: '{"events": [{"result": "Ignored"}]}' })]} />);
+
+    expect(screen.getByTestId("step-output")).toBeInTheDocument();
+    expect(screen.getByText(/"result": "Ignored"/)).toBeInTheDocument();
+  });
+
+  it("renders no output block when the step returned nothing", () => {
+    render(<StepTable steps={[step()]} />);
+    expect(screen.queryByTestId("step-output")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/runs/StepTable.tsx
+++ b/apps/web/src/components/runs/StepTable.tsx
@@ -105,6 +105,16 @@ export function StepTable({
                       {s.error_message}
                     </pre>
                   ) : null}
+                  {s.stdout ? (
+                    <details data-testid="step-output">
+                      <summary className="cursor-pointer font-mono text-[10.5px] uppercase tracking-wide text-fg-5">
+                        Output
+                      </summary>
+                      <pre className="mt-1 max-h-64 overflow-auto rounded-md bg-bg-code p-2 font-mono text-[11px] text-fg-3">
+                        {s.stdout}
+                      </pre>
+                    </details>
+                  ) : null}
                 </div>
               </td>
               <td className="px-3 py-2">

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -3929,6 +3929,11 @@ export interface components {
              */
             markStale: boolean;
             /**
+             * Mcpprovider
+             * @default
+             */
+            mcpProvider: string;
+            /**
              * Mode
              * @default backend
              */
@@ -6952,6 +6957,8 @@ export interface components {
             run_id: string;
             /** Started At */
             started_at?: string | null;
+            /** Stdout */
+            stdout?: string | null;
             /** Step Order */
             step_order: number;
             /**

--- a/docs/DESKTOP_TESTING.md
+++ b/docs/DESKTOP_TESTING.md
@@ -162,6 +162,8 @@ describing the catalog below. Suitest's `invoker` calls them through the normal
 | `slint.get_property` | `selector`, `property?` | current value of the resolved element (text / checked / value) |
 | `slint.set_property` | `selector`, `value`, `property?` | writes the value |
 | `slint.click` | `selector` | dispatches `accessible-action-default()` on the element |
+| `slint.drag` | `selector`, `to_id`/`to_label` or `x`+`y`, `button?` | presses at the element's centre, interpolates to the destination, releases — range selection, sliders, reordering |
+| `slint.accessibility_action` | `selector`, `action` | invokes an accessible action (`Default_`, `Increment`, `Decrement`, ...) |
 | `slint.type_text` | `selector`, `text`, `clear?` | sets text-input content (focused) |
 | `slint.check` / `slint.uncheck` | `selector` | toggles a check box |
 
@@ -185,7 +187,7 @@ describing the catalog below. Suitest's `invoker` calls them through the normal
 | Tool | Params | Returns |
 |------|--------|---------|
 | `slint.screenshot` | `selector?` | base64 PNG of window / element |
-| `slint.snapshot` | — | accessible-tree dump (id, role, label, text, state) for debugging/stepping |
+| `slint.element_tree` | `max_elements?` | flat dump of the window's elements (ids, labels, handles) for debugging/stepping |
 
 ---
 

--- a/docs/DESKTOP_TESTING.md
+++ b/docs/DESKTOP_TESTING.md
@@ -188,6 +188,7 @@ describing the catalog below. Suitest's `invoker` calls them through the normal
 |------|--------|---------|
 | `slint.screenshot` | `selector?` | base64 PNG of window / element |
 | `slint.element_tree` | `max_elements?` | flat dump of the window's elements (ids, labels, handles) for debugging/stepping |
+| `slint.start_recording` / `slint.stop_recording` | — | the events the app received between the two calls, each with `Accepted` or `Ignored` — separates "the step never arrived" from "the app ignored it" |
 
 ---
 

--- a/docs/DESKTOP_TESTING.md
+++ b/docs/DESKTOP_TESTING.md
@@ -188,6 +188,7 @@ describing the catalog below. Suitest's `invoker` calls them through the normal
 |------|--------|---------|
 | `slint.screenshot` | `selector?` | base64 PNG of window / element |
 | `slint.element_tree` | `max_elements?` | flat dump of the window's elements (ids, labels, handles) for debugging/stepping |
+| `slint.start_video` / `slint.stop_video` | `interval_ms?` | frames sampled between the two calls, encoded to MP4 by ffmpeg and attached as a VIDEO artifact — the run shows the interaction, not just its end state |
 | `slint.start_recording` / `slint.stop_recording` | — | the events the app received between the two calls, each with `Accepted` or `Ignored` — separates "the step never arrived" from "the app ignored it" |
 
 ---

--- a/packages/db/src/suitest_db/bootstrap.py
+++ b/packages/db/src/suitest_db/bootstrap.py
@@ -1,20 +1,60 @@
 """Schema creation for local mode (SQLite) — straight from models, no Alembic.
 
-ponytail: fresh local DBs only. There is no local-schema upgrade path between
-releases yet — add versioning (e.g. PRAGMA user_version) once local mode first
-needs a migration.
+`create_all` only ever adds missing *tables*, so a database created by an
+earlier release kept its old columns and every query naming a new one failed
+with ``no such column`` — the release notes said nothing, and the dashboard
+answered 500. Local mode now also adds columns that the models grew.
+
+ponytail: additive only. A column that was dropped, renamed or retyped still
+needs a real migration; this covers the case local mode actually hits, which is
+a release adding a nullable-or-defaulted column.
 """
 
-from sqlalchemy.ext.asyncio import AsyncEngine
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import inspect, text
+from sqlalchemy.schema import CreateColumn
 
 import suitest_db.models  # noqa: F401  # side-effect: register every model on Base.metadata
 from suitest_db.base import Base
 
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Connection
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
 
 async def create_local_schema(engine: AsyncEngine) -> None:
-    """Create all tables for a fresh local database."""
+    """Create the local schema, and add any columns the models have grown."""
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+        await conn.run_sync(_add_missing_columns)
+
+
+def _add_missing_columns(conn: Connection) -> None:
+    """``ALTER TABLE ... ADD COLUMN`` for model columns the database lacks.
+
+    The column spec is rendered by SQLAlchemy's own `CreateColumn`, so a NOT
+    NULL column with a server default arrives exactly as the model declares it. A NOT NULL column
+    *without* a default cannot be added to a table that already has rows, so it
+    is skipped rather than crashing startup: adding one is a real migration.
+    """
+    inspector = inspect(conn)
+    existing_tables = set(inspector.get_table_names())
+    # Not `sorted_tables`: ALTER order is irrelevant here, and sorting warns
+    # about the projects/suites FK cycle for nothing.
+    for table in Base.metadata.tables.values():
+        if table.name not in existing_tables:
+            continue
+        present = {column["name"] for column in inspector.get_columns(table.name)}
+        for column in table.columns:
+            if column.name in present:
+                continue
+            if not column.nullable and column.server_default is None:
+                continue
+            spec = CreateColumn(column).compile(dialect=conn.dialect)
+            conn.execute(text(f"ALTER TABLE {table.name} ADD COLUMN {spec}"))
 
 
 def _main() -> None:

--- a/packages/db/tests/test_sqlite_dialect.py
+++ b/packages/db/tests/test_sqlite_dialect.py
@@ -159,3 +159,29 @@ async def test_public_id_generated_on_sqlite(tmp_path: Path) -> None:
         assert await generate_public_id(session, "R", ws.id) == "R-1000"
         await session.commit()
     await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_create_local_schema_adds_columns_a_release_grew(tmp_path: Path) -> None:
+    """A database made by an earlier release keeps its tables, so `create_all`
+    skips them and any column added since stays missing — which surfaced as
+    `no such column` 500s, not as anything the user could act on."""
+    import sqlalchemy as sa
+    from sqlalchemy.ext.asyncio import create_async_engine
+    from suitest_db.bootstrap import create_local_schema
+
+    url = f"sqlite+aiosqlite:///{tmp_path / 'old.db'}"
+    engine = create_async_engine(url)
+    try:
+        await create_local_schema(engine)
+        async with engine.begin() as conn:
+            await conn.execute(sa.text("ALTER TABLE llm_configs DROP COLUMN auth_method"))
+
+        await create_local_schema(engine)
+
+        async with engine.begin() as conn:
+            rows = await conn.execute(sa.text("PRAGMA table_info(llm_configs)"))
+            columns = {row[1] for row in rows}
+        assert "auth_method" in columns
+    finally:
+        await engine.dispose()

--- a/packages/mcp/src/suitest_mcp/bundled/in_process_runtime.py
+++ b/packages/mcp/src/suitest_mcp/bundled/in_process_runtime.py
@@ -32,7 +32,13 @@ from typing import TYPE_CHECKING, Any, Protocol
 import anyio
 from mcp.server import Server
 from mcp.shared.memory import create_client_server_memory_streams
-from mcp.types import CallToolResult, ImageContent, ListToolsResult, TextContent
+from mcp.types import (
+    CallToolResult,
+    EmbeddedResource,
+    ImageContent,
+    ListToolsResult,
+    TextContent,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable, Sequence
@@ -57,12 +63,14 @@ class BundledServer(Protocol):
 
     async def call_tool(
         self, name: str, arguments: dict[str, Any]
-    ) -> Sequence[TextContent | ImageContent]:
+    ) -> Sequence[TextContent | ImageContent | EmbeddedResource]:
         """Dispatch a tool invocation and return MCP content blocks.
 
-        Image blocks are carried through to ``CallToolResult`` unchanged, which
-        is how a provider produces a run artifact (the client decodes them in
-        ``suitest_mcp.client``).
+        Image and embedded-resource blocks are carried through to
+        ``CallToolResult`` unchanged, which is how a provider produces a run
+        artifact — a screenshot as an image, anything else (a recording, a
+        trace) as a resource blob. The client decodes both in
+        ``suitest_mcp.client``.
         """
         ...
 

--- a/packages/mcp/src/suitest_mcp/bundled/slint.py
+++ b/packages/mcp/src/suitest_mcp/bundled/slint.py
@@ -27,6 +27,9 @@ Tool surface (mirrored in :mod:`suitest_mcp.providers.builtin_specs`):
   steps against an app whose ids you don't know yet.
 * ``slint.start_recording`` / ``slint.stop_recording`` — the events Slint
   actually received, and whether it accepted or ignored each one.
+* ``slint.start_video`` / ``slint.stop_video`` — sample the window while a
+  gesture runs and hand back an MP4, so a run shows the interaction rather than
+  its end state.
 * ``slint.accessibility_action`` — invoke an accessible action (``Default_``,
   ``Increment``, ``Decrement``, ...) on an element.
 * ``slint.press_key``      — send a key/text event to the focused element.
@@ -52,14 +55,18 @@ reached through ``get_window_properties`` instead.
 from __future__ import annotations
 
 import asyncio
+import base64
+import contextlib
 import json
 import os
 import shutil
 import socket
+import subprocess
 from typing import TYPE_CHECKING, Any, cast
 
 import httpx
-from mcp.types import ImageContent, TextContent, Tool
+from mcp.types import BlobResourceContents, EmbeddedResource, ImageContent, TextContent, Tool
+from pydantic import AnyUrl
 
 from suitest_mcp.bundled.in_process_runtime import BundledServer, register_bundled_builder
 
@@ -77,6 +84,11 @@ _DEFAULT_WAIT_SECONDS = 15.0
 # Slint's HTTP transport only accepts localhost origins, and binding the probe
 # socket to the same interface is what makes "is it up yet" meaningful.
 _HOST = "127.0.0.1"
+# Video sampling. Slint serves single frames, not a stream, so a "video" here is
+# screenshots on a timer stitched by ffmpeg. 5 fps is enough to read a drag or a
+# panel opening, and cheap enough not to perturb what it is filming.
+_VIDEO_INTERVAL_MS = 200
+_VIDEO_MAX_FRAMES = 900
 
 
 def _free_port() -> int:
@@ -155,6 +167,9 @@ class SlintServer:
         self._client: httpx.AsyncClient | None = None
         self._rpc_id = 0
         self._window: dict[str, Any] | None = None
+        self._video_task: asyncio.Task[None] | None = None
+        self._video_frames: list[bytes] = []
+        self._video_interval_ms = _VIDEO_INTERVAL_MS
 
     # ---------------------------------------------------------------- plumbing
 
@@ -417,6 +432,7 @@ class SlintServer:
         )
 
     async def _stop(self) -> None:
+        await self._stop_sampling()
         if self._client is not None:
             await self._client.aclose()
             self._client = None
@@ -431,6 +447,84 @@ class SlintServer:
             self._proc = None
         self._port = None
         self._window = None
+
+    # ------------------------------------------------------------------- video
+
+    async def _sample_frames(self) -> None:
+        """Screenshot the window on a timer until cancelled."""
+        while True:
+            try:
+                blocks = await self._call(
+                    "take_screenshot", {"windowHandle": await self._window_handle()}
+                )
+            except Exception:  # a frame lost to a busy UI must not end the recording
+                blocks = []
+            for block in blocks:
+                if block.get("type") == "image" and isinstance(block.get("data"), str):
+                    with contextlib.suppress(ValueError, TypeError):
+                        self._video_frames.append(base64.b64decode(block["data"], validate=False))
+                    break
+            if len(self._video_frames) >= _VIDEO_MAX_FRAMES:
+                return
+            await asyncio.sleep(self._video_interval_ms / 1000)
+
+    async def _stop_sampling(self) -> None:
+        task, self._video_task = self._video_task, None
+        if task is None:
+            return
+        task.cancel()
+        # Teardown must not raise: a cancelled sampler, or one that died on a
+        # busy UI, still has to leave the session closable.
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await task
+
+    def _encode_video(self, frames: list[bytes]) -> bytes:
+        """PNG frames -> MP4, through ffmpeg on stdin.
+
+        H.264 in an MP4 is what the dashboard's `<video>` element plays. ffmpeg
+        is not vendored, so its absence is reported as the missing dependency it
+        is rather than as a broken step.
+        """
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg is None:
+            raise AssertionError(
+                "ffmpeg is not on PATH — `slint.stop_video` needs it to encode "
+                "the sampled frames; install it or drop the video steps"
+            )
+        fps = max(1, round(1000 / self._video_interval_ms))
+        result = subprocess.run(  # fixed argv, no shell
+            [
+                ffmpeg,
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "image2pipe",
+                "-framerate",
+                str(fps),
+                "-i",
+                "-",
+                # yuv420p + even dimensions: what every browser will actually play.
+                "-vf",
+                "pad=ceil(iw/2)*2:ceil(ih/2)*2",
+                "-pix_fmt",
+                "yuv420p",
+                "-c:v",
+                "libx264",
+                "-movflags",
+                "+faststart",
+                "-f",
+                "mp4",
+                "-",
+            ],
+            input=b"".join(frames),
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0 or not result.stdout:
+            detail = result.stderr.decode(errors="replace").strip()[:400]
+            raise AssertionError(f"ffmpeg could not encode the frames: {detail}")
+        return result.stdout
 
     @staticmethod
     def _text_of(properties: dict[str, Any]) -> str:
@@ -615,6 +709,26 @@ class SlintServer:
                 [],
             ),
             tool(
+                "slint.start_video",
+                "Start filming the window: screenshots on a timer, stitched "
+                "into an MP4 by `slint.stop_video`. Wrap the interaction you "
+                "want a reviewer to watch, not the whole run.",
+                {
+                    "interval_ms": {
+                        "type": "integer",
+                        "description": "Milliseconds between frames. Default 200 (5 fps).",
+                    },
+                },
+                [],
+            ),
+            tool(
+                "slint.stop_video",
+                "Stop filming and attach the MP4 to the run, so the case shows "
+                "the interaction instead of only its end state. Needs ffmpeg.",
+                {},
+                [],
+            ),
+            tool(
                 "slint.accessibility_action",
                 "Invoke an accessible action on an element, e.g. `Default_` "
                 "(the element's primary action), `Increment`, `Decrement`. "
@@ -628,7 +742,7 @@ class SlintServer:
 
     async def call_tool(
         self, name: str, arguments: dict[str, Any]
-    ) -> list[TextContent | ImageContent]:
+    ) -> list[TextContent | ImageContent | EmbeddedResource]:
         if name == "slint.launch":
             return [TextContent(type="text", text=await self._launch(arguments))]
 
@@ -642,7 +756,7 @@ class SlintServer:
             )
             # Passed through untouched: the runner turns image blocks into
             # SCREENSHOT artifacts, which is what surfaces them in the web UI.
-            out: list[TextContent | ImageContent] = []
+            out: list[TextContent | ImageContent | EmbeddedResource] = []
             for block in blocks:
                 if block.get("type") == "image":
                     out.append(
@@ -665,6 +779,40 @@ class SlintServer:
                 {"windowHandle": await self._window_handle(), "text": text},
             )
             return [TextContent(type="text", text=f"sent {text!r}")]
+
+        if name == "slint.start_video":
+            if self._video_task is not None:
+                raise AssertionError("already filming — call `slint.stop_video` first")
+            raw_interval = arguments.get("interval_ms", _VIDEO_INTERVAL_MS)
+            self._video_interval_ms = (
+                int(raw_interval)
+                if isinstance(raw_interval, int) and raw_interval > 0
+                else _VIDEO_INTERVAL_MS
+            )
+            self._video_frames = []
+            await self._window_handle()  # fail here, not inside the sampler
+            self._video_task = asyncio.create_task(self._sample_frames())
+            return [TextContent(type="text", text="filming the window")]
+
+        if name == "slint.stop_video":
+            if self._video_task is None:
+                raise AssertionError("not filming — call `slint.start_video` first")
+            await self._stop_sampling()
+            frames, self._video_frames = self._video_frames, []
+            if not frames:
+                raise AssertionError("no frames were captured")
+            video = await asyncio.to_thread(self._encode_video, frames)
+            return [
+                TextContent(type="text", text=f"captured {len(frames)} frame(s)"),
+                EmbeddedResource(
+                    type="resource",
+                    resource=BlobResourceContents(
+                        uri=AnyUrl("slint://window/recording.mp4"),
+                        mimeType="video/mp4",
+                        blob=base64.b64encode(video).decode(),
+                    ),
+                ),
+            ]
 
         if name == "slint.start_recording":
             await self._call("start_event_recording", {})

--- a/packages/mcp/src/suitest_mcp/bundled/slint.py
+++ b/packages/mcp/src/suitest_mcp/bundled/slint.py
@@ -4,8 +4,9 @@ Slint 1.17 embeds an MCP server *inside the application under test*: build with
 ``--features slint/mcp`` and run with ``SLINT_EMIT_DEBUG_INFO=1`` and
 ``SLINT_MCP_PORT=<port>``, and the process serves MCP over Streamable HTTP on
 ``127.0.0.1:<port>/mcp``. Its tools are ``find_elements_by_id``,
-``get_element_properties``, ``click_element``, ``set_element_value``,
-``dispatch_key_event``, ``take_screenshot`` and friends.
+``get_element_properties``, ``click_element``, ``drag_element``,
+``set_element_value``, ``dispatch_key_event``, ``invoke_accessibility_action``,
+``take_screenshot`` and friends.
 
 So this provider is a **bridge, not a driver**. It owns the app process and
 translates Suitest's stable ``slint.*`` step contract onto whatever the running
@@ -17,8 +18,14 @@ Tool surface (mirrored in :mod:`suitest_mcp.providers.builtin_specs`):
 
 * ``slint.launch``         — start the app, wait for its MCP port, handshake.
 * ``slint.click``          — click the element with the given id.
+* ``slint.drag``           — press on an element, drag to another element or to
+  a point, release: the gesture behind range selections, sliders and reorders.
 * ``slint.set_property``   — set an element's value (text inputs, sliders, ...).
 * ``slint.get_property``   — read an element's properties.
+* ``slint.element_tree``   — flat dump of the window's elements, for authoring
+  steps against an app whose ids you don't know yet.
+* ``slint.accessibility_action`` — invoke an accessible action (``Default_``,
+  ``Increment``, ``Decrement``, ...) on an element.
 * ``slint.press_key``      — send a key/text event to the focused element.
 * ``slint.assert_visible`` — element exists and is not fully transparent.
 * ``slint.assert_text``    — element's label/value equals or contains a string.
@@ -107,6 +114,26 @@ def _selector(arguments: dict[str, Any]) -> tuple[str | None, str | None, int]:
         )
     raw_index = arguments.get("index", 0)
     return element_id, label, int(raw_index) if isinstance(raw_index, int) else 0
+
+
+def _drag_destination(arguments: dict[str, Any]) -> dict[str, Any]:
+    """Where a drag ends: an explicit point, or another element's selector.
+
+    Parsed before anything touches the application, so a step that forgot the
+    far end of the gesture says so instead of failing later on a lookup.
+    """
+    x, y = arguments.get("x"), arguments.get("y")
+    if isinstance(x, (int, float)) and isinstance(y, (int, float)):
+        return {"x": float(x), "y": float(y)}
+    destination = {
+        key[3:]: arguments[key] for key in ("to_id", "to_label", "to_index") if key in arguments
+    }
+    if not destination:
+        raise AssertionError(
+            "no drag destination — pass `to_id`/`to_label` for another "
+            "element, or `x` and `y` for a point"
+        )
+    return destination
 
 
 class SlintServer:
@@ -292,6 +319,34 @@ class SlintServer:
         payload = await self._call_json("get_element_properties", {"elementHandle": handle})
         return cast("dict[str, Any]", payload or {})
 
+    async def _centre(self, handle: dict[str, Any]) -> dict[str, float]:
+        """Logical centre of an element, the point a drag aims at.
+
+        ``drag_element`` presses at the source element's own centre, so aiming
+        at the destination's centre keeps a step readable as "drag A onto B"
+        instead of asking the author for pixels. ``absolutePosition`` comes back
+        empty for an element at the origin, hence the 0.0 defaults.
+        """
+        payload = await self._call_json("get_element_properties", {"elementHandle": handle})
+        props = cast("dict[str, Any]", payload or {})
+        position = props.get("absolutePosition") or {}
+        size = props.get("size") or {}
+
+        def number(source: dict[str, Any], key: str) -> float:
+            value = source.get(key)
+            return float(value) if isinstance(value, (int, float)) else 0.0
+
+        return {
+            "x": number(position, "x") + number(size, "width") / 2,
+            "y": number(position, "y") + number(size, "height") / 2,
+        }
+
+    async def _drag_target(self, destination: dict[str, Any]) -> dict[str, float]:
+        """Resolve a destination from :func:`_drag_destination` to a point."""
+        if "x" in destination and "y" in destination:
+            return {"x": float(destination["x"]), "y": float(destination["y"])}
+        return await self._centre(await self._element(destination))
+
     # ------------------------------------------------------------------- tools
 
     async def _launch(self, arguments: dict[str, Any]) -> str:
@@ -445,6 +500,35 @@ class SlintServer:
             ),
             tool("slint.click", "Click an element.", dict(element), ["id"]),
             tool(
+                "slint.drag",
+                "Press on an element, drag, release. Name a destination "
+                "element with `to_id`/`to_label`, or a point with `x`/`y`. "
+                "This is the gesture a click cannot stand in for: range "
+                "selection across a grid, sliders, reordering.",
+                {
+                    **element,
+                    "to_id": {
+                        "type": "string",
+                        "description": "Destination element id; the drag ends at its centre.",
+                    },
+                    "to_label": {
+                        "type": "string",
+                        "description": "Destination element's visible/accessible label.",
+                    },
+                    "to_index": {
+                        "type": "integer",
+                        "description": "Which destination match to use. Default 0.",
+                    },
+                    "x": {"type": "number", "description": "Destination x, logical pixels."},
+                    "y": {"type": "number", "description": "Destination y, logical pixels."},
+                    "button": {
+                        "type": "string",
+                        "description": "Left (default), Right, or Middle.",
+                    },
+                },
+                ["id"],
+            ),
+            tool(
                 "slint.set_property",
                 "Set an element's value.",
                 {**element, "value": {"type": "string"}},
@@ -497,6 +581,28 @@ class SlintServer:
                 {},
                 [],
             ),
+            tool(
+                "slint.element_tree",
+                "Flat list of the window's elements — ids, labels and handles. "
+                "Use it to find what to address in an app whose ids you don't "
+                "know yet; every other tool takes those ids.",
+                {
+                    "max_elements": {
+                        "type": "integer",
+                        "description": "Cap on elements returned. Default 200.",
+                    },
+                },
+                [],
+            ),
+            tool(
+                "slint.accessibility_action",
+                "Invoke an accessible action on an element, e.g. `Default_` "
+                "(the element's primary action), `Increment`, `Decrement`. "
+                "Reaches controls that respond to assistive tech rather than "
+                "to a raw click.",
+                {**element, "action": {"type": "string"}},
+                ["id", "action"],
+            ),
             tool("slint.close", "Stop the application.", {}, []),
         ]
 
@@ -540,11 +646,52 @@ class SlintServer:
             )
             return [TextContent(type="text", text=f"sent {text!r}")]
 
+        if name == "slint.element_tree":
+            raw_cap = arguments.get("max_elements", 200)
+            cap = int(raw_cap) if isinstance(raw_cap, int) and raw_cap > 0 else 200
+            elements = [
+                {
+                    "ids": [d.get("id") for d in el.get("typeNamesAndIds") or []],
+                    "labels": self._labels_of(el),
+                    "handle": el.get("handle"),
+                }
+                for el in (await self._tree())[:cap]
+            ]
+            return [TextContent(type="text", text=json.dumps(elements, indent=2))]
+
         target = _selector(arguments)[0] or _selector(arguments)[1] or "element"
 
         if name == "slint.click":
             await self._call("click_element", {"elementHandle": await self._element(arguments)})
             return [TextContent(type="text", text=f"clicked {target}")]
+
+        if name == "slint.drag":
+            # Both ends are validated before either is resolved, so a step that
+            # named only one of them is told that, not that the app is missing.
+            wanted = _drag_destination(arguments)
+            source = await self._element(arguments)
+            destination = await self._drag_target(wanted)
+            payload: dict[str, Any] = {"elementHandle": source, "target": destination}
+            button = arguments.get("button")
+            if isinstance(button, str) and button:
+                payload["button"] = button
+            await self._call("drag_element", payload)
+            return [
+                TextContent(
+                    type="text",
+                    text=f"dragged {target} to ({destination['x']:.0f}, {destination['y']:.0f})",
+                )
+            ]
+
+        if name == "slint.accessibility_action":
+            action = arguments.get("action")
+            if not isinstance(action, str) or not action:
+                raise AssertionError("`action` is required")
+            await self._call(
+                "invoke_accessibility_action",
+                {"elementHandle": await self._element(arguments), "action": action},
+            )
+            return [TextContent(type="text", text=f"invoked {action} on {target}")]
 
         if name == "slint.set_property":
             value = arguments.get("value")

--- a/packages/mcp/src/suitest_mcp/bundled/slint.py
+++ b/packages/mcp/src/suitest_mcp/bundled/slint.py
@@ -68,7 +68,6 @@ from typing import TYPE_CHECKING, Any, cast
 
 import httpx
 from mcp.types import BlobResourceContents, EmbeddedResource, ImageContent, TextContent, Tool
-from pydantic import AnyUrl
 
 from suitest_mcp.bundled.in_process_runtime import BundledServer, register_bundled_builder
 
@@ -817,7 +816,7 @@ class SlintServer:
                 EmbeddedResource(
                     type="resource",
                     resource=BlobResourceContents(
-                        uri=AnyUrl("slint://window/recording.mp4"),
+                        uri="slint://window/recording.mp4",
                         mimeType="video/mp4",
                         blob=base64.b64encode(video).decode(),
                     ),

--- a/packages/mcp/src/suitest_mcp/bundled/slint.py
+++ b/packages/mcp/src/suitest_mcp/bundled/slint.py
@@ -72,6 +72,8 @@ from mcp.types import BlobResourceContents, EmbeddedResource, ImageContent, Text
 from suitest_mcp.bundled.in_process_runtime import BundledServer, register_bundled_builder
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from suitest_mcp.models import McpProviderConfig
 
 PROVIDER_NAME = "slint-mcp"
@@ -333,6 +335,40 @@ class SlintServer:
         if handle is None:
             raise AssertionError(f"element labelled {label!r} exposes no handle")
         return cast("dict[str, Any]", handle)
+
+    async def _await_text(
+        self, arguments: dict[str, Any], matches: Callable[[str], bool]
+    ) -> tuple[bool, str]:
+        """Poll an element's text until it matches, or the timeout expires.
+
+        Reading once is a race: the click that changed the text returns before
+        the property behind it has settled, so a correct assertion failed
+        depending on how fast the runner got there. Same deadline the element
+        lookup already uses.
+        """
+        raw_timeout = arguments.get("timeout_s", _DEFAULT_WAIT_SECONDS)
+        timeout = (
+            float(raw_timeout) if isinstance(raw_timeout, (int, float)) else _DEFAULT_WAIT_SECONDS
+        )
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        actual = ""
+        while True:
+            try:
+                actual = self._text_of(await self._properties(arguments))
+            except AssertionError:
+                # No readable text *yet*. Only worth reporting if it never
+                # arrives — an element gains its label a frame after the
+                # interaction that gave it one.
+                if loop.time() >= deadline:
+                    raise
+                await asyncio.sleep(0.25)
+                continue
+            if matches(actual):
+                return True, actual
+            if loop.time() >= deadline:
+                return False, actual
+            await asyncio.sleep(0.25)
 
     async def _properties(self, arguments: dict[str, Any]) -> dict[str, Any]:
         handle = await self._element(arguments)
@@ -854,8 +890,11 @@ class SlintServer:
             # Both ends are validated before either is resolved, so a step that
             # named only one of them is told that, not that the app is missing.
             wanted = _drag_destination(arguments)
-            source = await self._element(arguments)
+            # Destination first: resolving it costs a lookup, and a handle goes
+            # stale the moment the row under it is recycled. The source handle
+            # is the one `drag_element` dereferences, so it is taken last.
             destination = await self._drag_target(wanted)
+            source = await self._element(arguments)
             payload: dict[str, Any] = {"elementHandle": source, "target": destination}
             button = arguments.get("button")
             if isinstance(button, str) and button:
@@ -900,23 +939,24 @@ class SlintServer:
             return [TextContent(type="text", text=f"{target} is visible")]
 
         if name == "slint.assert_text":
-            actual = self._text_of(await self._properties(arguments))
             if "contains" in arguments:
                 needle = str(arguments["contains"])
-                if needle not in actual:
+                ok, actual = await self._await_text(arguments, lambda text: needle in text)
+                if not ok:
                     raise AssertionError(
                         f"{target}: expected text containing {needle!r}, got {actual!r}"
                     )
             else:
                 expected = str(arguments.get("equals", ""))
-                if actual != expected:
+                ok, actual = await self._await_text(arguments, lambda text: text == expected)
+                if not ok:
                     raise AssertionError(f"{target}: expected text {expected!r}, got {actual!r}")
             return [TextContent(type="text", text=f"{target} text matched")]
 
         if name == "slint.assert_value":
-            actual = self._text_of(await self._properties(arguments))
             expected = str(arguments.get("equals", ""))
-            if actual != expected:
+            ok, actual = await self._await_text(arguments, lambda text: text == expected)
+            if not ok:
                 raise AssertionError(f"{target}: expected value {expected!r}, got {actual!r}")
             return [TextContent(type="text", text=f"{target} value matched")]
 

--- a/packages/mcp/src/suitest_mcp/bundled/slint.py
+++ b/packages/mcp/src/suitest_mcp/bundled/slint.py
@@ -316,7 +316,30 @@ class SlintServer:
                 )
             return cast("dict[str, Any]", handles[index])
 
-        # Label lookup walks the tree, since Slint only indexes by id.
+        if element_id is not None:
+            # Both given: start from the id index and keep the ones carrying the
+            # label. The tree walk below also sees elements the id index does
+            # not — including ones that are not on screen — so with an id in
+            # hand the index is the more faithful source, and a click that
+            # landed on an off-screen twin is exactly the bug this avoids.
+            payload = await self._call_json(
+                "find_elements_by_id",
+                {"windowHandle": await self._window_handle(), "elementsId": element_id},
+            )
+            candidates = (payload or {}).get("elementHandles") or []
+            labelled: list[dict[str, Any]] = []
+            for handle in candidates:
+                props = await self._call_json("get_element_properties", {"elementHandle": handle})
+                if label in self._labels_of(cast("dict[str, Any]", props or {})):
+                    labelled.append(cast("dict[str, Any]", handle))
+            if labelled:
+                if index >= len(labelled):
+                    raise AssertionError(
+                        f"{label!r} matched {len(labelled)} element(s), asked for #{index}"
+                    )
+                return labelled[index]
+
+        # Label-only lookup walks the tree, since Slint only indexes by id.
         matches = [
             el
             for el in await self._tree()

--- a/packages/mcp/src/suitest_mcp/bundled/slint.py
+++ b/packages/mcp/src/suitest_mcp/bundled/slint.py
@@ -62,6 +62,8 @@ import os
 import shutil
 import socket
 import subprocess
+import tempfile
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import httpx
@@ -168,6 +170,7 @@ class SlintServer:
         self._rpc_id = 0
         self._window: dict[str, Any] | None = None
         self._video_task: asyncio.Task[None] | None = None
+        self._filming = False
         self._video_frames: list[bytes] = []
         self._video_interval_ms = _VIDEO_INTERVAL_MS
 
@@ -469,6 +472,8 @@ class SlintServer:
             await asyncio.sleep(self._video_interval_ms / 1000)
 
     async def _stop_sampling(self) -> None:
+        # A sampler that finished on its own must not read as "never started".
+        self._filming = False
         task, self._video_task = self._video_task, None
         if task is None:
             return
@@ -492,39 +497,43 @@ class SlintServer:
                 "the sampled frames; install it or drop the video steps"
             )
         fps = max(1, round(1000 / self._video_interval_ms))
-        result = subprocess.run(  # fixed argv, no shell
-            [
-                ffmpeg,
-                "-hide_banner",
-                "-loglevel",
-                "error",
-                "-f",
-                "image2pipe",
-                "-framerate",
-                str(fps),
-                "-i",
-                "-",
-                # yuv420p + even dimensions: what every browser will actually play.
-                "-vf",
-                "pad=ceil(iw/2)*2:ceil(ih/2)*2",
-                "-pix_fmt",
-                "yuv420p",
-                "-c:v",
-                "libx264",
-                "-movflags",
-                "+faststart",
-                "-f",
-                "mp4",
-                "-",
-            ],
-            input=b"".join(frames),
-            capture_output=True,
-            check=False,
-        )
-        if result.returncode != 0 or not result.stdout:
-            detail = result.stderr.decode(errors="replace").strip()[:400]
-            raise AssertionError(f"ffmpeg could not encode the frames: {detail}")
-        return result.stdout
+        # Written to a file, not a pipe: the MP4 muxer seeks back to finish its
+        # header, so `-f mp4 -` fails with "muxer does not support non seekable
+        # output".
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "recording.mp4"
+            result = subprocess.run(  # fixed argv, no shell
+                [
+                    ffmpeg,
+                    "-hide_banner",
+                    "-loglevel",
+                    "error",
+                    "-y",
+                    "-f",
+                    "image2pipe",
+                    "-framerate",
+                    str(fps),
+                    "-i",
+                    "-",
+                    # yuv420p + even dimensions: what a browser will actually play.
+                    "-vf",
+                    "pad=ceil(iw/2)*2:ceil(ih/2)*2",
+                    "-pix_fmt",
+                    "yuv420p",
+                    "-c:v",
+                    "libx264",
+                    "-movflags",
+                    "+faststart",
+                    str(target),
+                ],
+                input=b"".join(frames),
+                capture_output=True,
+                check=False,
+            )
+            if result.returncode != 0 or not target.exists():
+                detail = result.stderr.decode(errors="replace").strip()[:400]
+                raise AssertionError(f"ffmpeg could not encode the frames: {detail}")
+            return target.read_bytes()
 
     @staticmethod
     def _text_of(properties: dict[str, Any]) -> str:
@@ -781,7 +790,7 @@ class SlintServer:
             return [TextContent(type="text", text=f"sent {text!r}")]
 
         if name == "slint.start_video":
-            if self._video_task is not None:
+            if self._filming:
                 raise AssertionError("already filming — call `slint.stop_video` first")
             raw_interval = arguments.get("interval_ms", _VIDEO_INTERVAL_MS)
             self._video_interval_ms = (
@@ -791,11 +800,12 @@ class SlintServer:
             )
             self._video_frames = []
             await self._window_handle()  # fail here, not inside the sampler
+            self._filming = True
             self._video_task = asyncio.create_task(self._sample_frames())
             return [TextContent(type="text", text="filming the window")]
 
         if name == "slint.stop_video":
-            if self._video_task is None:
+            if not self._filming:
                 raise AssertionError("not filming — call `slint.start_video` first")
             await self._stop_sampling()
             frames, self._video_frames = self._video_frames, []

--- a/packages/mcp/src/suitest_mcp/bundled/slint.py
+++ b/packages/mcp/src/suitest_mcp/bundled/slint.py
@@ -6,7 +6,8 @@ Slint 1.17 embeds an MCP server *inside the application under test*: build with
 ``127.0.0.1:<port>/mcp``. Its tools are ``find_elements_by_id``,
 ``get_element_properties``, ``click_element``, ``drag_element``,
 ``set_element_value``, ``dispatch_key_event``, ``invoke_accessibility_action``,
-``take_screenshot`` and friends.
+``take_screenshot``, ``start_event_recording``/``stop_event_recording`` and
+friends.
 
 So this provider is a **bridge, not a driver**. It owns the app process and
 translates Suitest's stable ``slint.*`` step contract onto whatever the running
@@ -24,6 +25,8 @@ Tool surface (mirrored in :mod:`suitest_mcp.providers.builtin_specs`):
 * ``slint.get_property``   — read an element's properties.
 * ``slint.element_tree``   — flat dump of the window's elements, for authoring
   steps against an app whose ids you don't know yet.
+* ``slint.start_recording`` / ``slint.stop_recording`` — the events Slint
+  actually received, and whether it accepted or ignored each one.
 * ``slint.accessibility_action`` — invoke an accessible action (``Default_``,
   ``Increment``, ``Decrement``, ...) on an element.
 * ``slint.press_key``      — send a key/text event to the focused element.
@@ -595,6 +598,23 @@ class SlintServer:
                 [],
             ),
             tool(
+                "slint.start_recording",
+                "Start recording the events the application receives. Pair it "
+                "with `slint.stop_recording` around an interaction to see what "
+                "the app actually got.",
+                {},
+                [],
+            ),
+            tool(
+                "slint.stop_recording",
+                "Stop recording and return the events since the last start, "
+                "each with the result Slint gave it: `Accepted` when something "
+                "handled it, `Ignored` when nothing did. This is what separates "
+                '"the step never arrived" from "the app ignored it".',
+                {},
+                [],
+            ),
+            tool(
                 "slint.accessibility_action",
                 "Invoke an accessible action on an element, e.g. `Default_` "
                 "(the element's primary action), `Increment`, `Decrement`. "
@@ -645,6 +665,14 @@ class SlintServer:
                 {"windowHandle": await self._window_handle(), "text": text},
             )
             return [TextContent(type="text", text=f"sent {text!r}")]
+
+        if name == "slint.start_recording":
+            await self._call("start_event_recording", {})
+            return [TextContent(type="text", text="recording events")]
+
+        if name == "slint.stop_recording":
+            recorded = await self._call_json("stop_event_recording", {})
+            return [TextContent(type="text", text=json.dumps(recorded or {}, indent=2))]
 
         if name == "slint.element_tree":
             raw_cap = arguments.get("max_elements", 200)

--- a/packages/mcp/src/suitest_mcp/client.py
+++ b/packages/mcp/src/suitest_mcp/client.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import contextlib
+import mimetypes
 import time
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
@@ -70,7 +71,15 @@ def _resource_artifact(resource: object, idx: int) -> McpArtifact | None:
         raw = base64.b64decode(blob, validate=False)
     except (ValueError, TypeError):
         return None
-    mime = str(getattr(resource, "mimeType", None) or "application/octet-stream")
+    # The SDK spells it `mimeType`; a resource that round-tripped through JSON
+    # may carry `mime_type`, and one that carries neither still has a filename
+    # to go on — better than filing every recording as an opaque blob.
+    mime = str(
+        getattr(resource, "mimeType", None)
+        or getattr(resource, "mime_type", None)
+        or mimetypes.guess_type(str(getattr(resource, "uri", "") or ""))[0]
+        or "application/octet-stream"
+    )
     kind = next((k for prefix, k in _RESOURCE_KINDS if mime.startswith(prefix)), "CUSTOM")
     uri = str(getattr(resource, "uri", "") or "")
     name = uri.rsplit("/", 1)[-1] or f"resource-{idx}"

--- a/packages/mcp/src/suitest_mcp/client.py
+++ b/packages/mcp/src/suitest_mcp/client.py
@@ -52,6 +52,33 @@ log = structlog.get_logger(__name__)
 tracer = trace.get_tracer("suitest.mcp.client")
 
 
+#: Artifact kind for an embedded resource, by mime type. Anything else is
+#: CUSTOM: the bytes are still worth keeping, they just have no viewer.
+_RESOURCE_KINDS = (
+    ("video/", "VIDEO"),
+    ("image/", "SCREENSHOT"),
+    ("text/html", "DOM_SNAPSHOT"),
+)
+
+
+def _resource_artifact(resource: object, idx: int) -> McpArtifact | None:
+    """One embedded-resource block -> an artifact, or None if it carries no blob."""
+    blob = getattr(resource, "blob", None)
+    if not isinstance(blob, str):
+        return None
+    try:
+        raw = base64.b64decode(blob, validate=False)
+    except (ValueError, TypeError):
+        return None
+    mime = str(getattr(resource, "mimeType", None) or "application/octet-stream")
+    kind = next((k for prefix, k in _RESOURCE_KINDS if mime.startswith(prefix)), "CUSTOM")
+    uri = str(getattr(resource, "uri", "") or "")
+    name = uri.rsplit("/", 1)[-1] or f"resource-{idx}"
+    if "." not in name:
+        name = f"{name}.{mime.split('/', 1)[-1].split('+', 1)[0] or 'bin'}"
+    return McpArtifact(kind=kind, filename=name, content_type=mime, bytes=raw)
+
+
 @dataclass
 class McpSession:
     """Single open MCP session (one underlying transport + ClientSession)."""
@@ -144,6 +171,16 @@ class McpSession:
                         )
                     else:
                         output.setdefault("blocks", []).append({"type": ctype, "data": data_b64})
+                elif ctype == "resource":
+                    # An embedded resource is how a tool hands back a file that
+                    # is not an image — a screen recording, a trace. Without
+                    # this the blob was stashed in `output` and the run kept no
+                    # artifact, so the dashboard had nothing to play.
+                    artifact = _resource_artifact(getattr(content, "resource", None), idx)
+                    if artifact is not None:
+                        artifacts.append(artifact)
+                    else:
+                        output.setdefault("blocks", []).append({"type": ctype})
                 else:
                     output.setdefault("blocks", []).append(
                         {"type": ctype, "data": getattr(content, "data", None)}

--- a/packages/mcp/src/suitest_mcp/providers/builtin_specs.py
+++ b/packages/mcp/src/suitest_mcp/providers/builtin_specs.py
@@ -203,6 +203,7 @@ BUILTIN_SPECS: list[McpProviderConfig] = [
             "tools": [
                 "slint.launch",
                 "slint.click",
+                "slint.drag",
                 "slint.set_property",
                 "slint.get_property",
                 "slint.press_key",
@@ -211,6 +212,8 @@ BUILTIN_SPECS: list[McpProviderConfig] = [
                 "slint.assert_checked",
                 "slint.assert_value",
                 "slint.screenshot",
+                "slint.element_tree",
+                "slint.accessibility_action",
                 "slint.close",
             ]
         },

--- a/packages/mcp/src/suitest_mcp/providers/builtin_specs.py
+++ b/packages/mcp/src/suitest_mcp/providers/builtin_specs.py
@@ -213,6 +213,8 @@ BUILTIN_SPECS: list[McpProviderConfig] = [
                 "slint.assert_value",
                 "slint.screenshot",
                 "slint.element_tree",
+                "slint.start_recording",
+                "slint.stop_recording",
                 "slint.accessibility_action",
                 "slint.close",
             ]

--- a/packages/mcp/src/suitest_mcp/providers/builtin_specs.py
+++ b/packages/mcp/src/suitest_mcp/providers/builtin_specs.py
@@ -213,6 +213,8 @@ BUILTIN_SPECS: list[McpProviderConfig] = [
                 "slint.assert_value",
                 "slint.screenshot",
                 "slint.element_tree",
+                "slint.start_video",
+                "slint.stop_video",
                 "slint.start_recording",
                 "slint.stop_recording",
                 "slint.accessibility_action",

--- a/packages/mcp/tests/test_bundled_slint.py
+++ b/packages/mcp/tests/test_bundled_slint.py
@@ -124,3 +124,34 @@ async def test_launch_without_a_command_is_rejected() -> None:
 async def test_aclose_is_safe_before_launch() -> None:
     """Session teardown runs whether or not a step ever launched anything."""
     await build_slint_server(_config()).aclose()
+
+
+@pytest.mark.asyncio
+async def test_video_tools_report_the_missing_half_of_the_pair() -> None:
+    """Filming is two calls. Each half should name the other when used alone,
+    rather than failing on empty frames or a stray background task."""
+    server = build_slint_server(_config())
+    with pytest.raises(AssertionError, match=r"slint\.start_video"):
+        await server.call_tool("slint.stop_video", {})
+
+
+def test_a_video_blob_becomes_a_video_artifact() -> None:
+    """An embedded resource is the only way a tool can hand back a file that is
+    not an image; mapping it by mime is what gives the run something to play."""
+    import base64 as _base64
+    from types import SimpleNamespace
+
+    from suitest_mcp.client import _resource_artifact
+
+    resource = SimpleNamespace(
+        blob=_base64.b64encode(b"\x00\x01mp4").decode(),
+        mimeType="video/mp4",
+        uri="slint://window/recording.mp4",
+    )
+    artifact = _resource_artifact(resource, 0)
+    assert artifact is not None
+    assert artifact.kind == "VIDEO"
+    assert artifact.filename == "recording.mp4"
+    assert artifact.bytes_ == b"\x00\x01mp4"
+
+    assert _resource_artifact(SimpleNamespace(text="not a blob"), 0) is None

--- a/packages/mcp/tests/test_bundled_slint.py
+++ b/packages/mcp/tests/test_bundled_slint.py
@@ -69,6 +69,40 @@ async def test_selector_accepts_id_label_and_index() -> None:
 
 
 @pytest.mark.asyncio
+async def test_drag_without_a_destination_says_which_arguments_it_wants() -> None:
+    """A drag names two things. Missing the second one is an authoring mistake
+    worth spelling out, not a stack trace from the coordinate maths."""
+    server = build_slint_server(_config())
+    with pytest.raises(AssertionError, match="no drag destination"):
+        await server.call_tool("slint.drag", {"id": "Grid::cell"})
+
+
+@pytest.mark.asyncio
+async def test_drag_reports_the_missing_launch_before_the_destination() -> None:
+    """With both ends addressed there is nothing left to validate offline, so
+    the failure must be the one that actually blocks: no app running."""
+    server = build_slint_server(_config())
+    with pytest.raises(AssertionError, match=r"slint\.launch"):
+        await server.call_tool("slint.drag", {"id": "Grid::cell", "to_id": "Grid::other"})
+
+
+@pytest.mark.asyncio
+async def test_accessibility_action_requires_an_action() -> None:
+    server = build_slint_server(_config())
+    with pytest.raises(AssertionError, match="`action` is required"):
+        await server.call_tool("slint.accessibility_action", {"id": "Btn::ta"})
+
+
+@pytest.mark.asyncio
+async def test_element_tree_needs_no_selector_but_needs_an_app() -> None:
+    """It is the tool you reach for when you don't know the ids yet, so it must
+    not demand one — but it still has nothing to read before launch."""
+    server = build_slint_server(_config())
+    with pytest.raises(AssertionError, match=r"slint\.launch"):
+        await server.call_tool("slint.element_tree", {})
+
+
+@pytest.mark.asyncio
 async def test_launch_without_a_command_is_rejected() -> None:
     server = build_slint_server(_config())
     with pytest.raises(AssertionError, match=r"`command` is required"):

--- a/packages/mcp/tests/test_bundled_slint.py
+++ b/packages/mcp/tests/test_bundled_slint.py
@@ -103,6 +103,17 @@ async def test_element_tree_needs_no_selector_but_needs_an_app() -> None:
 
 
 @pytest.mark.asyncio
+async def test_recording_tools_need_no_selector_but_need_an_app() -> None:
+    """Recording is what you reach for when a step did nothing and you cannot
+    tell whether the app never got it — so it addresses no element, and before
+    launch it can only say there is no app."""
+    server = build_slint_server(_config())
+    for tool in ("slint.start_recording", "slint.stop_recording"):
+        with pytest.raises(AssertionError, match=r"slint\.launch"):
+            await server.call_tool(tool, {})
+
+
+@pytest.mark.asyncio
 async def test_launch_without_a_command_is_rejected() -> None:
     server = build_slint_server(_config())
     with pytest.raises(AssertionError, match=r"`command` is required"):

--- a/packages/shared/openapi.json
+++ b/packages/shared/openapi.json
@@ -1035,6 +1035,11 @@
             "title": "Markstale",
             "type": "boolean"
           },
+          "mcpProvider": {
+            "default": "",
+            "title": "Mcpprovider",
+            "type": "string"
+          },
           "mode": {
             "default": "backend",
             "title": "Mode",
@@ -8131,6 +8136,17 @@
               }
             ],
             "title": "Started At"
+          },
+          "stdout": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stdout"
           },
           "step_order": {
             "title": "Step Order",


### PR DESCRIPTION
## Summary

- Desktop testing could not actually drive a Slint app end to end: the bridge exposed seven of the fourteen tools a Slint window serves, and the missing ones covered the gesture a click cannot stand in for — a drag.
- Everything a run produced downstream of that was invisible too: a step's output was persisted and never surfaced, and no VIDEO artifact was ever emitted even though the dashboard has played them since M14.
- Found while validating a real app (a Rust/Slint database client). Every change here comes from a failing run, not from reading the code.

## Changes

**Slint bridge** (`packages/mcp/src/suitest_mcp/bundled/slint.py`)
- `slint.drag` — press at an element's centre, release at another element's centre or at a point.
- `slint.element_tree` — flat dump of ids and labels, for authoring against an app whose ids you don't know.
- `slint.accessibility_action` — invoke an accessible action on an element.
- `slint.start_video` / `slint.stop_video` — sample the window on a timer, encode to MP4 with ffmpeg, attach as a VIDEO artifact.
- `slint.start_recording` / `slint.stop_recording` — the events Slint received, each with its `Accepted` / `Ignored` verdict. This is what separates "the step never arrived" from "the app ignored it".
- Text assertions poll to the same deadline the element lookup uses. Reading once was a race: the property behind an assertion settles a frame or two after the interaction that changed it, so a correct assertion passed locally and failed in the runner.
- `id` + `label` together resolve through the id index rather than the element tree, which also carries elements that are not on screen — a click could land on an off-screen twin and nothing happened.
- Drag resolves its destination before its source: a handle goes stale when the row under it is recycled, and the source is the handle the drag dereferences.

**MCP client** (`packages/mcp/src/suitest_mcp/client.py`)
- An embedded-resource blob becomes an artifact, keyed by mime (video → VIDEO), with the filename as a fallback when no mime is given. This is the general path for any file a tool returns that is not an image.

**API / runs**
- `mode: "desktop"` maps to `FE_DESKTOP`, with `mcpProvider` overriding the mode default. Anything that was not `"frontend"` previously fell through to the backend default, so a desktop suite was imported as BE_REST and its steps dispatched to a provider that cannot drive a window.
- `RunStepPublic` carries `stdout`, the router passes it through (capped), and the step table renders it in a collapsed Output block.

**Local database**
- `create_local_schema` adds columns the models have grown. `create_all` only ever adds tables, so a database from an earlier release kept its old columns and every query naming a new one failed with `no such column` — the dashboard answered 500 and nothing said why. Still additive only.

## Test plan

- [x] `packages/mcp` — 147 passed, 9 skipped; new contract tests cover the drag/recording/video tool pairs and the resource-to-artifact mapping
- [x] `packages/db` — schema-upgrade test: drop a column from a built database, re-run `create_local_schema`, assert it comes back
- [x] `apps/api` — `_target` routing test (Postgres-backed tests skip locally, as documented)
- [x] `apps/web` — StepTable renders a step's output; `pnpm typecheck` and `pnpm lint` clean
- [x] ruff, ruff format, mypy via pre-commit on every commit
- [x] End to end against a real Slint app: 6 desktop cases, 43 steps, all green, 5 MP4 artifacts (H.264, verified with ffprobe) — five earlier runs failed first and each failure is one of the fixes above
- [ ] Postgres-backed API tests against the Docker stack
