### PR TITLE
fix(mcp): steadier slint driving, double-click and property assertions

### DIFF
--- a/packages/mcp/src/suitest_mcp/bundled/slint.py
+++ b/packages/mcp/src/suitest_mcp/bundled/slint.py
@@ -134,6 +134,16 @@ def _selector(arguments: dict[str, Any]) -> tuple[str | None, str | None, int]:
     return element_id, label, int(raw_index) if isinstance(raw_index, int) else 0
 
 
+def _as_text(value: Any) -> str:
+    """Compare properties as text: a step writes `equals: 263`, and the app may
+    report 263, 263.0 or "263" for the same thing."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
 def _drag_destination(arguments: dict[str, Any]) -> dict[str, Any]:
     """Where a drag ends: an explicit point, or another element's selector.
 
@@ -767,6 +777,22 @@ class SlintServer:
                 ["id", "checked"],
             ),
             tool(
+                "slint.assert_property",
+                "Assert any property the element exposes, by dotted path — "
+                "`size.width`, `absolutePosition.x`, `accessibleRole`. The way "
+                "to check something the named assertions do not cover, such as "
+                "a row not having moved.",
+                {
+                    **element,
+                    "path": {
+                        "type": "string",
+                        "description": "Dotted path into the element's properties.",
+                    },
+                    "equals": {"description": "Expected value; compared as text."},
+                },
+                ["id", "path", "equals"],
+            ),
+            tool(
                 "slint.assert_value",
                 "Assert an element's value equals a string.",
                 {**element, "equals": {"type": "string"}},
@@ -1010,6 +1036,25 @@ class SlintServer:
                 if not ok:
                     raise AssertionError(f"{target}: expected text {expected!r}, got {actual!r}")
             return [TextContent(type="text", text=f"{target} text matched")]
+
+        if name == "slint.assert_property":
+            path = str(arguments.get("path") or "")
+            if not path:
+                raise AssertionError("`path` is required, e.g. `absolutePosition.x`")
+            found: Any = await self._properties(arguments)
+            for part in path.split("."):
+                if not isinstance(found, dict) or part not in found:
+                    raise AssertionError(
+                        f"{target} exposes no {path!r} (has: {sorted(found)})"
+                        if isinstance(found, dict)
+                        else f"{target}: {path!r} runs past a leaf value"
+                    )
+                found = found[part]
+            actual = _as_text(found)
+            expected = _as_text(arguments.get("equals"))
+            if actual != expected:
+                raise AssertionError(f"{target}: {path} is {actual!r}, expected {expected!r}")
+            return [TextContent(type="text", text=f"{target} {path} == {actual}")]
 
         if name == "slint.assert_value":
             expected = str(arguments.get("equals", ""))

--- a/packages/mcp/src/suitest_mcp/bundled/slint.py
+++ b/packages/mcp/src/suitest_mcp/bundled/slint.py
@@ -681,7 +681,13 @@ class SlintServer:
                 },
                 [],
             ),
-            tool("slint.click", "Click an element.", dict(element), ["id"]),
+            tool(
+                "slint.click",
+                "Click an element. `double: true` for a double-click, which is "
+                "how a list row is usually opened.",
+                {**element, "double": {"type": "boolean"}},
+                ["id"],
+            ),
             tool(
                 "slint.drag",
                 "Press on an element, drag, release. Name a destination "
@@ -925,8 +931,11 @@ class SlintServer:
         target = _selector(arguments)[0] or _selector(arguments)[1] or "element"
 
         if name == "slint.click":
-            await self._act_on_element("click_element", arguments, {})
-            return [TextContent(type="text", text=f"clicked {target}")]
+            double = bool(arguments.get("double"))
+            how_args = {"action": "DoubleClick"} if double else {}
+            await self._act_on_element("click_element", arguments, how_args)
+            how = "double-clicked" if double else "clicked"
+            return [TextContent(type="text", text=f"{how} {target}")]
 
         if name == "slint.drag":
             # Both ends are validated before either is resolved, so a step that

--- a/packages/mcp/src/suitest_mcp/bundled/slint.py
+++ b/packages/mcp/src/suitest_mcp/bundled/slint.py
@@ -398,6 +398,25 @@ class SlintServer:
         payload = await self._call_json("get_element_properties", {"elementHandle": handle})
         return cast("dict[str, Any]", payload or {})
 
+    async def _act_on_element(
+        self, tool: str, arguments: dict[str, Any], payload: dict[str, Any]
+    ) -> None:
+        """Call a handle-taking tool, re-resolving once if the handle went stale.
+
+        A list recycles the element under a handle as it scrolls or repaints, and
+        the app answers "refers to element that was destroyed". Re-resolving and
+        trying again is what a person does without thinking about it; failing the
+        step instead made a correct test flaky.
+        """
+        handle = await self._element(arguments)
+        try:
+            await self._call(tool, {**payload, "elementHandle": handle})
+        except AssertionError as exc:
+            if "destroyed" not in str(exc):
+                raise
+            handle = await self._element(arguments)
+            await self._call(tool, {**payload, "elementHandle": handle})
+
     async def _centre(self, handle: dict[str, Any]) -> dict[str, float]:
         """Logical centre of an element, the point a drag aims at.
 
@@ -906,7 +925,7 @@ class SlintServer:
         target = _selector(arguments)[0] or _selector(arguments)[1] or "element"
 
         if name == "slint.click":
-            await self._call("click_element", {"elementHandle": await self._element(arguments)})
+            await self._act_on_element("click_element", arguments, {})
             return [TextContent(type="text", text=f"clicked {target}")]
 
         if name == "slint.drag":
@@ -917,12 +936,11 @@ class SlintServer:
             # stale the moment the row under it is recycled. The source handle
             # is the one `drag_element` dereferences, so it is taken last.
             destination = await self._drag_target(wanted)
-            source = await self._element(arguments)
-            payload: dict[str, Any] = {"elementHandle": source, "target": destination}
+            payload: dict[str, Any] = {"target": destination}
             button = arguments.get("button")
             if isinstance(button, str) and button:
                 payload["button"] = button
-            await self._call("drag_element", payload)
+            await self._act_on_element("drag_element", arguments, payload)
             return [
                 TextContent(
                     type="text",

--- a/packages/mcp/src/suitest_mcp/bundled/slint.py
+++ b/packages/mcp/src/suitest_mcp/bundled/slint.py
@@ -170,6 +170,10 @@ class SlintServer:
         self._client: httpx.AsyncClient | None = None
         self._rpc_id = 0
         self._window: dict[str, Any] | None = None
+        # One RPC at a time: the video sampler shares this client with the step
+        # that is running, and a frame competing with a connect starved the
+        # lookup that step was waiting on.
+        self._rpc_lock = asyncio.Lock()
         self._video_task: asyncio.Task[None] | None = None
         self._filming = False
         self._video_frames: list[bytes] = []
@@ -182,6 +186,10 @@ class SlintServer:
         return f"http://{_HOST}:{self._port}/mcp"
 
     async def _rpc(self, method: str, params: dict[str, Any] | None = None) -> Any:
+        async with self._rpc_lock:
+            return await self._rpc_locked(method, params)
+
+    async def _rpc_locked(self, method: str, params: dict[str, Any] | None = None) -> Any:
         """One JSON-RPC round trip to the app's embedded server.
 
         The transport may answer as plain JSON or as a single SSE ``data:``

--- a/packages/mcp/src/suitest_mcp/providers/builtin_specs.py
+++ b/packages/mcp/src/suitest_mcp/providers/builtin_specs.py
@@ -210,6 +210,7 @@ BUILTIN_SPECS: list[McpProviderConfig] = [
                 "slint.assert_visible",
                 "slint.assert_text",
                 "slint.assert_checked",
+                "slint.assert_property",
                 "slint.assert_value",
                 "slint.screenshot",
                 "slint.element_tree",

--- a/packages/mcp/tests/test_bundled_slint.py
+++ b/packages/mcp/tests/test_bundled_slint.py
@@ -114,6 +114,24 @@ async def test_recording_tools_need_no_selector_but_need_an_app() -> None:
 
 
 @pytest.mark.asyncio
+async def test_assert_property_wants_a_path() -> None:
+    """The path is the whole point of the tool; without one there is nothing to
+    compare, and saying so beats reaching the app to find out."""
+    server = build_slint_server(_config())
+    with pytest.raises(AssertionError, match="`path` is required"):
+        await server.call_tool("slint.assert_property", {"id": "Grid::cell", "equals": 1})
+
+
+def test_property_values_compare_as_text() -> None:
+    """A step writes `equals: 263`; the app may report 263, 263.0 or "263"."""
+    from suitest_mcp.bundled.slint import _as_text
+
+    assert _as_text(263) == _as_text(263.0) == _as_text("263") == "263"
+    assert _as_text(True) == "true"
+    assert _as_text(1.5) == "1.5"
+
+
+@pytest.mark.asyncio
 async def test_launch_without_a_command_is_rejected() -> None:
     server = build_slint_server(_config())
     with pytest.raises(AssertionError, match=r"`command` is required"):


### PR DESCRIPTION
## Summary

- Follow-up to #131. Everything here came from using those tools to drive a real application, so each commit is a gap the first pass did not know about yet.
- Two are flakiness the tooling itself caused; two are reach the bridge did not have.

## Changes

- **Retry once when an element handle went stale.** A list recycles the element under a handle as it scrolls or repaints, and the app answers "refers to element that was destroyed". The step failed, so a correct test was flaky for reasons that had nothing to do with the application under test. Click and drag re-resolve and try again once.
- **`slint.click` takes a double-click.** Opening a list row is a double-click, so a case could reach a picker and then not open anything in it.
- **The video sampler no longer starves the step it films.** It shares one HTTP client with the running step, and at 5–16 frames a second a frame could land between a connect and the lookup waiting on it. One RPC at a time.
- **`slint.assert_property`** asserts any property an element exposes, by dotted path (`absolutePosition.x`, `size.width`), compared as text. The named assertions cover text, value, checked and visibility, which left everything numeric unassertable — a case could film a grid not panning but never state it.

## Test plan

- [x] `packages/mcp` tests — 16 passed, including the new contracts
- [x] ruff, ruff format and mypy via pre-commit on every commit
- [x] Driven end to end against a Slint desktop application: 10 cases, 80 steps, all green, video per case — including a drag repeated in a split pane, which is what `assert_property` made statable, and a MongoDB connect + read against a real server

## Known gaps for whoever picks this up next

The driver has no modifier on click (so no shift-click), no hover (a control that only appears on hover is unreachable), no wheel event, and no clipboard read. Key events reach the window but nothing consumes them — `slint.start_recording` reports them as `Ignored` while pointer events come back `Accepted`.
