### PR TITLE
feat(cases): per-case pixel-diff threshold override (M12-3)

### DIFF
--- a/apps/api/src/suitest_api/schemas/test_case.py
+++ b/apps/api/src/suitest_api/schemas/test_case.py
@@ -96,6 +96,9 @@ class TestCaseDetail(TestCaseListItem):
     last_run_result: str | None = None
     last_run_at: datetime | None = None
     last_duration_ms: int | None = None
+    # M12-3: per-case pixel-diff threshold override (0-255). NULL = the
+    # ScreenshotDiffViewer falls back to its client-side default.
+    diff_threshold: int | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -188,6 +191,12 @@ class TestCaseUpdate(BaseModel):
     framework: Annotated[str, Field(min_length=1, max_length=64)] | None = None
     strategy_id: str | None = Field(default=None, alias="strategyId")
     tags: list[str] | None = None
+    # M12-3: per-case pixel-diff threshold override. `null` clears the
+    # override (falls back to the viewer's client-side default); omitted =
+    # untouched, matching every other optional field on this DTO.
+    diff_threshold: Annotated[int, Field(ge=0, le=255)] | None = Field(
+        default=None, alias="diffThreshold"
+    )
 
 
 class StepReplace(BaseModel):

--- a/apps/api/src/suitest_api/services/test_case_service.py
+++ b/apps/api/src/suitest_api/services/test_case_service.py
@@ -440,6 +440,7 @@ class TestCaseService:
             "test_level",
             "framework",
             "strategy_id",
+            "diff_threshold",
         ):
             if field in payload:
                 setattr(case, field, payload[field])

--- a/apps/web/src/components/runs/CaseDetailPanel.tsx
+++ b/apps/web/src/components/runs/CaseDetailPanel.tsx
@@ -166,6 +166,7 @@ export function CaseDetailPanel({
         logs={logItems}
         artifacts={caseArtifacts}
         runId={runId}
+        caseId={group.caseId}
       />
     </div>
   );
@@ -180,6 +181,7 @@ interface CaseEvidenceTabsProps {
   logs: components["schemas"]["RunLogItem"][];
   artifacts: ArtifactPublic[];
   runId: string;
+  caseId: string;
 }
 
 function CaseEvidenceTabs({
@@ -191,6 +193,7 @@ function CaseEvidenceTabs({
   logs,
   artifacts,
   runId,
+  caseId,
 }: CaseEvidenceTabsProps): React.ReactElement {
   const [tab, setTab] = useState("preview");
   const showStep = Boolean(stepScreenshotUrl);
@@ -292,6 +295,7 @@ function CaseEvidenceTabs({
       <TabsContent value="diff">
         <ScreenshotDiffViewer
           runId={runId}
+          caseId={caseId}
           artifacts={artifacts.filter((a) => a.kind === "SCREENSHOT")}
         />
       </TabsContent>

--- a/apps/web/src/components/runs/ScreenshotDiffViewer.stories.tsx
+++ b/apps/web/src/components/runs/ScreenshotDiffViewer.stories.tsx
@@ -36,7 +36,7 @@ const baseArtifacts: ArtifactPublic[] = [
 const meta: Meta<typeof ScreenshotDiffViewer> = {
   title: "Runs/ScreenshotDiffViewer",
   component: ScreenshotDiffViewer,
-  args: { runId: "run_demo", artifacts: baseArtifacts },
+  args: { runId: "run_demo", caseId: "case_demo", artifacts: baseArtifacts },
 };
 
 export default meta;
@@ -44,9 +44,13 @@ export default meta;
 export const Default: StoryObj<typeof ScreenshotDiffViewer> = {};
 
 export const NoScreenshots: StoryObj<typeof ScreenshotDiffViewer> = {
-  args: { runId: "run_demo", artifacts: [] },
+  args: { runId: "run_demo", caseId: "case_demo", artifacts: [] },
 };
 
 export const OneScreenshot: StoryObj<typeof ScreenshotDiffViewer> = {
-  args: { runId: "run_demo", artifacts: [baseArtifacts[0] as ArtifactPublic] },
+  args: {
+    runId: "run_demo",
+    caseId: "case_demo",
+    artifacts: [baseArtifacts[0] as ArtifactPublic],
+  },
 };

--- a/apps/web/src/components/runs/ScreenshotDiffViewer.test.tsx
+++ b/apps/web/src/components/runs/ScreenshotDiffViewer.test.tsx
@@ -32,7 +32,7 @@ function screenshot(id: string, runStepId = "rs_02"): ArtifactPublic {
 
 describe("<ScreenshotDiffViewer>", () => {
   it("shows an empty state when fewer than 2 screenshots", () => {
-    renderViewer({ runId: "run_1", artifacts: [screenshot("a")] });
+    renderViewer({ runId: "run_1", caseId: "case_1", artifacts: [screenshot("a")] });
     expect(screen.getByTestId("screenshot-diff-empty")).toBeInTheDocument();
     expect(
       screen.getByText(/fewer than two screenshots/i),
@@ -40,13 +40,14 @@ describe("<ScreenshotDiffViewer>", () => {
   });
 
   it("shows an empty state for zero screenshots", () => {
-    renderViewer({ runId: "run_1", artifacts: [] });
+    renderViewer({ runId: "run_1", caseId: "case_1", artifacts: [] });
     expect(screen.getByTestId("screenshot-diff-empty")).toBeInTheDocument();
   });
 
   it("renders pickers A and B with two screenshots available", () => {
     renderViewer({
       runId: "run_1",
+      caseId: "case_1",
       artifacts: [screenshot("art_01"), screenshot("art_02")],
     });
     expect(screen.getByTestId("diff-pick-a")).toBeInTheDocument();
@@ -61,6 +62,7 @@ describe("<ScreenshotDiffViewer>", () => {
   it("defaults pickers to the first two screenshots", () => {
     renderViewer({
       runId: "run_1",
+      caseId: "case_1",
       artifacts: [screenshot("art_01"), screenshot("art_02")],
     });
     expect(
@@ -74,6 +76,7 @@ describe("<ScreenshotDiffViewer>", () => {
   it("exposes the pixel mode toggle and the disabled perceptual stub", () => {
     renderViewer({
       runId: "run_1",
+      caseId: "case_1",
       artifacts: [screenshot("a"), screenshot("b")],
     });
     expect(screen.getByTestId("diff-mode-pixel")).toBeInTheDocument();
@@ -84,6 +87,7 @@ describe("<ScreenshotDiffViewer>", () => {
   it("exposes all three view modes", () => {
     renderViewer({
       runId: "run_1",
+      caseId: "case_1",
       artifacts: [screenshot("a"), screenshot("b")],
     });
     expect(screen.getByTestId("diff-view-side-by-side")).toBeInTheDocument();
@@ -94,9 +98,24 @@ describe("<ScreenshotDiffViewer>", () => {
   it("canvas wrap renders (canvas path is skipped under jsdom)", () => {
     renderViewer({
       runId: "run_1",
+      caseId: "case_1",
       artifacts: [screenshot("a"), screenshot("b")],
     });
     // The canvas element is present even if drawing is a no-op in jsdom.
     expect(screen.getByTestId("diff-canvas-wrap")).toBeInTheDocument();
+  });
+
+  it("exposes the per-case threshold input defaulting to DEFAULT_PIXEL_THRESHOLD (M12-3)", async () => {
+    renderViewer({
+      runId: "run_1",
+      caseId: "case_1",
+      artifacts: [screenshot("a"), screenshot("b")],
+    });
+    const input = (await screen.findByTestId(
+      "diff-threshold-input",
+    )) as HTMLInputElement;
+    // The mock `GET /test-cases/:id` handler returns no diff_threshold, so
+    // the control falls back to DEFAULT_PIXEL_THRESHOLD (30).
+    expect(input.value).toBe("30");
   });
 });

--- a/apps/web/src/components/runs/ScreenshotDiffViewer.tsx
+++ b/apps/web/src/components/runs/ScreenshotDiffViewer.tsx
@@ -1,13 +1,18 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { GitCompareArrows } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { EmptyState } from "@/components/shared/EmptyState";
-import { fetchRunSignedUrl } from "@/lib/api-client";
+import {
+  fetchRunSignedUrl,
+  fetchTestCaseDiffThreshold,
+  updateTestCaseDiffThreshold,
+} from "@/lib/api-client";
 import type { components } from "@/lib/api-types";
 import { cn } from "@/lib/utils";
 
 import {
+  DEFAULT_PIXEL_THRESHOLD,
   diffImage,
   diffPctColor,
   pixelDiffPct,
@@ -21,6 +26,8 @@ interface ScreenshotDiffViewerProps {
   runId: string;
   /** Artifacts already filtered to SCREENSHOT kind by the parent. */
   artifacts: ArtifactPublic[];
+  /** Case id — used to load/persist the per-case threshold override (M12-3). */
+  caseId: string;
 }
 
 type ViewMode = "side-by-side" | "overlay" | "diff";
@@ -31,10 +38,15 @@ type ViewMode = "side-by-side" | "overlay" | "diff";
  * via the presigned-URL API, draws them to a canvas, and reports the pixel-diff
  * percentage plus a red-overlay visualization. Perceptual mode is scaffolded
  * as a disabled toggle — it lands in M12-2 behind an LLM gate.
+ *
+ * M12-3 — the pixel threshold is tunable per case: the picker below the mode
+ * toggle loads/persists `TestCase.diff_threshold` via `PATCH /test-cases/:id`
+ * and falls back to `DEFAULT_PIXEL_THRESHOLD` when the case has no override.
  */
 export function ScreenshotDiffViewer({
   runId,
   artifacts,
+  caseId,
 }: ScreenshotDiffViewerProps): React.ReactElement {
   // Two pickers default to the first two screenshots.
   const [aId, setAId] = useState<string | null>(null);
@@ -82,10 +94,12 @@ export function ScreenshotDiffViewer({
         />
         <ModeToggle mode={mode} onModeChange={setMode} />
         <ViewToggle view={view} onViewChange={setView} />
+        <ThresholdControl caseId={caseId} />
       </div>
 
       <DiffCanvas
         runId={runId}
+        caseId={caseId}
         aId={aId}
         bId={bId}
         view={view}
@@ -97,6 +111,72 @@ export function ScreenshotDiffViewer({
 }
 
 // ---------------------------------------------------------------------------
+
+/**
+ * Per-case pixel-diff threshold control (M12-3). Loads `TestCase.diff_threshold`
+ * (falls back to `DEFAULT_PIXEL_THRESHOLD` display when unset) and persists
+ * edits via `PATCH /test-cases/:id`. The number input is debounced-free —
+ * commits on blur/Enter so a keystroke never spams the API.
+ */
+function ThresholdControl({ caseId }: { caseId: string }): React.ReactElement {
+  const queryClient = useQueryClient();
+  const { data: savedThreshold } = useQuery({
+    queryKey: ["case-diff-threshold", caseId] as const,
+    queryFn: () => fetchTestCaseDiffThreshold(caseId),
+  });
+
+  const effective = savedThreshold ?? DEFAULT_PIXEL_THRESHOLD;
+  const [draft, setDraft] = useState<string>(effective.toString());
+
+  // Resync the draft when the persisted value changes underneath us (new
+  // case, or a save round-trips a normalized value).
+  useEffect(() => {
+    setDraft(effective.toString());
+  }, [effective]);
+
+  const mutation = useMutation({
+    mutationFn: (value: number | null) => updateTestCaseDiffThreshold(caseId, value),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["case-diff-threshold", caseId] });
+    },
+  });
+
+  const commit = (): void => {
+    const trimmed = draft.trim();
+    if (trimmed === "") {
+      mutation.mutate(null); // clear override → back to DEFAULT_PIXEL_THRESHOLD
+      return;
+    }
+    const parsed = Number(trimmed);
+    if (!Number.isInteger(parsed) || parsed < 0 || parsed > 255) {
+      setDraft(effective.toString()); // reject out-of-range input, revert
+      return;
+    }
+    if (parsed !== savedThreshold) mutation.mutate(parsed);
+  };
+
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="text-[10.5px] uppercase tracking-wide text-fg-5">
+        Threshold
+      </span>
+      <input
+        type="number"
+        min={0}
+        max={255}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") e.currentTarget.blur();
+        }}
+        data-testid="diff-threshold-input"
+        title="Per-case pixel RGB-distance threshold (0-255). Blank clears the override."
+        className="w-16 rounded-md border border-border bg-bg-elev-1 px-2 py-1 font-mono text-[12px] text-fg-1 focus:border-accent focus:outline-none"
+      />
+    </label>
+  );
+}
 
 function Picker({
   label,
@@ -235,12 +315,14 @@ function ViewToggle({
 
 function DiffCanvas({
   runId,
+  caseId,
   aId,
   bId,
   view,
   computeMode,
 }: {
   runId: string;
+  caseId: string;
   aId: string | null;
   bId: string | null;
   view: ViewMode;
@@ -253,11 +335,19 @@ function DiffCanvas({
   const aImg = useImage(aUrl);
   const bImg = useImage(bUrl);
 
+  // M12-3: the persisted per-case override (falls back to
+  // DEFAULT_PIXEL_THRESHOLD when the case has none set).
+  const { data: savedThreshold } = useQuery({
+    queryKey: ["case-diff-threshold", caseId] as const,
+    queryFn: () => fetchTestCaseDiffThreshold(caseId),
+  });
+  const threshold = savedThreshold ?? DEFAULT_PIXEL_THRESHOLD;
+
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [pct, setPct] = useState<number | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
 
-  // Redraw whenever images or view change.
+  // Redraw whenever images, view, or the threshold change.
   useEffect(() => {
     const canvas = canvasRef.current;
     if (canvas === null) return;
@@ -309,10 +399,10 @@ function DiffCanvas({
     ctx.clearRect(0, 0, w, h);
     ctx.drawImage(imgB, 0, 0, w, h);
     const dataB = ctx.getImageData(0, 0, w, h);
-    const diff = diffImage(dataA, dataB);
+    const diff = diffImage(dataA, dataB, { threshold });
     ctx.putImageData(diff, 0, 0);
-    setPct(pixelDiffPct(dataA, dataB));
-  }, [aImg, bImg, view, computeMode]);
+    setPct(pixelDiffPct(dataA, dataB, { threshold }));
+  }, [aImg, bImg, view, computeMode, threshold]);
 
   const loading = aImg.status === "loading" || bImg.status === "loading";
   const error = aImg.status === "error" || bImg.status === "error";

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -139,6 +139,33 @@ export async function fetchTestCaseDescription(caseId: string): Promise<string |
   return res.data.description ?? null;
 }
 
+// ---------------------------------------------------------------------------
+// Screenshot diff threshold (M12-3 — per-case pixel-diff threshold override).
+// ---------------------------------------------------------------------------
+
+interface TestCaseDiffThreshold {
+  diff_threshold?: number | null;
+  diffThreshold?: number | null;
+}
+
+/** ``GET /test-cases/:id`` — read just the persisted diff-threshold override. */
+export async function fetchTestCaseDiffThreshold(caseId: string): Promise<number | null> {
+  const res = await api.get<TestCaseDiffThreshold>(`/test-cases/${caseId}`);
+  return res.data.diff_threshold ?? res.data.diffThreshold ?? null;
+}
+
+/**
+ * ``PATCH /test-cases/:id`` — persist a per-case pixel-diff threshold
+ * override (0-255) for the {@link ScreenshotDiffViewer}. Pass `null` to clear
+ * the override and fall back to `DEFAULT_PIXEL_THRESHOLD`.
+ */
+export async function updateTestCaseDiffThreshold(
+  caseId: string,
+  diffThreshold: number | null,
+): Promise<void> {
+  await api.patch(`/test-cases/${caseId}`, { diffThreshold });
+}
+
 type RunLogPage = components["schemas"]["RunLogPage"];
 
 /** ``GET /runs/:id/logs`` — persisted log stream (M4-10 time-travel replay reads this). */

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -7392,6 +7392,8 @@ export interface components {
             created_at: string;
             /** Description */
             description?: string | null;
+            /** Diff Threshold */
+            diff_threshold?: number | null;
             /** @default BLACK_BOX */
             effective_testing_approach: components["schemas"]["TestingApproach"];
             /** Framework */
@@ -7509,6 +7511,8 @@ export interface components {
         TestCaseUpdate: {
             /** Description */
             description?: string | null;
+            /** Diffthreshold */
+            diffThreshold?: number | null;
             /** Framework */
             framework?: string | null;
             /** Name */

--- a/apps/web/src/mocks/handlers.ts
+++ b/apps/web/src/mocks/handlers.ts
@@ -268,6 +268,18 @@ export const handlers: HttpHandler[] = [
   }),
   http.get(`${BASE}/test-cases/:caseId/steps`, () => HttpResponse.json({ items: [] })),
 
+  // M12-3: per-case pixel-diff threshold — PATCH echoes the new value back so
+  // ScreenshotDiffViewer's threshold control round-trips in tests/storybook.
+  http.patch(`${BASE}/test-cases/:caseId`, async ({ params, request }) => {
+    const publicId = String(params["caseId"]);
+    const body = (await request.json()) as { diffThreshold?: number | null };
+    return HttpResponse.json({
+      id: `case_${publicId}`,
+      public_id: publicId,
+      diff_threshold: body.diffThreshold ?? null,
+    });
+  }),
+
   // M1-12: step write endpoints — thin stubs (per-test overrides via server.use)
   http.post(`${BASE}/test-cases/:caseId/steps`, ({ params }) => {
     const publicId = String(params["caseId"]);

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -328,7 +328,7 @@ Tag `v1.0.0`. Announce on HN / Reddit / dev.to. Discord + community forum set up
 
 - [x] **M12-1** Screenshot diff (pixel + perceptual) — pixel diff shipped; `components/runs/ScreenshotDiffViewer.tsx` + pure `screenshot-diff.ts` math, "Diff" tab in run-detail Case evidence panel (side-by-side / overlay / red-overlay views, `% pixel diff` badge). Perceptual mode scaffolded as a disabled stub (lands with vision LLM in M12-2). No backend change — compares any two SCREENSHOT artifacts in a run via the existing presigned-URL API. Baseline persistence + per-case threshold tuning deferred to M12-3.
 - [ ] **M12-2** Semantic reason via vision LLM ("Button color changed from green to blue")
-- [ ] **M12-3** Threshold tuning per case
+- [x] **M12-3** Threshold tuning per case (shipped — `TestCase.diff_threshold` column [migration `0050_case_diff_threshold`] + `TestCaseUpdate.diffThreshold` [0-255] in [`schemas/test_case.py`](../apps/api/src/suitest_api/schemas/test_case.py); FE `ThresholdControl` in [`ScreenshotDiffViewer.tsx`](../apps/web/src/components/runs/ScreenshotDiffViewer.tsx) loads/persists the override via `PATCH /test-cases/:id`, falls back to `DEFAULT_PIXEL_THRESHOLD` when unset)
 
 ## M13 — Mobile testing (5 weeks)
 

--- a/packages/db/alembic/versions/20260828_0050_case_diff_threshold.py
+++ b/packages/db/alembic/versions/20260828_0050_case_diff_threshold.py
@@ -1,0 +1,27 @@
+"""Add per-case pixel-diff threshold override (M12-3).
+
+Revision ID: 0050_case_diff_threshold
+Revises: 0049_llm_config_oauth
+Create Date: 2026-08-28
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0050_case_diff_threshold"
+down_revision: str | None = "0049_llm_config_oauth"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "test_cases",
+        sa.Column("diff_threshold", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("test_cases", "diff_threshold")

--- a/packages/db/src/suitest_db/models/case.py
+++ b/packages/db/src/suitest_db/models/case.py
@@ -136,6 +136,11 @@ class TestCase(Base, TimestampMixin):
     order_in_suite: Mapped[int] = mapped_column(
         Integer, nullable=False, default=0, server_default="0"
     )
+    # M12-3: per-case pixel-diff threshold override for the screenshot diff
+    # viewer (docs/ROADMAP.md M12-3). NULL = use the viewer's client-side
+    # default (`DEFAULT_PIXEL_THRESHOLD` in screenshot-diff.ts). 0-255 range
+    # is enforced at the API layer (schemas/test_case.py `TestCaseUpdate`).
+    diff_threshold: Mapped[int | None] = mapped_column(Integer)
 
     suite: Mapped[Suite] = relationship("Suite")
     steps: Mapped[list[TestStep]] = relationship(

--- a/packages/shared/openapi.json
+++ b/packages/shared/openapi.json
@@ -9167,6 +9167,17 @@
             ],
             "title": "Description"
           },
+          "diff_threshold": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Diff Threshold"
+          },
           "effective_testing_approach": {
             "$ref": "#/components/schemas/TestingApproach",
             "default": "BLACK_BOX"
@@ -9548,6 +9559,19 @@
               }
             ],
             "title": "Description"
+          },
+          "diffThreshold": {
+            "anyOf": [
+              {
+                "maximum": 255.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Diffthreshold"
           },
           "framework": {
             "anyOf": [


### PR DESCRIPTION
Adds a tunable per-case pixel-diff threshold for the screenshot diff viewer shipped in M12-1, closing the last open ZERO-tier acceptance criterion in the M12 milestone (`docs/ROADMAP.md` M12-3).

## Changes

- `TestCase.diff_threshold` (nullable int) + Alembic migration `0050_case_diff_threshold`
- `TestCaseUpdate.diffThreshold` (0-255, validated) wired through the existing `PATCH /test-cases/:id` update path — no new endpoint, reuses the audited write path
- FE `ThresholdControl` in `ScreenshotDiffViewer` loads/persists the override via the API client and falls back to `DEFAULT_PIXEL_THRESHOLD` (30) when unset
- `DiffCanvas` now computes `pixelDiffPct`/`diffImage` with the resolved threshold instead of the hardcoded default
- MSW handler for the new PATCH shape, story args updated, one new test asserting the threshold input defaults correctly

## Testing

- `uv run ruff check` / `ruff format --check` on touched files: clean
- `uv run mypy .`: 0 new errors (identical to baseline — verified via `git stash` diff)
- `pnpm -C apps/web exec tsc --noEmit -p .`: clean
- `pnpm -C apps/web exec eslint <touched files> --max-warnings=0`: clean
- `pnpm -C apps/web` vitest: 393/396 pass; the 3 failures are in `GenerateModal.test.tsx` (untouched by this PR) and reproduce identically on `main` before this change (confirmed via `git stash`) — pre-existing, unrelated to this diff
- Backend `pytest` for `test_test_cases*.py` / `packages/db/tests/test_case.py`: skipped locally (testcontainers need Docker, unavailable in this sandbox); these will run against the real Postgres service in CI

Closes #M12-3
