### PR TITLE
fix(api): stop the UAT export 500ing on unrenderable content

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -28,6 +28,9 @@ dependencies = [
   "arq>=0.26",
   "aioboto3>=12.4",
   "fpdf2>=2.8.5",
+  # Already pulled in by fpdf2; declared because the UAT renderer validates
+  # evidence screenshots with it directly.
+  "pillow>=11",
 ]
 
 [build-system]

--- a/apps/api/src/suitest_api/services/uat_renderer.py
+++ b/apps/api/src/suitest_api/services/uat_renderer.py
@@ -21,11 +21,13 @@ footer with ``page N of M``.
 from __future__ import annotations
 
 import base64
+from dataclasses import replace
 from io import BytesIO
 from pathlib import Path
 
 from fpdf import FPDF
 from fpdf.fonts import FontFace
+from PIL import Image
 
 from suitest_api.services.uat_document import UatDocument
 
@@ -148,6 +150,66 @@ _LABELS: dict[str, dict[str, str]] = {
 }
 
 
+# fpdf2 core fonts (Helvetica) encode Latin-1 only; anything outside that range
+# raises FPDFUnicodeEncodingException mid-render. LLM-written case titles and
+# suite names routinely carry typographic punctuation, which used to 500 the
+# whole export.
+_LATIN1_FALLBACK = str.maketrans(
+    {
+        "\u2014": "-",
+        "\u2013": "-",
+        "\u2018": "'",
+        "\u2019": "'",
+        "\u201c": '"',
+        "\u201d": '"',
+        "\u2026": "...",
+        "\u2192": "->",
+        "\u2022": "-",
+        "\u00a0": " ",
+    }
+)
+
+
+def _latin1(text: str) -> str:
+    """Coerce text into the Latin-1 range Helvetica can encode.
+
+    ponytail: transliteration, not an embedded Unicode font. Ship a TTF via
+    ``add_font`` if a non-Latin locale (CJK, Cyrillic) is ever added.
+    """
+    return text.translate(_LATIN1_FALLBACK).encode("latin-1", "replace").decode("latin-1")
+
+
+def _encodable(doc: UatDocument) -> UatDocument:
+    """Copy the document with every rendered string coerced to Latin-1.
+
+    Done once at the entry point rather than at each of the 30+ draw calls, and
+    on a copy so the caller's document is untouched. ``evidence`` is left alone —
+    it holds base64 data URIs, which are ASCII by construction.
+    """
+    return replace(
+        doc,
+        title=_latin1(doc.title),
+        generated_at=_latin1(doc.generated_at),
+        sections=[
+            replace(
+                section,
+                module_name=_latin1(section.module_name),
+                rows=[
+                    replace(
+                        row,
+                        modul_fitur=_latin1(row.modul_fitur),
+                        test_case=_latin1(row.test_case),
+                        steps=[_latin1(x) for x in row.steps],
+                        results=[_latin1(x) for x in row.results],
+                    )
+                    for row in section.rows
+                ],
+            )
+            for section in doc.sections
+        ],
+    )
+
+
 class _UatPdf(FPDF):
     """Running header/footer. Both are suppressed on the cover page."""
 
@@ -267,7 +329,13 @@ def _first_image(evidence: list[str]) -> BytesIO | None:
         return None
     try:
         b64 = evidence[0].split(",", 1)[1]
-        return BytesIO(base64.b64decode(b64))
+        buf = BytesIO(base64.b64decode(b64))
+        # Decoding base64 is not enough: fpdf2 hands the bytes to Pillow at
+        # ``output()`` time, and a truncated or mislabelled screenshot raises
+        # UnidentifiedImageError there — far from this call site, as a bare 500.
+        Image.open(buf).verify()
+        buf.seek(0)
+        return buf
     except Exception:  # bad/absent image must never break the export
         return None
 
@@ -545,6 +613,7 @@ def _signoff(pdf: _UatPdf, doc: UatDocument, labels: dict[str, str]) -> None:
 def render_pdf(doc: UatDocument) -> bytes:
     """Render the document to PDF bytes (fpdf2). Pure, deterministic, ZERO-tier."""
     labels = _LABELS.get(doc.locale, _LABELS["id"])
+    doc = _encodable(doc)
     pdf = _UatPdf(labels, doc.title)
     pdf.set_auto_page_break(auto=True, margin=18)
     pdf.alias_nb_pages()

--- a/apps/api/tests/services/test_uat_renderer.py
+++ b/apps/api/tests/services/test_uat_renderer.py
@@ -58,9 +58,28 @@ def test_both_locales_render_and_differ() -> None:
     assert id_pdf != en_pdf
 
 
+def test_typographic_characters_do_not_crash() -> None:
+    # Helvetica is a Latin-1 core font; an em dash used to raise mid-render and
+    # surface as a bare 500 on the export endpoint.
+    doc = _doc()
+    doc.title = "RDB V43 \u2014 \u201cgrid\u201d selection\u2026"
+    doc.sections[0].module_name = "Editor \u2014 caret"
+    doc.sections[0].rows[0].test_case = "Verifikasi user tidak bisa \u2192 pindah"
+    doc.sections[0].rows[0].steps = ["Klik \u2018Copy\u2019", "Tekan \U0001f600"]
+    pdf = render_pdf(doc)
+    assert pdf[:5] == b"%PDF-"
+
+
 def test_bad_evidence_uri_does_not_crash() -> None:
     pdf = render_pdf(_doc(evidence=["data:image/png;base64,not-valid-b64!!"]))
     assert pdf[:5] == b"%PDF-"
+
+
+def test_undecodable_evidence_image_does_not_crash() -> None:
+    # Valid base64, unreadable image — a truncated screenshot. Pillow used to
+    # raise inside pdf.output(), long after _first_image had waved it through.
+    uri = "data:image/png;base64," + base64.b64encode(_PNG[:20]).decode("ascii")
+    assert render_pdf(_doc(evidence=[uri]))[:5] == b"%PDF-"
 
 
 def _page_count(pdf: bytes) -> int:


### PR DESCRIPTION
## Summary

- Export UAT returned a bare `text/plain` 500 for any project whose case or suite titles carry typographic punctuation — the document was simply unobtainable. The renderer uses fpdf2's core Helvetica, which encodes Latin-1 only, so an em dash raised `FPDFUnicodeEncodingException` mid-render.
- Evidence screenshots had the same failure one layer down: `_first_image` validated only the base64, while Pillow decodes the bytes much later inside `output()`, so a truncated screenshot surfaced as the same opaque 500.

## Changes

**`apps/api/src/suitest_api/services/uat_renderer.py`**
- `_latin1()` + `_encodable()`: coerce the document's strings to Latin-1 once at the renderer entry point rather than at each of the 30+ draw calls, and on a copy so the caller's document is untouched. `evidence` is left alone — base64 data URIs are ASCII by construction.
- Transliteration rather than an embedded Unicode font: the product ships two Latin locales, and a TTF would cost ~2 MB in every wheel to buy script coverage nothing asks for yet. The `ponytail:` comment names `add_font` as the upgrade path.
- `_first_image()` now verifies the image where it is decoded and drops it if unreadable, which the surrounding code already treats as normal.

**`apps/api/pyproject.toml`**
- Declare `pillow` explicitly; it was already present transitively via fpdf2, but the renderer now imports it directly.

**`apps/api/tests/services/test_uat_renderer.py`**
- Two regression tests. Both inputs are silent from the outside — the renderer returns valid PDF bytes either way — so they pin the inputs that broke it.

## Test plan

- [x] `pytest apps/api/tests/services/test_uat_renderer.py apps/api/tests/services/test_uat_document.py` — 12 passed
- [x] ruff check, ruff format, mypy strict on the touched files — clean
- [x] Fix is load-bearing: stubbing `_encodable` to identity brings `FPDFUnicodeEncodingException` back
- [x] Replayed the original failing request end-to-end against a real project (22 cases, a suite name containing an em dash): `200 OK`, `application/pdf`, 81392 bytes, valid `%PDF-1.4`, 10 pages, evidence images embedded, section header rendered with a plain hyphen
- [x] Same request with `"locale":"en"` — `200 OK`, `application/pdf`
- [ ] `apps/api/tests/test_exports_uat.py` — skipped locally (needs docker/Postgres); relying on CI