### PR TITLE
feat(deploy): standalone self-host compose + Streamable-HTTP MCP relay

### DIFF
--- a/.env.deploy.example
+++ b/.env.deploy.example
@@ -1,0 +1,45 @@
+# Example env for compose.deploy.yml (self-hosted Suitest behind Caddy).
+# Copy to .env (gitignored) and fill. All values have generous defaults except
+# the three secrets marked REQUIRED.
+
+# ── Core secrets (REQUIRED) ────────────────────────────────────────────
+# 32-char random hex:  openssl rand -hex 32
+SUITEST_AUTH_SECRET=
+# base64 32-byte key:  openssl rand -base64 32
+SUITEST_ENCRYPTION_KEY=
+# Super-admin bootstrap (created idempotently on first boot if no users exist).
+SUITEST_SUPERADMIN_EMAIL=admin@suitest.local
+SUITEST_SUPERADMIN_PASSWORD=admin123
+
+# Suitest API key for the MCP relay (minted in the web UI after boot:
+# Settings → API keys). Needed before `mcp-relay` will start.
+SUITEST_API_KEY=
+# Shared secret clients send as `X-API-Key` to the Streamable-HTTP relay.
+MCP_RELAY_TOKEN=
+
+# ── Postgres (container-internal, published to loopback only) ──────────
+POSTGRES_PASSWORD=suitest
+
+# ── Object storage (MinIO) ─────────────────────────────────────────────
+SUITEST_S3_BUCKET=suitest
+SUITEST_S3_ACCESS_KEY=minioadmin
+SUITEST_S3_SECRET_KEY=minioadmin
+
+# ── Public URLs (behind Caddy; SPA is same-origin so only WEB_URL matters) ─
+SUITEST_WEB_URL=http://localhost:3033
+SUITEST_API_URL=http://localhost:4040
+
+# ── Image tag (pin a release for stability; default latest) ────────────
+# SUITEST_IMAGE_TAG=0.x.y
+
+# ── Host port mapping (loopback sources for Caddy → container targets) ──
+SUITEST_WEB_PORT=3033
+SUITEST_API_PORT=4040
+SUITEST_MCP_PORT=4044
+SUITEST_PG_PORT=15432
+SUITEST_REDIS_PORT=16379
+SUITEST_MINIO_PORT=19000
+SUITEST_MINIO_CONSOLE_PORT=19001
+
+# HTTPS production → send session cookie over TLS only.
+# SUITEST_COOKIE_SECURE=true

--- a/compose.deploy.yml
+++ b/compose.deploy.yml
@@ -1,0 +1,203 @@
+# Standalone Suitest deploy stack — a full fork of infra/docker/docker-compose.yml
+# tuned for single-host self-hosting behind Caddy.
+#
+# Why a standalone file instead of an override?
+#   Docker Compose MERGES `ports` lists by appending; an override cannot strip a
+#   base-file host publish. To reclaim ports that collide with other tenants on
+#   a shared host (5432/6379/9000/9001/3000), the authoritative compose is forked
+#   here and republished to loopback on configurable ports.
+#
+# Quick start (see .env for all knobs):
+#   cp .env.deploy.example .env   # fill secrets
+#   echo "SUITEST_API_KEY=sk_..." >> .env   # after first boot, mint a key
+#   docker compose -f compose.deploy.yml --profile zero up -d
+#
+# Services:
+#   infra (postgres/redis/minio)  loopback-only, inaccessible from the internet
+#   web / api / runner / migrate    Suitest core (ZERO/CLOUD/LOCAL tiers)
+#   mcp-relay                       Streamable-HTTP relay for @suiflex/suitest-mcp
+#
+# Everything host-specific (domains, secrets, ports) comes from .env, so this
+# file is portable across hosts.
+
+x-suitest-env: &suitest-env
+  SUITEST_DATABASE_URL: ${SUITEST_DATABASE_URL:-postgresql+asyncpg://suitest:${POSTGRES_PASSWORD:-suitest}@postgres:5432/suitest}
+  SUITEST_REDIS_URL: ${SUITEST_REDIS_URL:-redis://redis:6379/0}
+  SUITEST_S3_ENDPOINT: ${SUITEST_S3_ENDPOINT:-http://minio:9000}
+  SUITEST_S3_BUCKET: ${SUITEST_S3_BUCKET:-suitest}
+  SUITEST_S3_ACCESS_KEY: ${SUITEST_S3_ACCESS_KEY:-minioadmin}
+  SUITEST_S3_SECRET_KEY: ${SUITEST_S3_SECRET_KEY:-minioadmin}
+  SUITEST_LLM_PROVIDER: ${SUITEST_LLM_PROVIDER:-}
+  SUITEST_ENCRYPTION_KEY: ${SUITEST_ENCRYPTION_KEY}
+  SUITEST_AUTH_SECRET: ${SUITEST_AUTH_SECRET}
+  SUITEST_WEB_URL: ${SUITEST_WEB_URL:-http://localhost:3000}
+  SUITEST_API_URL: ${SUITEST_API_URL:-http://localhost:4000}
+  SUITEST_OAUTH_GOOGLE_CLIENT_ID: ${SUITEST_OAUTH_GOOGLE_CLIENT_ID:-}
+  SUITEST_OAUTH_GOOGLE_CLIENT_SECRET: ${SUITEST_OAUTH_GOOGLE_CLIENT_SECRET:-}
+  SUITEST_SUPERADMIN_EMAIL: ${SUITEST_SUPERADMIN_EMAIL:-admin@suitest.local}
+  SUITEST_SUPERADMIN_PASSWORD: ${SUITEST_SUPERADMIN_PASSWORD:-admin123}
+
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    profiles: ["zero", "cloud", "local", "demo"]
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: suitest
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-suitest}
+      POSTGRES_DB: suitest
+    ports:
+      - "127.0.0.1:${SUITEST_PG_PORT:-15432}:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U suitest -d suitest"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    profiles: ["zero", "cloud", "local", "demo"]
+    restart: unless-stopped
+    command: ["redis-server", "--appendonly", "yes"]
+    ports:
+      - "127.0.0.1:${SUITEST_REDIS_PORT:-16379}:6379"
+    volumes:
+      - redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  minio:
+    image: minio/minio:latest
+    profiles: ["zero", "cloud", "local", "demo"]
+    restart: unless-stopped
+    command: ["server", "/data", "--console-address", ":9001"]
+    environment:
+      MINIO_ROOT_USER: ${SUITEST_S3_ACCESS_KEY:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${SUITEST_S3_SECRET_KEY:-minioadmin}
+    ports:
+      - "127.0.0.1:${SUITEST_MINIO_PORT:-19000}:9000"
+      - "127.0.0.1:${SUITEST_MINIO_CONSOLE_PORT:-19001}:9001"
+    volumes:
+      - miniodata:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  minio-init:
+    image: minio/mc:latest
+    profiles: ["zero", "cloud", "local", "demo"]
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+        mc alias set local http://minio:9000 ${SUITEST_S3_ACCESS_KEY:-minioadmin} ${SUITEST_S3_SECRET_KEY:-minioadmin} &&
+        mc mb --ignore-existing local/${SUITEST_S3_BUCKET:-suitest} &&
+        mc anonymous set download local/${SUITEST_S3_BUCKET:-suitest} ||
+        echo 'bucket init done';
+      "
+    restart: "no"
+
+  migrate:
+    image: ghcr.io/suiflex/suitest-api:${SUITEST_IMAGE_TAG:-latest}
+    build:
+      context: .
+      dockerfile: infra/docker/Dockerfile.api
+    profiles: ["zero", "cloud", "local", "demo"]
+    environment: *suitest-env
+    depends_on:
+      postgres:
+        condition: service_healthy
+    working_dir: /app/packages/db
+    command: ["uv", "run", "--project", "/app", "alembic", "upgrade", "head"]
+    restart: "no"
+
+  api:
+    image: ghcr.io/suiflex/suitest-api:${SUITEST_IMAGE_TAG:-latest}
+    build:
+      context: .
+      dockerfile: infra/docker/Dockerfile.api
+    profiles: ["zero", "cloud", "local", "demo"]
+    environment: *suitest-env
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      minio:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    ports:
+      - "127.0.0.1:${SUITEST_API_PORT:-4040}:4000"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:4000/health"]
+      interval: 15s
+      timeout: 5s
+      start_period: 20s
+      retries: 5
+
+  runner:
+    image: ghcr.io/suiflex/suitest-runner:${SUITEST_IMAGE_TAG:-latest}
+    build:
+      context: .
+      dockerfile: infra/docker/Dockerfile.runner
+    profiles: ["zero", "cloud", "local", "demo"]
+    environment: *suitest-env
+    depends_on:
+      api:
+        condition: service_healthy
+      redis:
+        condition: service_started
+
+  web:
+    image: ghcr.io/suiflex/suitest-web:${SUITEST_IMAGE_TAG:-latest}
+    build:
+      context: .
+      dockerfile: infra/docker/Dockerfile.web
+    profiles: ["zero", "cloud", "local", "demo"]
+    depends_on:
+      api:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:${SUITEST_WEB_PORT:-3033}:80"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  # Streamable-HTTP MCP relay: Suitest's MCP server is stdio-only; this proxy
+  # (mcp-proxy) exposes the same tools over the Streamable HTTP transport at
+  # /mcp. Clients authenticate with X-API-Key: $MCP_RELAY_TOKEN.
+  mcp-relay:
+    build:
+      context: mcp-relay/
+      dockerfile: Dockerfile
+    profiles: ["zero", "cloud", "local", "demo"]
+    restart: unless-stopped
+    depends_on:
+      api:
+        condition: service_healthy
+    environment:
+      SUITEST_API_URL: http://api:4000
+      SUITEST_API_KEY: ${SUITEST_API_KEY:?set SUITEST_API_KEY in .env}
+      MCP_RELAY_TOKEN: ${MCP_RELAY_TOKEN:?set MCP_RELAY_TOKEN in .env}
+    ports:
+      - "127.0.0.1:${SUITEST_MCP_PORT:-4044}:4044"
+
+volumes:
+  pgdata:
+  redisdata:
+  miniodata:
+
+networks:
+  default:
+    name: suitest

--- a/mcp-relay/Dockerfile
+++ b/mcp-relay/Dockerfile
@@ -1,0 +1,28 @@
+# Streamable-HTTP MCP relay for Suitest.
+#
+# Suitest's own MCP server (@suiflex/suitest-mcp) speaks only stdio. This image
+# wraps it behind mcp-proxy (sparfenyuk), which exposes the same tools over the
+# Streamable HTTP transport at /mcp, so remote MCP clients can drive Suitest
+# over HTTPS (Caddy → mcp.sui.keton.id/mcp → this container → stdio).
+#
+# The relay delegates to the Suitest API over the internal docker network
+# (SUITEST_API_URL=http://api:4000) and authenticates with a Suitest API key
+# (SUITEST_API_KEY). Clients must present the relay bearer token
+# (MCP_RELAY_TOKEN) via the X-API-Key header.
+#
+# Requires Python >= 3.11 on PATH for the suitest lifecycle server; bookworm
+# ships python3.11.
+FROM node:22-bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g mcp-proxy @suiflex/suitest-mcp@latest
+
+# The spawned child (suitest-mcp) inherits this process's environment, so
+# SUITEST_API_URL / SUITEST_API_KEY / MCP_RELAY_TOKEN reach it via compose env.
+EXPOSE 4044
+# Shell form so the container shell expands ${MCP_RELAY_TOKEN} from its env at
+# runtime (compose writes a literal $${...} here after its own interpolation).
+ENTRYPOINT []
+CMD ["sh", "-c", "mcp-proxy --host 0.0.0.0 --port 4044 --streamEndpoint /mcp --apiKey \"${MCP_RELAY_TOKEN}\" -- suitest-mcp"]

--- a/mcp-relay/README.md
+++ b/mcp-relay/README.md
@@ -1,0 +1,64 @@
+# Suitest over Streamable HTTP (MCP relay)
+
+Suitest's own MCP server — `@suiflex/suitest-mcp` — speaks **only stdio** (its
+lifecycle server is a minimal NDJSON-over-pipes JSON-RPC process; see
+`packages/lifecycle/src/suitest_lifecycle/mcp_server.py`). That limits clients
+to boxes that can spawn the npm package locally.
+
+This directory ships a thin relay that exposes the same tools over the
+[Streamable HTTP](https://modelcontextprotocol.io) transport, so any MCP client
+can drive Suitest over HTTPS from anywhere.
+
+```
+MCP client ──HTTPS──▶ Caddy ──▶ mcp-relay (mcp-proxy, :4044) ──stdio──▶ suitest-mcp
+                                                                              │
+                                                                    http://api:4000
+```
+
+## How it works
+
+- [`mcp-proxy`](https://github.com/sparfenyuk/mcp-proxy) (npm) listens on
+  `/mcp` and translates Streamable-HTTP JSON-RPC into stdio frames.
+- The spawned child is the global `suitest-mcp` binary from
+  `@suiflex/suitest-mcp`; it inherits the relay's environment, so compose sets
+  `SUITEST_API_URL` / `SUITEST_API_KEY` and they reach Suitest's API.
+- Clients authenticate with `X-API-Key: <MCP_RELAY_TOKEN>` (configured on the
+  proxy via `--apiKey`). Combined with a Suitest API key, that's the remote
+  access boundary.
+
+## Files
+
+| Path | Purpose |
+|------|---------|
+| `Dockerfile` | `node:22-bookworm-slim` + `python3` (Suitest needs ≥3.11) + `mcp-proxy` + `@suiflex/suitest-mcp` |
+| `../compose.deploy.yml` | `mcp-relay` service wiring it into the stack |
+
+## Structured config for an MCP client
+
+```json
+{
+  "mcpServers": {
+    "suitest": {
+      "type": "streamable-http",
+      "url": "https://mcp.example.com/mcp",
+      "headers": {
+        "X-API-Key": "<MCP_RELAY_TOKEN>"
+      }
+    }
+  }
+}
+```
+
+> Stanza shape varies by client; `type: "streamable-http"` / `"http"` is the
+> commonly accepted marker. The token and the Suitest API key are independent.
+
+## Notes / limits
+
+- **One stdio server per proxy process.** Stateful Streamable-HTTP keeps a
+  session open vs. Suitest's pooled runner (idle TTL 60s), so each connected
+  client holds a spawned `suitest-mcp`. Reconfigure pooling
+  (`SUITEST_MCP_MAX_SESSIONS_PER_WORKSPACE`) if you need many concurrent
+  remote agents.
+- `mcp-proxy --streamEndpoint` defaults to `/mcp`.
+- The underlying server is MCP 2024-11-05; keep `mcp-proxy`'s default legacy
+  upstream protocol.


### PR DESCRIPTION
<!-- One PR = one ROADMAP acceptance criterion. -->

## What

Adds a **remote-access path for Suitest's own MCP server**, which currently speaks stdio only (`packages/mcp-npx` → `packages/lifecycle/src/suitest_lifecycle/mcp_server.py`): a client has to run on the same machine as the project under test. Two pieces:

1. **`mcp-relay/`** — a [mcp-proxy](https://github.com/sparfenyuk/mcp-proxy) container fronting `@suiflex/suitest-mcp` over the **Streamable HTTP** transport at `/mcp`, so remote MCP clients (agent runtimes, IDEs on other hosts) can drive a self-hosted Suitest over TLS. The spawned child inherits `SUITEST_API_URL`/`SUITEST_API_KEY` from compose; clients authenticate to the relay itself with `X-API-Key: $MCP_RELAY_TOKEN` (independent of the Suitest API key). Both vars are `${VAR:?}`-required so the relay never boots half-configured.

2. **`compose.deploy.yml`** — a standalone single-file deploy stack that carries the relay, forked from `infra/docker/docker-compose.yml`. Forked (not an override) because Compose **merges `ports` lists by appending** — an override cannot strip a base host publish, and the canonical file publishes `5432/6379/9000/9001/3000`, which collide with other tenants on a shared host. The fork republishes postgres/redis/minio to loopback-only high ports (15432/16379/19000/19001), keeps every knob env-driven, and adds the `mcp-relay` service. `.env.deploy.example` documents every knob.

Docs: `DEPLOYMENT.md` §1.5 (proxy + client stanza + two-secret model), `ARCHITECTURE.md` §4 (new dependency), `ROADMAP.md` (M4-33).

## Roadmap criterion

Closes #M4-33 (Remote MCP access over Streamable HTTP — added to the M4 operational-hardening section in this PR, per "if the ROADMAP disagrees, update the doc in the same PR").

## Checklist

- [x] Works at **ZERO tier** (no LLM) or gracefully degrades — the relay is LLM-free: it proxies MCP JSON-RPC to the stdio server and the Suitest API; nothing here calls a model.
- [x] Capability/autonomy gating added for any LLM-dependent feature — N/A, no LLM-dependent feature and no new endpoint (`require_tier` untouched).
- [ ] `make check-all` passes (ruff + mypy + eslint + tsc) — **not run**: the diff adds only YAML/Dockerfile/Markdown, no Python/TS files; CI's path filter skips python-lint/ts-lint for this change.
- [ ] `make test` passes (new tests added for new behavior) — **not run locally** (no test surface for YAML/Dockerfile in the repo's suites); see Verification for what was exercised instead.
- [x] `make test-web` passes (if FE touched) — N/A, no FE changes.
- [x] Alembic migration added for any schema change — N/A, no schema change.
- [x] Secrets handled via AES-GCM; mutations audit-logged — N/A: no new secret storage; the two new secrets live in env/compose only, and the relay holds no DB writes.
- [x] Docs updated (`docs/*`, `ROADMAP.md` checkbox) — DEPLOYMENT §1.5, ARCHITECTURE §4, ROADMAP M4-33 entry added.

## Verification (commands actually run)

On a clean Debian 13 host with Docker 29.7.1, from this branch:

```bash
# 1. compose renders + the required-secrets guard works
SUITEST_API_KEY=sk_dummy MCP_RELAY_TOKEN=abc \
  docker compose --env-file .env -f compose.deploy.yml --profile zero config   # exit 0
docker compose --env-file .env -f compose.deploy.yml --profile zero config    # fails on missing SUITEST_API_KEY, as designed

# 2. full stack boot (migrate → api healthy → web/runner/mcp-relay)
docker compose --env-file .env -f compose.deploy.yml --profile zero up -d \
  --build postgres redis minio minio-init migrate api web runner
# → all healthy; GET /health → {"status":"ok","service":"api","version":"0.1.0"}

# 3. MCP over the relay: initialize through a real TLS reverse proxy
curl -X POST https://mcp.example.com/mcp \
  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
  -H 'X-API-Key: <MCP_RELAY_TOKEN>' \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"curl","version":"1"}}}'
# → 200, event-stream frame: {"result":{"protocolVersion":"2024-11-05",
#    "capabilities":{"tools":{}},"serverInfo":{"name":"suitest-lifecycle","version":"0.1.2"}}}
# tools/list (with the returned Mcp-Session-Id) → analyze_project, generate_test_cases, …

# 4. data plane through the deployed API (superadmin session):
#    POST /projects → POST /suites → POST /test-cases → GET back TC-1000 ✓
```

## Notes / open questions

- **Why fork the compose instead of an override?** Compose list-merge semantics make port-stripping via override impossible (documented in the file header too). If maintainers would rather see `infra/docker/docker-compose.yml` grow an opt-in `mcp-relay` profile service instead, that is a smaller diff and I'm happy to rework; the relay image (`mcp-relay/Dockerfile`) is standalone either way.
- **Session model:** stateful Streamable-HTTP keeps one stdio child per connected client (mcp-proxy session TTL 30 min default). Fine for a self-hosted install; worth revisiting (stateless mode / pooling) if remote agents multiply.
- **Upstream protocol pinned legacy** (MCP 2024-11-05) matching what `packages/lifecycle` speaks; mcp-proxy `--modern` left at its default (it classifies per request, so legacy clients are unaffected).
- CLA: first PR from this account — will sign when the CLA bot comments.