### PR TITLE
fix(deploy): bake pip+playwright+chromium into mcp-relay image

### DIFF
--- a/mcp-relay/Dockerfile
+++ b/mcp-relay/Dockerfile
@@ -3,7 +3,7 @@
 # Suitest's own MCP server (@suiflex/suitest-mcp) speaks only stdio. This image
 # wraps it behind mcp-proxy (sparfenyuk), which exposes the same tools over the
 # Streamable HTTP transport at /mcp, so remote MCP clients can drive Suitest
-# over HTTPS (Caddy → mcp.sui.keton.id/mcp → this container → stdio).
+# over HTTPS (Caddy → mcpsui.keton.id/mcp → this container → stdio).
 #
 # The relay delegates to the Suitest API over the internal docker network
 # (SUITEST_API_URL=http://api:4000) and authenticates with a Suitest API key
@@ -14,8 +14,16 @@
 # ships python3.11.
 FROM node:22-bookworm-slim
 
+# Python ≥3.11 runtime for the suitest lifecycle server (bookworm ships 3.11),
+# plus pip and the black-box tooling dependencies baked in at build time:
+# suitest_lifecycle can pip-install playwright on demand, but bookworm-slim
+# python3 has neither pip nor ensurepip, and a runtime
+# `playwright install chromium` would still miss the chromium OS libraries.
+# requests is preinstalled for orchestrator.py's pydeps.ensure("requests").
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        python3 ca-certificates \
+        python3 python3-pip ca-certificates \
+    && pip install --no-cache-dir --break-system-packages playwright requests \
+    && python3 -m playwright install --with-deps chromium \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g mcp-proxy @suiflex/suitest-mcp@latest
 

--- a/mcp-relay/README.md
+++ b/mcp-relay/README.md
@@ -18,7 +18,7 @@ MCP client ──HTTPS──▶ reverse proxy ──▶ mcp-relay (:4044) ──
 
 | Path | Purpose |
 |------|---------|
-| `Dockerfile` | `node:22-bookworm-slim` + `python3` (Suitest needs ≥3.11 on PATH) + `mcp-proxy` + `@suiflex/suitest-mcp` |
+| `Dockerfile` | `node:22-bookworm-slim` + `python3`+`python3-pip` (Suitest needs ≥3.11 on PATH) + `playwright`+`requests` (pip, `--break-system-packages`) + Chromium via `playwright install --with-deps` + `mcp-proxy` + `@suiflex/suitest-mcp` — the black-box Playwright tools need the browser stack preinstalled: slim python3 ships no pip/ensurepip, and a runtime install would miss chromium's OS libraries |
 | `../compose.deploy.yml` | the `mcp-relay` service wiring it into the deploy stack |
 
 ## How it works


### PR DESCRIPTION
<!-- One PR = one ROADMAP acceptance criterion. -->

## What

The `mcp-relay` image (merged in #143) could never serve its black-box Playwright tools: the Dockerfile installed bare `python3` (bookworm-slim), which ships **no pip and no ensurepip**. `suitest_lifecycle`'s on-demand provisioning chain (`frontend_runtime.ensure_browser` → `pydeps.install("playwright")` → `pydeps.ensure_pip` → `python -m ensurepip`) therefore died before it could install playwright, and the surfaced error told users to run `python3 -m pip install playwright` in an interpreter that had no pip. A runtime `playwright install chromium` would additionally have missed chromium's OS libraries on a slim base (the package calls plain `playwright install chromium`, not `--with-deps`).

Fix: bake the whole stack at build time — `python3-pip`, `playwright` + `requests` (the orchestrator also `pydeps.ensure("requests")` for the API data plane), and `playwright install --with-deps chromium`. `ensure_browser()` is idempotent, so runtime cost stays a fast-path probe.

## Roadmap criterion

Follow-up bug fix to M4-33 (Remote MCP access over Streamable HTTP, shipped in #143) — the relay boots but its advertised `blackbox_*` tools fail without this.

## Checklist

- [x] Works at **ZERO tier** (no LLM) or gracefully degrades — no LLM surface touched; provisioning is deterministic build-time installs.
- [x] Capability/autonomy gating added for any LLM-dependent feature — N/A.
- [ ] `make check-all` passes — N/A: diff is Dockerfile + Markdown only (same rationale as #143's CI note).
- [ ] `make test` passes — N/A: no Python/TS test surface for this path in-repo; exercised live instead (see Verification).
- [x] `make test-web` — N/A, no FE changes.
- [x] Alembic migration — N/A, no schema change.
- [x] Secrets — N/A: no new secret; `SUITEST_API_KEY` / `MCP_RELAY_TOKEN` semantics unchanged.
- [x] Docs updated — `mcp-relay/README.md` layout table now matches the image; no `docs/*` file mentions pip/playwright for the relay (checked), so no spec changes needed.

## Verification (commands actually run)

On the deploy host (Debian 13, Docker 29.7.1), from this branch's Dockerfile:

```bash
docker compose --env-file .env -f compose.deploy.yml --profile cloud build mcp-relay
docker compose --env-file .env -f compose.deploy.yml --profile cloud up -d mcp-relay

# inside the rebuilt container:
python3 -m pip --version                          # pip 23.0.1 (was: "No module named pip")
python3 -c "import playwright, requests"          # was: ModuleNotFoundError
python3 -m playwright install chromium --dry-run  # Chrome for Testing 151.0.7922.34 present
# suitest_lifecycle.frontend_runtime.ensure_browser() → BrowserStatus(ready=True)

# real headless launch + render (was the failing path):
# sync_playwright → chromium.launch → goto(data:text/html,<h1>ok</h1>) → text_content → "ok"

# end-to-end through the deployed relay:
# initialize → tools/list now includes blackbox_analyze_page, blackbox_crawl_routes, …
# tools/call blackbox_analyze_page {url: http://web:80/} →
#   {"success": true, "route": "http://web/login", "pattern": "login", inputs: [#email, …]}
```

## Notes / open questions

- Build-time image grows by the browser stack (chromium + OS libs, a few hundred MB). Alternative considered: ship `python3-pip` only and let the first blackbox call auto-install at runtime — rejected: `ensurepip` is absent in slim python3 so `pydeps.ensure_pip` can't bootstrap, and a runtime `--with-deps` would need root + apt lists that the Dockerfile scrubs; baking keeps the relay deterministic and offline-safe.
- No code changes in `packages/*`: the runtime auto-install chain stays as-is for non-container users (local bundle / venv paths still benefit).
