### PR TITLE
build(release): bring every published package under release-please

### DIFF
--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -6,6 +6,11 @@ name: release-mcp
 #
 # npm uses OIDC Trusted Publishing; no long-lived NPM_TOKEN is required. PyPI
 # still uses PYPI_TOKEN. On PRs, the build + smoke + dry-run steps validate.
+#
+# The lifecycle version is no longer hand-edited: release-please links it to
+# the mcp version (`linked-versions` group "mcp"), so packages/lifecycle and
+# packages/mcp-npx always carry the same number and the publish step below
+# reads a version that release-please already bumped.
 
 on:
   push:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,9 +1,17 @@
 name: release-please
 
-# Version + changelog automation for the three published npm packages:
-#   - packages/mcp-npx     → @suiflex/suitest-mcp  → tag mcp-v*      → release-mcp.yml
-#   - sdk/typescript       → @suiflex/suitest-sdk  → tag tssdk-v*    → release-ts-sdk.yml
-#   - packages/suitest-npx → @suiflex/suitest      → tag launcher-v* → release-launcher.yml
+# Version + changelog automation for every published artifact:
+#   - packages/mcp-npx     → @suiflex/suitest-mcp        → tag mcp-v*       → release-mcp.yml
+#   - packages/lifecycle   → suiflex-suitest-lifecycle   → tag lifecycle-v* → release-mcp.yml (publishes on mcp-v*)
+#   - sdk/typescript       → @suiflex/suitest-sdk        → tag tssdk-v*     → release-ts-sdk.yml
+#   - sdk/python           → suiflex-suitest-sdk         → tag pysdk-v*     → release-python-sdk.yml
+#   - cli                  → suiflex-suitest-cli         → tag cli-v*       → release-python-sdk.yml (publishes on pysdk-v*)
+#   - packages/suitest-npx → @suiflex/suitest            → tag launcher-v*  → release-launcher.yml + release-images.yml
+#
+# Two `linked-versions` groups keep artifacts that ship together on one
+# version: mcp+lifecycle and pysdk+cli. Each group member still gets its own
+# tag; the lifecycle-v* and cli-v* tags are inert markers, since the publish
+# workflows key off their group partner's tag.
 # A maintainer starts release preparation explicitly (workflow_dispatch) to
 # open/update a release PR. Merging that PR finalizes it automatically into a
 # tag + GitHub Release, which then triggers the matching publish workflow

--- a/.github/workflows/release-python-sdk.yml
+++ b/.github/workflows/release-python-sdk.yml
@@ -46,6 +46,19 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
+      - name: Tag matches package version
+        # release-please owns both versions, so this should never fire — it
+        # turns a hand-cut or stale tag into a red build instead of a PyPI
+        # release whose number disagrees with the code inside it.
+        if: github.event_name != 'pull_request'
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          TAG_VERSION="${RELEASE_TAG:-$GITHUB_REF_NAME}"
+          TAG_VERSION="${TAG_VERSION#pysdk-v}"
+          PKG_VERSION="$(grep -m1 '^version = ' "${{ matrix.package }}/pyproject.toml" | cut -d'"' -f2)"
+          [ "$TAG_VERSION" = "$PKG_VERSION" ] || {
+            echo "tag $TAG_VERSION != ${{ matrix.package }} $PKG_VERSION" >&2; exit 1; }
       - name: Build
         run: |
           python -m pip install --upgrade build twine

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,8 @@
 {
   "packages/mcp-npx": "0.8.0",
+  "packages/lifecycle": "0.1.9",
   "sdk/typescript": "0.1.1",
+  "sdk/python": "0.1.1",
+  "cli": "0.1.1",
   ".": "0.8.0"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,9 +188,27 @@ than from memory, and open an issue before you start.
 ## Commit conventions
 
 Commits follow [Conventional Commits](https://www.conventionalcommits.org/), and
-`release-please` parses them to generate changelogs and version bumps for three
-separately released components: `packages/mcp-npx`, `packages/suitest-npx` and
-`sdk/typescript`.
+`release-please` parses them to generate the changelog and version bump for
+every published artifact. Nothing is versioned by hand:
+
+| Path | Tag | Published as |
+|------|-----|--------------|
+| `packages/mcp-npx` | `mcp-v*` | npm `@suiflex/suitest-mcp` |
+| `packages/lifecycle` | `lifecycle-v*` | PyPI `suiflex-suitest-lifecycle` |
+| `sdk/typescript` | `tssdk-v*` | npm `@suiflex/suitest-sdk` |
+| `sdk/python` | `pysdk-v*` | PyPI `suiflex-suitest-sdk` |
+| `cli` | `cli-v*` | PyPI `suiflex-suitest-cli` |
+| `.` → `packages/suitest-npx` | `launcher-v*` | npm `@suiflex/suitest` + GHCR images |
+
+Two `linked-versions` groups keep artifacts that ship together on one version:
+`mcp` + `lifecycle` (the npm package vendors the lifecycle sources at
+`prepack`), and `pysdk` + `cli` (one `pysdk-v*` tag publishes both). Bumping
+either member bumps both, so a change to `packages/lifecycle` alone still
+produces a new `@suiflex/suitest-mcp` release.
+
+The remaining packages — `apps/*` and `packages/{core,db,mcp,shared,agent}` —
+are never published on their own; they ship inside the launcher bundle and
+their `version` fields are not maintained.
 
 - Types: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`, `build`, `ci`
 - Subject ≤ 72 characters, imperative mood, no trailing period

--- a/cli/src/suitest_cli/__init__.py
+++ b/cli/src/suitest_cli/__init__.py
@@ -1,3 +1,3 @@
 """Suitest CLI package (M4-7)."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"  # x-release-please-version

--- a/packages/lifecycle/src/suitest_lifecycle/__init__.py
+++ b/packages/lifecycle/src/suitest_lifecycle/__init__.py
@@ -1,3 +1,3 @@
 """Suitest testing lifecycle — TestSprite-parity analyze→generate→run→report."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.9"  # x-release-please-version

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,18 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "separate-pull-requests": true,
   "include-component-in-tag": true,
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "mcp",
+      "components": ["mcp", "lifecycle"]
+    },
+    {
+      "type": "linked-versions",
+      "groupName": "pysdk",
+      "components": ["pysdk", "cli"]
+    }
+  ],
   "packages": {
     "packages/mcp-npx": {
       "release-type": "node",
@@ -9,10 +21,43 @@
       "package-name": "@suiflex/suitest-mcp",
       "extra-files": ["VERSION"]
     },
+    "packages/lifecycle": {
+      "release-type": "python",
+      "component": "lifecycle",
+      "package-name": "suiflex-suitest-lifecycle",
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "packages/lifecycle/src/suitest_lifecycle/__init__.py"
+        }
+      ]
+    },
     "sdk/typescript": {
       "release-type": "node",
       "component": "tssdk",
       "package-name": "@suiflex/suitest-sdk"
+    },
+    "sdk/python": {
+      "release-type": "python",
+      "component": "pysdk",
+      "package-name": "suiflex-suitest-sdk",
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "sdk/python/src/suitest_sdk/__init__.py"
+        }
+      ]
+    },
+    "cli": {
+      "release-type": "python",
+      "component": "cli",
+      "package-name": "suiflex-suitest-cli",
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "cli/src/suitest_cli/__init__.py"
+        }
+      ]
     },
     ".": {
       "release-type": "simple",

--- a/sdk/python/src/suitest_sdk/__init__.py
+++ b/sdk/python/src/suitest_sdk/__init__.py
@@ -17,4 +17,4 @@ Example::
 from suitest_sdk.client import SuitestAPIError, SuitestClient
 
 __all__ = ["SuitestAPIError", "SuitestClient"]
-__version__ = "0.1.0"
+__version__ = "0.1.1"  # x-release-please-version


### PR DESCRIPTION
## Summary

- Three of the six published artifacts — `suiflex-suitest-sdk`, `suiflex-suitest-cli` and `suiflex-suitest-lifecycle` — sat outside `release-please-config.json`, so their versions were bumped by hand and the `pysdk-v*` tag was cut manually.
- That has already drifted: all three carried `__version__ = "0.1.0"` while their `pyproject.toml` read `0.1.1` / `0.1.1` / `0.1.9`.
- Worse, `packages/mcp-npx` vendors the lifecycle sources at `prepack`, but 12 of the last 20 commits touching `packages/lifecycle` left `packages/mcp-npx` alone — the npm package repeatedly shipped new lifecycle code under an unchanged version.

## Changes

**Version constants**
- Pinned `__version__` in `sdk/python`, `cli` and `packages/lifecycle` to the version actually published, annotated `# x-release-please-version` so it stays in step.

**release-please**
- Added `packages/lifecycle`, `sdk/python` and `cli` as `release-type: python` components (`lifecycle`, `pysdk`, `cli`), each with a `generic` extra-file for its `__init__.py`.
- Added two `linked-versions` groups: `mcp` = {`mcp`, `lifecycle`} and `pysdk` = {`pysdk`, `cli`}. Bumping either member bumps both, so a lifecycle-only change now forces a new `@suiflex/suitest-mcp` release.
- Seeded the manifest at the versions actually on PyPI (`0.1.9`, `0.1.1`, `0.1.1`); the first grouped run raises lifecycle to the group version.

**CI**
- `release-python-sdk.yml` now asserts the `pysdk-v*` tag matches the `version` in both `sdk/python/pyproject.toml` and `cli/pyproject.toml`, mirroring the existing guard in `release-mcp.yml`.

**Docs**
- `CONTRIBUTING.md` and the `release-please.yml` / `release-mcp.yml` headers described three released components; replaced with the full six-component table and a note on the two linked groups.

## Notes

- `linked-versions` still cuts a tag per component, so `lifecycle-v*` and `cli-v*` tags will start appearing. Nothing triggers on them — the publish workflows key off their group partner's tag (`mcp-v*` / `pysdk-v*`). Not suppressed with `skip-github-release`, which the schema warns is only for repos with their own tagging infrastructure.
- Lifecycle jumps `0.1.9` → the mcp version on its first grouped release. PyPI accepts the jump, and the two are one artifact in two package managers.
- The unpublished internal packages (`apps/*`, `packages/{core,db,mcp,shared,agent}`) are deliberately left alone — nothing reads their versions.

## Test plan

- [x] `release-please-config.json` validates against the upstream schema (ajv 8 + ajv-formats, draft-07) — **VALID**
- [x] release-please's `PyProjectToml` updater run directly against all three `pyproject.toml` files rewrites `version` correctly, so no `type: toml` fallback is needed
- [x] release-please's `Generic` updater run against all three `__init__.py` files rewrites `__version__` and preserves the annotation
- [x] Tag-guard shell logic smoke-tested: matching tag passes for both packages, mismatched tag fails
- [x] All three touched workflows parse as valid YAML; pre-commit clean on every commit
- [ ] Post-merge: run `release-please.yml` via `workflow_dispatch` and review the opened PR — expect mcp+lifecycle on one version and pysdk+cli on one version — before merging it
- [ ] Post-release: `pip index versions suiflex-suitest-lifecycle` matches `npm view @suiflex/suitest-mcp version`
