### PR TITLE
fix(release): drop linked-versions, give each component its own tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
       web: ${{ steps.filter.outputs.web }}
       mcp: ${{ steps.filter.outputs.mcp }}
       floor: ${{ steps.filter.outputs.floor }}
+      lifecycle: ${{ steps.filter.outputs.lifecycle }}
+      mcp_npx: ${{ steps.filter.outputs.mcp_npx }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -54,11 +56,41 @@ jobs:
               - 'packages/mcp-npx/**'
               - 'packages/lifecycle/**'
               - '.github/workflows/ci.yml'
+            lifecycle:
+              - 'packages/lifecycle/**'
+            mcp_npx:
+              - 'packages/mcp-npx/**'
             floor:
               - 'packages/mcp-npx/**'
               - 'packages/lifecycle/**'
               - 'packages/suitest-npx/**'
               - '.github/workflows/ci.yml'
+
+  # packages/mcp-npx vendors the lifecycle sources at prepack, so a lifecycle
+  # change that does not also touch packages/mcp-npx ships inside a new npm
+  # tarball under an unchanged version. release-please cannot see that
+  # coupling — the linked-versions plugin was tried and had no working mode —
+  # so the PR has to carry the mcp-npx bump itself.
+  lifecycle-ships-with-mcp:
+    name: Lifecycle change bumps the npm package
+    # release-please's own lifecycle PR touches only packages/lifecycle by
+    # design — it is the release, not a change that needs one.
+    if: >-
+      github.event_name == 'pull_request' &&
+      needs.changes.outputs.lifecycle == 'true' &&
+      !startsWith(github.head_ref, 'release-please--')
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: packages/mcp-npx must change too
+        if: needs.changes.outputs.mcp_npx != 'true'
+        run: |
+          echo "::error::This PR changes packages/lifecycle but not packages/mcp-npx." >&2
+          echo "packages/mcp-npx vendors the lifecycle sources at prepack, so the" >&2
+          echo "npm package would ship this change under an unchanged version." >&2
+          echo "Touch packages/mcp-npx in the same PR — a CHANGELOG or comment" >&2
+          echo "line is enough to make release-please cut a new mcp release." >&2
+          exit 1
 
   python-lint:
     name: Python lint (ruff + mypy)

--- a/.github/workflows/release-mcp.yml
+++ b/.github/workflows/release-mcp.yml
@@ -1,20 +1,21 @@
 name: release-mcp
 
-# Publish the MCP server packages on a `mcp-v*` tag:
-#   - @suiflex/suitest-mcp        → npm  (npx -y @suiflex/suitest-mcp)
-#   - suiflex-suitest-lifecycle   → PyPI (uvx --from suiflex-suitest-lifecycle suitest-mcp)
+# Publish the two MCP server packages, each on its own tag:
+#   - `mcp-v*`       → @suiflex/suitest-mcp      → npm  (npx -y @suiflex/suitest-mcp)
+#   - `lifecycle-v*` → suiflex-suitest-lifecycle → PyPI (uvx --from suiflex-suitest-lifecycle suitest-mcp)
+#
+# They share this file because they are the same server in two package
+# managers, but every job is gated on its own tag family — a lifecycle tag
+# must not reach the npm jobs, and an mcp tag must not reach the PyPI one.
+# Lifecycle used to ride the mcp tag, which meant its version could only ever
+# be published as a side effect of an mcp release.
 #
 # npm uses OIDC Trusted Publishing; no long-lived NPM_TOKEN is required. PyPI
 # still uses PYPI_TOKEN. On PRs, the build + smoke + dry-run steps validate.
-#
-# The lifecycle version is no longer hand-edited: release-please links it to
-# the mcp version (`linked-versions` group "mcp"), so packages/lifecycle and
-# packages/mcp-npx always carry the same number and the publish step below
-# reads a version that release-please already bumped.
 
 on:
   push:
-    tags: ["mcp-v*"]
+    tags: ["mcp-v*", "lifecycle-v*"]
   pull_request:
     paths:
       - "packages/mcp-npx/**"
@@ -26,7 +27,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing mcp release tag to publish to npm
+        description: Existing mcp-v* or lifecycle-v* release tag to publish
         required: true
         type: string
 
@@ -36,7 +37,9 @@ permissions:
 jobs:
   npm:
     name: "@suiflex/suitest-mcp → npm"
-    if: github.event_name != 'workflow_dispatch'
+    if: >-
+      github.event_name == 'pull_request' ||
+      startsWith(github.ref, 'refs/tags/mcp-v')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -68,7 +71,7 @@ jobs:
 
   publish-npm:
     name: "@suiflex/suitest-mcp → npm"
-    if: github.event_name == 'push'
+    if: startsWith(github.ref, 'refs/tags/mcp-v')
     needs: [npm]
     runs-on: ubuntu-latest
     # OIDC Trusted Publishing: npm trusts this repository, workflow, and the
@@ -99,7 +102,7 @@ jobs:
 
   publish-installers:
     name: "suitest-mcp → homebrew-tap + scoop-bucket"
-    if: github.event_name == 'push'
+    if: startsWith(github.ref, 'refs/tags/mcp-v')
     # After the npm publish, so a formula never points at a version npm rejected.
     needs: [publish-npm]
     runs-on: ubuntu-latest
@@ -132,7 +135,7 @@ jobs:
 
   recover-npm:
     name: "Recover @suiflex/suitest-mcp npm publish"
-    if: github.event_name == 'workflow_dispatch'
+    if: startsWith(inputs.tag, 'mcp-v')
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -164,7 +167,9 @@ jobs:
 
   pypi:
     name: "suiflex-suitest-lifecycle → PyPI"
-    if: github.event_name != 'pull_request'
+    if: >-
+      startsWith(github.ref, 'refs/tags/lifecycle-v') ||
+      startsWith(inputs.tag, 'lifecycle-v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -195,7 +200,6 @@ jobs:
             | python3 -c 'import sys, json; m = json.loads(sys.stdin.readline()); assert "suitest" in m["result"]["serverInfo"]["name"]; print("boot OK")'
 
       - name: Publish lifecycle package
-        if: startsWith(github.ref, 'refs/tags/mcp-v') || github.event_name == 'workflow_dispatch'
         run: |
           python3 - <<'PY'
           import hashlib

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,26 +2,22 @@ name: release-please
 
 # Version + changelog automation for every published artifact:
 #   - packages/mcp-npx     → @suiflex/suitest-mcp        → tag mcp-v*       → release-mcp.yml
-#   - packages/lifecycle   → suiflex-suitest-lifecycle   → tag lifecycle-v* → release-mcp.yml (publishes on mcp-v*)
+#   - packages/lifecycle   → suiflex-suitest-lifecycle   → tag lifecycle-v* → release-mcp.yml
 #   - sdk/typescript       → @suiflex/suitest-sdk        → tag tssdk-v*     → release-ts-sdk.yml
 #   - sdk/python           → suiflex-suitest-sdk         → tag pysdk-v*     → release-python-sdk.yml
-#   - cli                  → suiflex-suitest-cli         → tag cli-v*       → release-python-sdk.yml (publishes on pysdk-v*)
+#   - cli                  → suiflex-suitest-cli         → tag cli-v*       → release-python-sdk.yml
 #   - packages/suitest-npx → @suiflex/suitest            → tag launcher-v*  → release-launcher.yml + release-images.yml
 #
-# Two `linked-versions` groups keep artifacts that ship together on one
-# version: mcp+lifecycle and pysdk+cli. Each group member still gets its own
-# tag; the lifecycle-v* and cli-v* tags are inert markers, since the publish
-# workflows key off their group partner's tag.
+# All six version independently — no `linked-versions` plugin. It was tried
+# and has no working mode here: merging on produces a group PR with no
+# ${component}/${version} in its title, so nothing can be tagged and every
+# later run aborts; merging off lets members land one at a time, and the
+# plugin then drags whichever member is ahead back down to the version of
+# whichever one had commits. See CONTRIBUTING.md before reintroducing it.
 #
-# Both groups set `merge: false`. With merging on, the plugin folds a group
-# into a single PR titled "chore(main): release <group> libraries", which has
-# no ${component} and no ${version} for the release stage to parse — the PR
-# merges, nothing is tagged, and every later run aborts with "There are
-# untagged, merged release PRs outstanding". Do not turn merging back on.
+# packages/mcp-npx vendors the lifecycle sources, and that coupling is
+# enforced by the `lifecycle-ships-with-mcp` job in ci.yml, not here.
 #
-# Keep the members of a group on the same version line. The plugin takes the
-# maximum across only the members that had commits this cycle and forces it
-# onto the rest, so a member left behind on an older line gets downgraded.
 # A maintainer starts release preparation explicitly (workflow_dispatch) to
 # open/update a release PR. Merging that PR finalizes it automatically into a
 # tag + GitHub Release, which then triggers the matching publish workflow

--- a/.github/workflows/release-python-sdk.yml
+++ b/.github/workflows/release-python-sdk.yml
@@ -13,7 +13,7 @@ name: release-python-sdk
 
 on:
   push:
-    tags: ["pysdk-v*"]
+    tags: ["pysdk-v*", "cli-v*"]
   pull_request:
     paths:
       - "sdk/python/**"
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Existing Python SDK/CLI release tag to publish
+        description: Existing pysdk-v* or cli-v* release tag to publish
         required: true
         type: string
 
@@ -37,8 +37,10 @@ jobs:
         include:
           - package: "sdk/python"
             artifact: "dist-sdk"
+            tag_prefix: "pysdk-v"
           - package: "cli"
             artifact: "dist-cli"
+            tag_prefix: "cli-v"
     steps:
       - uses: actions/checkout@v7
         with:
@@ -50,12 +52,14 @@ jobs:
         # release-please owns both versions, so this should never fire — it
         # turns a hand-cut or stale tag into a red build instead of a PyPI
         # release whose number disagrees with the code inside it.
-        if: github.event_name != 'pull_request'
+        if: >-
+          startsWith(github.ref, format('refs/tags/{0}', matrix.tag_prefix)) ||
+          startsWith(inputs.tag, matrix.tag_prefix)
         env:
           RELEASE_TAG: ${{ inputs.tag }}
         run: |
           TAG_VERSION="${RELEASE_TAG:-$GITHUB_REF_NAME}"
-          TAG_VERSION="${TAG_VERSION#pysdk-v}"
+          TAG_VERSION="${TAG_VERSION#${{ matrix.tag_prefix }}}"
           PKG_VERSION="$(grep -m1 '^version = ' "${{ matrix.package }}/pyproject.toml" | cut -d'"' -f2)"
           [ "$TAG_VERSION" = "$PKG_VERSION" ] || {
             echo "tag $TAG_VERSION != ${{ matrix.package }} $PKG_VERSION" >&2; exit 1; }
@@ -74,7 +78,9 @@ jobs:
 
   publish-sdk:
     needs: build
-    if: startsWith(github.ref, 'refs/tags/pysdk-v') || github.event_name == 'workflow_dispatch'
+    if: >-
+      startsWith(github.ref, 'refs/tags/pysdk-v') ||
+      startsWith(inputs.tag, 'pysdk-v')
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -90,7 +96,9 @@ jobs:
 
   publish-cli:
     needs: build
-    if: startsWith(github.ref, 'refs/tags/pysdk-v') || github.event_name == 'workflow_dispatch'
+    if: >-
+      startsWith(github.ref, 'refs/tags/cli-v') ||
+      startsWith(inputs.tag, 'cli-v')
     runs-on: ubuntu-latest
     environment: pypi-cli
     permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,24 +200,31 @@ every published artifact. Nothing is versioned by hand:
 | `cli` | `cli-v*` | PyPI `suiflex-suitest-cli` |
 | `.` → `packages/suitest-npx` | `launcher-v*` | npm `@suiflex/suitest` + GHCR images |
 
-Two `linked-versions` groups keep artifacts that ship together on one version:
-`mcp` + `lifecycle` (the npm package vendors the lifecycle sources at
-`prepack`), and `pysdk` + `cli` (one `pysdk-v*` tag publishes both). Bumping
-either member bumps both, so a change to `packages/lifecycle` alone still
-produces a new `@suiflex/suitest-mcp` release.
+The six components version independently. Each has its own line, its own tag,
+and its own release PR; a release PR is safe to merge on its own, and the
+others rebase themselves on the next run.
 
-Two constraints on those groups are load-bearing, and both were learned the
-hard way:
+`packages/mcp-npx` vendors the lifecycle sources at `prepack`, so a change to
+`packages/lifecycle` has to ship as a new `@suiflex/suitest-mcp` release too.
+CI enforces that: the `Lifecycle change bumps the npm package` job fails a PR
+that touches `packages/lifecycle` without touching `packages/mcp-npx`. A
+CHANGELOG or comment line in `packages/mcp-npx` is enough — it just has to
+give release-please a commit to attribute.
 
-- **`merge: false` stays.** With merging on, the plugin folds a group into one
-  PR titled `chore(main): release <group> libraries`. That title carries no
-  `${component}` and no `${version}`, so the release stage cannot parse it, no
-  tag is cut, and every subsequent run aborts with *"There are untagged,
-  merged release PRs outstanding"* until the labels are cleared by hand.
-- **Group members stay on the same version line.** The plugin takes the
-  maximum across only the members that had commits in that cycle and forces it
-  onto the rest — a member sitting on an older line gets *downgraded*, not
-  left alone.
+> **Do not reach for the `linked-versions` plugin to automate that coupling.**
+> It was tried and has no working mode here, both of them proven on `main`:
+>
+> - With merging on it folds the group into one PR titled
+>   `chore(main): release <group> libraries` — hardcoded in the plugin, not
+>   read from config. That title has no `${component}` and no `${version}`, so
+>   nothing can be tagged, the merged PRs keep the `autorelease: pending`
+>   label, and every later run aborts with *"There are untagged, merged
+>   release PRs outstanding"* until the labels are cleared by hand.
+> - With merging off each member gets a taggable PR, but they are then merged
+>   one at a time. `preconfigure()` takes the maximum across only the members
+>   that had commits that cycle and forces it onto the rest, so the moment one
+>   lands, the member that is ahead gets dragged back — merging lifecycle
+>   0.9.0 produced a follow-up PR proposing lifecycle 0.8.1.
 
 The remaining packages — `apps/*` and `packages/{core,db,mcp,shared,agent}` —
 are never published on their own; they ship inside the launcher bundle and

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,20 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "separate-pull-requests": true,
   "include-component-in-tag": true,
-  "plugins": [
-    {
-      "type": "linked-versions",
-      "groupName": "mcp",
-      "components": ["mcp", "lifecycle"],
-      "merge": false
-    },
-    {
-      "type": "linked-versions",
-      "groupName": "pysdk",
-      "components": ["pysdk", "cli"],
-      "merge": false
-    }
-  ],
   "packages": {
     "packages/mcp-npx": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

- The `linked-versions` plugin has no working mode in this repo, and both were proven on `main` over the last few hours. Remove it and let the six components version independently.
- The coupling it was bought for — `packages/mcp-npx` vendors the lifecycle sources at `prepack` — moves to a CI job that checks the PR's own diff.
- Nothing has escaped: npm `@suiflex/suitest-mcp` is still `0.8.0`, PyPI `suiflex-suitest-lifecycle` still `0.1.9`, PyPI sdk/cli still `0.1.1`.

## Why the plugin cannot work here

**Merging on** folds the group into one PR titled `chore${scope}: release <group> libraries` — hardcoded in the plugin, not read from config. No `${component}`, no `${version}`, so the release stage cannot parse it:

```
✖ Bad pull request title: 'chore(main): release mcp libraries'
⚠ There are untagged, merged release PRs outstanding - aborting
```

#147 and #149 merged, nothing was tagged, and every later run aborted until the labels were cleared by hand.

**Merging off** gives each member a taggable PR — but they are then merged one at a time. `preconfigure()` takes the maximum across only the members that had commits that cycle and forces it onto the rest, so the moment one lands, the member that is ahead gets dragged back. Merging #154 (`lifecycle 0.9.0`) produced #155 proposing **`lifecycle 0.8.1`**, and rewrote #151 from `mcp 0.9.0` down to `mcp 0.8.1`.

The plugin assumes a group is released atomically, and its only mechanism for that is the PR that cannot be tagged.

## Changes

- **Remove the `plugins` block.** Six independent components, each with its own version line, tag and release PR.
- **`release-mcp.yml` also fires on `lifecycle-v*`.** Lifecycle only ever published as a side effect of an mcp release; independent versions need an independent trigger. Every job is now gated on its own tag family, so an mcp tag cannot reach the PyPI job and a lifecycle tag cannot reach the npm ones.
- **`release-python-sdk.yml` also fires on `cli-v*`**, for exactly the same reason. The tag-matches-version guard moves onto the matrix entry's own prefix, so a `cli-v*` tag is checked against `cli/pyproject.toml` and leaves the SDK alone.
- **New CI job `Lifecycle change bumps the npm package`** fails a PR touching `packages/lifecycle` without touching `packages/mcp-npx`. release-please's own lifecycle PR is exempt — it *is* the release.
- **`CONTRIBUTING.md` and the `release-please.yml` header** record what was tried and what happened, so nobody reaches for the plugin again.

## Test plan

- [x] Config validates against the upstream schema (ajv 8 + ajv-formats); 6 components, no plugins block
- [x] `release-mcp.yml` gating evaluated across 5 trigger scenarios — `mcp-v*` runs npm/installers only, `lifecycle-v*` runs PyPI only, PR runs validation only, each dispatch reaches only its own tag family's job
- [x] `release-python-sdk.yml` gating evaluated across 4 scenarios — `pysdk-v*` publishes the SDK only, `cli-v*` publishes the CLI only, and the version guard runs only for the matching package
- [x] CI guard evaluated across 5 cases — lifecycle-only PR fails, lifecycle+mcp-npx passes, unrelated PR skips, release-please branch skips, push to main skips
- [x] All touched workflows parse as YAML; pre-commit clean on every commit
- [ ] After merge: re-run `release-please.yml` and confirm #155 proposes a version **above** 0.9.0 rather than 0.8.1, and that each release PR can be merged on its own

## Note on `lifecycle-v0.9.0`

That tag exists from #154 but was never published — the PyPI job only fired on `mcp-v*`. Once this merges it can be published with a `workflow_dispatch` on `release-mcp.yml` using that tag, or simply left for the next lifecycle release to supersede.
