### PR TITLE
fix(release): always rewrite open release PRs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "separate-pull-requests": true,
+  "always-update": true,
   "include-component-in-tag": true,
   "packages": {
     "packages/mcp-npx": {


### PR DESCRIPTION
## Summary

- Every component's release PR edits the same `.release-please-manifest.json`, so merging one leaves the others based on a manifest that no longer exists on `main`.
- Whether they recover is accidental. #152 and #148 have been stuck conflicting since #153 merged, and re-running the workflow does not help.

## Why

`manifest.js` only rewrites a PR when its **body** changed:

```js
async maybeUpdateExistingPullRequest(existing, pullRequest) {
    if (existing.body === pullRequest.body.toString()) {
        this.logger.info(`PR ... remained the same`);
        return undefined;          // branch never rewritten
    }
    return await this.updateExistingPullRequest(existing, pullRequest);
}
```

The last run ended with exactly that:

```
✔ PR https://github.com/suiflex/suitest/pull/152 remained the same
✔ PR https://github.com/suiflex/suitest/pull/148 remained the same
```

Earlier PRs *did* recover, but only because their computed version changed (pysdk went `0.2.0` → `0.1.2` when the plugin was dropped), which forced a rewrite as a side effect. A PR whose version does not move never gets rebased and stays conflicted indefinitely.

`always-update: true` takes the `updateExistingPullRequest` branch unconditionally, so every open release PR is rebuilt against current `main` on each run.

## Changes

- `release-please-config.json`: add `"always-update": true`.

## Test plan

- [x] Config validates against the upstream schema (ajv 8 + ajv-formats)
- [x] Traced the option end to end in the pinned release-please build: `config['always-update']` → `manifestOptions.alwaysUpdate` → `this.alwaysUpdate` → the `updateExistingPullRequest` branch in `createOrUpdatePullRequest`
- [ ] After merge: re-run `release-please.yml` and confirm #152 and #148 go from `DIRTY` to `CLEAN` without being touched by hand
