### PR TITLE
feat(mcp): tauri-mcp — drive Tauri 2 desktop apps over WebDriver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,10 @@ help: ## Show this help
 ##@ Python (uv)
 
 install: ## Install all Python deps + dev + pre-commit hooks
-	uv sync --all-extras --dev
+	# --all-packages, not just the root: without it the workspace members
+	# (suitest_mcp, suitest_api, ...) are never installed into .venv and every
+	# test that imports one fails at collection with ModuleNotFoundError.
+	uv sync --all-extras --dev --all-packages
 	@echo "--- frontend ---"
 	cd apps/web && pnpm install && cd ../..
 	@echo "--- pre-commit ---"

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ See [Get Started in 3 Steps](#get-started-in-3-steps) above. Just one command: `
 **Yes.** Suitest is self-hosted — your data never leaves your server. API keys are encrypted with AES-GCM. No mandatory telemetry.
 
 ### ❓ Can Suitest test things other than browsers?
-**Yes.** Suitest can test: browsers (Playwright), APIs (HTTP/GraphQL/gRPC), databases (Postgres/Mongo/MySQL), mobile (Appium), desktop (Slint/Electron/computer-use), infrastructure (Kubernetes), and other MCP servers.
+**Yes.** Suitest can test: browsers (Playwright), APIs (HTTP/GraphQL/gRPC), databases (Postgres/Mongo/MySQL), mobile (Appium), desktop (Slint, Tauri), infrastructure (Kubernetes), and other MCP servers.
 
 ### ❓ What if I'm stuck / get an error?
 Check [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md) or open an issue at [GitHub Issues](https://github.com/suiflex/suitest/issues).

--- a/README_ID.md
+++ b/README_ID.md
@@ -395,7 +395,7 @@ Lihat [Mulai dalam 3 Langkah](#mulai-dalam-3-langkah) di atas. Cukup satu comman
 **Ya.** Suitest self-host — data tidak pernah keluar dari server kamu. API key di-encrypt AES-GCM. Tidak ada telemetry wajib.
 
 ### ❓ Apakah Suitest bisa test selain browser?
-**Ya.** Suitest bisa test: browser (Playwright), API (HTTP/GraphQL/gRPC), database (Postgres/Mongo/MySQL), mobile (Appium), desktop (Slint/Electron/computer-use), infra (Kubernetes), dan MCP server lainnya.
+**Ya.** Suitest bisa test: browser (Playwright), API (HTTP/GraphQL/gRPC), database (Postgres/Mongo/MySQL), mobile (Appium), desktop (Slint, Tauri), infra (Kubernetes), dan MCP server lainnya.
 
 ### ❓ Bagaimana jika saya stuck / ada error?
 Lihat [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md) atau buka issue di [GitHub Issues](https://github.com/suiflex/suitest/issues).

--- a/docs/DESKTOP_TESTING.md
+++ b/docs/DESKTOP_TESTING.md
@@ -130,7 +130,14 @@ it comes up without being listed.
 
 Tools: `tauri.launch`, `tauri.close`, `tauri.click`, `tauri.type_text`,
 `tauri.get_text`, `tauri.assert_text`, `tauri.assert_visible`, `tauri.eval`,
-`tauri.screenshot`. Selectors are W3C strategies — pass `css` or `xpath`.
+`tauri.screenshot`, `tauri.start_video`, `tauri.stop_video`. Selectors are W3C
+strategies — pass `css` or `xpath`.
+
+`tauri.screenshot` returns an MCP image block and `tauri.stop_video` an MP4
+resource, which the runner files as `SCREENSHOT` and `VIDEO` artifacts. Video
+needs `ffmpeg` on PATH, and is worth pairing with
+`SUITEST_EVIDENCE_RECORDING=1`: steps otherwise complete faster than the
+sampler, and a two-frame recording of a passing case tells nobody anything.
 
 `tauri.eval` is the seam onto Rust: the page's own
 `window.__TAURI_INTERNALS__.invoke` reaches real commands, so a step can assert

--- a/docs/DESKTOP_TESTING.md
+++ b/docs/DESKTOP_TESTING.md
@@ -1,4 +1,4 @@
-# Desktop Testing (M14) — Design & slint-mcp Contract
+# Desktop Testing (M14) — Design, slint-mcp and tauri-mcp Contracts
 
 > Cross-links: [MCP_PLUGINS.md](./MCP_PLUGINS.md), [ROADMAP.md](./ROADMAP.md),
 > [DATA_MODEL.md](./DATA_MODEL.md), [DEPLOYMENT.md](./DEPLOYMENT.md),
@@ -28,18 +28,20 @@ assert text/visibility/value — exactly as browser steps drive the DOM.
 
 ---
 
-## 2. Three backends (M14-1 .. M14-3)
+## 2. Four backends (M14-1 .. M14-3, plus Tauri)
 
-Desktop automation is not one problem; it is three. Suitest ships **three
-provider configs** in `builtin_specs.py`. Two are external binaries resolved at
-runtime via `command_pin` (they stay **outside the image** — see
-[DEPLOYMENT.md](./DEPLOYMENT.md)); `slint-mcp` needs no binary at all.
+Desktop automation is not one problem. Suitest ships **four provider configs**
+in `builtin_specs.py`. Two name external binaries resolved at runtime via
+`command_pin` (they stay **outside the image** — see
+[DEPLOYMENT.md](./DEPLOYMENT.md)) and are **not implemented in this repo**;
+`slint-mcp` and `tauri-mcp` need no binary at all and are bundled in-process.
 
 | ID | M14 item | Driver | Transport | Best for |
 |----|----------|--------|-----------|----------|
 | `computer-use-mcp` | **M14-1** | Screen pixels + OS input | stdio, `command_pin` | Any legacy/native app; last-resort fallback |
 | `electron-mcp` | **M14-2** | Chrome DevTools Protocol inside Electron (Playwright `_electron`) | stdio, `command_pin` | Electron apps with real DOM |
 | `slint-mcp` | **M14-3** | Slint's own embedded MCP server | **bundled, in-process** | Slint apps (Rust, cross-platform, optionally headless) |
+| `tauri-mcp` | — | W3C WebDriver served inside the app (`tauri-plugin-wdio-webdriver`) | **bundled, in-process** | Tauri 2 apps on Windows, Linux **and macOS** |
 
 > **`slint-mcp` changed shape after this document was first written.** It was
 > specified as an external `slint-mcp` binary, and no such binary was ever
@@ -84,6 +86,58 @@ runner, so:
   a *sample target only* and is not modified).
 
 ---
+
+### 2.3 tauri-mcp: a standard protocol, and why that matters
+
+`tauri-mcp` (`suitest_mcp.bundled.tauri`) follows the same shape as `slint-mcp`
+— it owns the application process and bridges a stable `tauri.*` contract onto
+what the app already speaks — but the wire protocol is not bespoke. It is
+**W3C WebDriver**, served from inside the app by `tauri-plugin-wdio-webdriver`.
+
+Two consequences:
+
+* **macOS works.** The standalone `tauri-driver` binary drives the platform's
+  native WebDriver and exists only for Windows and Linux. An in-process server
+  sidesteps that, which is how the official `@wdio/tauri-service` supports
+  macOS too. There is no paid component and no external driver to install.
+* **Nothing is app-specific.** Any Tauri 2 app that registers the plugin is
+  drivable, and the app's own code never learns it is under test.
+
+The app under test must be built with the plugin registered — the same bargain
+Slint makes. Gate it on a cargo feature so a release build carries no server:
+
+```toml
+[features]
+wdio = ["dep:tauri-plugin-wdio-webdriver"]
+
+[dependencies]
+tauri-plugin-wdio-webdriver = { version = "1", optional = true }
+```
+
+```rust
+let builder = tauri::Builder::default();
+#[cfg(feature = "wdio")]
+let builder = builder.plugin(tauri_plugin_wdio_webdriver::init());
+```
+
+A `debug_assertions` gate is the alternative the plugin's own docs show, but it
+opens the port during any ordinary `tauri dev`; a feature does not.
+
+**Do not** add `wdio-webdriver:default` to `capabilities/*.json`. A build
+without the feature then fails with `Permission ... not found`, and the set
+grants no IPC anyway — the plugin is an HTTP server, not a command surface, and
+it comes up without being listed.
+
+Tools: `tauri.launch`, `tauri.close`, `tauri.click`, `tauri.type_text`,
+`tauri.get_text`, `tauri.assert_text`, `tauri.assert_visible`, `tauri.eval`,
+`tauri.screenshot`. Selectors are W3C strategies — pass `css` or `xpath`.
+
+`tauri.eval` is the seam onto Rust: the page's own
+`window.__TAURI_INTERNALS__.invoke` reaches real commands, so a step can assert
+on what the backend actually did rather than only on what the DOM shows.
+
+`tauri.launch` takes an optional `command`; omit it to attach to an app that is
+already running, which is what a local `tauri dev` session wants.
 
 ## 3. slint-mcp: selector grammar
 

--- a/docs/MCP_PLUGINS.md
+++ b/docs/MCP_PLUGINS.md
@@ -138,7 +138,7 @@ These providers ship inside the main Suitest image (see [DEPLOYMENT.md](./DEPLOY
 | `computer-use-mcp` | desktop | stdio (Anthropic computer-use) | FE_DESKTOP (v1.x preview, v2 stable) | Desktop app tests — screen-level default | OS-level (VNC / X11 / Wayland) |
 | `electron-mcp` | desktop | stdio | FE_DESKTOP | Electron app tests via CDP DOM (Playwright `_electron`) | none |
 | `slint-mcp` | desktop | **bundled, in-process** | FE_DESKTOP | Slint app tests via accessible tree (headless-capable) | none |
-| `tauri-mcp` | desktop | **bundled, in-process** | FE_DESKTOP | Tauri 2 app tests over W3C WebDriver served inside the app | none |
+| `tauri-mcp` | desktop | **bundled, in-process** | FE_DESKTOP | Tauri 2 app tests over W3C WebDriver served inside the app; screenshots + MP4 recording | ffmpeg (video only) |
 | `jirac-mcp` | issue-tracker | stdio | EXTERNAL_TOOL | Jira issue tracker (file defect, transition, comment, JQL search) | cloud-token / DC PAT |
 | `github-mcp` | issue-tracker | stdio | EXTERNAL_TOOL | GitHub Issues + labels + comments | github-app-installation-token / PAT |
 

--- a/docs/MCP_PLUGINS.md
+++ b/docs/MCP_PLUGINS.md
@@ -2,7 +2,7 @@
 
 > Cross-links: [API.md](./API.md), [DATA_MODEL.md](./DATA_MODEL.md), [GENERATORS.md](./GENERATORS.md), [AI_AGENT.md](./AI_AGENT.md), [ARCHITECTURE.md](./ARCHITECTURE.md), [DEPLOYMENT.md](./DEPLOYMENT.md).
 
-> ⚠️ **PARTIAL.** Bundled providers built: `playwright`, `api-http`, `postgres`, `graphql`, `mysql`, `mongo`, `kubernetes`, and `grpc`, plus lifecycle-local `suitest.whitebox.v1` adapters for pytest and Vitest/Jest. M14 adds the desktop set: `computer-use-mcp`, `electron-mcp`, `slint-mcp` (configs registered; binaries resolve via `command_pin` — see [DESKTOP_TESTING.md](./DESKTOP_TESTING.md)). Documented-but-unbuilt: `browser-use`/`appium`/`jira`/`github` (later milestones). See [ROADMAP.md](./ROADMAP.md).
+> ⚠️ **PARTIAL.** Bundled providers built: `playwright`, `api-http`, `postgres`, `graphql`, `mysql`, `mongo`, `kubernetes`, and `grpc`, plus lifecycle-local `suitest.whitebox.v1` adapters for pytest and Vitest/Jest. M14 adds the desktop set: `slint-mcp` and `tauri-mcp` are **built and bundled in-process**; `computer-use-mcp` and `electron-mcp` are **configs only** — the binaries they name do not exist in this repo (see [DESKTOP_TESTING.md](./DESKTOP_TESTING.md)). Documented-but-unbuilt: `browser-use`/`appium`/`jira`/`github` (later milestones). See [ROADMAP.md](./ROADMAP.md).
 
 ---
 
@@ -137,7 +137,8 @@ These providers ship inside the main Suitest image (see [DEPLOYMENT.md](./DEPLOY
 | `appium-mcp` | mobile | stdio | FE_MOBILE | iOS / Android UI tests | appium server URL |
 | `computer-use-mcp` | desktop | stdio (Anthropic computer-use) | FE_DESKTOP (v1.x preview, v2 stable) | Desktop app tests — screen-level default | OS-level (VNC / X11 / Wayland) |
 | `electron-mcp` | desktop | stdio | FE_DESKTOP | Electron app tests via CDP DOM (Playwright `_electron`) | none |
-| `slint-mcp` | desktop | stdio | FE_DESKTOP | Slint app tests via accessible tree (headless-capable) | none |
+| `slint-mcp` | desktop | **bundled, in-process** | FE_DESKTOP | Slint app tests via accessible tree (headless-capable) | none |
+| `tauri-mcp` | desktop | **bundled, in-process** | FE_DESKTOP | Tauri 2 app tests over W3C WebDriver served inside the app | none |
 | `jirac-mcp` | issue-tracker | stdio | EXTERNAL_TOOL | Jira issue tracker (file defect, transition, comment, JQL search) | cloud-token / DC PAT |
 | `github-mcp` | issue-tracker | stdio | EXTERNAL_TOOL | GitHub Issues + labels + comments | github-app-installation-token / PAT |
 
@@ -158,7 +159,7 @@ Each `target_kind` resolves to a primary MCP plus an optional fallback. The runn
 | `BE_GRPC` | `grpc-mcp` | _none_ |
 | `FE_WEB` | `playwright-mcp` | `browser-use-mcp` |
 | `FE_MOBILE` | `appium-mcp` | _none_ |
-| `FE_DESKTOP` | `computer-use-mcp` | `electron-mcp` / `slint-mcp` (per step) |
+| `FE_DESKTOP` | `computer-use-mcp` | `electron-mcp` / `slint-mcp` / `tauri-mcp` (per step) |
 | `DATA` | `postgres-mcp` | _user must override per workspace_ |
 | `INFRA` | `kubernetes-mcp` | _none_ |
 | `CUSTOM` | _user must set per step or workspace_ | _none_ |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -339,9 +339,10 @@ Tag `v1.0.0`. Announce on HN / Reddit / dev.to. Discord + community forum set up
 
 ## M14 — Desktop testing (5 weeks)
 
-- [x] **M14-1** `computer-use-mcp` integration (screen-level default for `FE_DESKTOP`)
-- [x] **M14-2** Generic desktop UI testing (Electron, Win32, macOS) — `electron-mcp` (CDP/DOM) + `computer-use-mcp` fallback
+- [ ] **M14-1** `computer-use-mcp` integration (screen-level default for `FE_DESKTOP`) — **config only**: `builtin_specs.py` registers the provider and routing defaults to it, but no `computer-use-mcp` binary or module exists in this repo, so a step that lands on the default fails at spawn
+- [ ] **M14-2** Generic desktop UI testing (Electron, Win32, macOS) — `electron-mcp` (CDP/DOM) + `computer-use-mcp` fallback — **config only**, same as M14-1
 - [x] **M14-3** Slint desktop testing via accessible tree — `slint-mcp` (headless software renderer); see [DESKTOP_TESTING.md](./DESKTOP_TESTING.md) and `examples/slint-demo/`
+- [x] **M14-4** Tauri 2 desktop testing over W3C WebDriver — `tauri-mcp`, bundled in-process against the app's embedded server; works on macOS, where `tauri-driver` does not exist
 
 ## M15 — Multi-agent swarm (6 weeks)
 

--- a/packages/mcp/src/suitest_mcp/bundled/_video.py
+++ b/packages/mcp/src/suitest_mcp/bundled/_video.py
@@ -1,0 +1,73 @@
+"""Turn sampled PNG frames into an MP4 a dashboard can play.
+
+Shared by the desktop providers: both `slint-mcp` and `tauri-mcp` record by
+screenshotting on a timer, and the encoding step is identical for both. Keeping
+one copy means a fix to the ffmpeg invocation — the pixel format, the padding,
+the faststart flag — reaches every provider rather than the one whose file
+someone happened to open.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+#: Sampling cadence for desktop screen recording, in milliseconds.
+VIDEO_INTERVAL_MS = 200
+#: Cap on retained frames, so a forgotten `stop_video` cannot exhaust memory.
+VIDEO_MAX_FRAMES = 900
+
+
+def encode_video(frames: list[bytes], interval_ms: int, *, tool: str) -> bytes:
+    """PNG frames -> MP4, through ffmpeg on stdin.
+
+    H.264 in an MP4 is what the dashboard's `<video>` element plays. ffmpeg is
+    not vendored, so its absence is reported as the missing dependency it is
+    rather than as a broken step; `tool` names the step that needs it.
+    """
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg is None:
+        raise AssertionError(
+            f"ffmpeg is not on PATH — `{tool}` needs it to encode the sampled "
+            "frames; install it or drop the video steps"
+        )
+    fps = max(1, round(1000 / interval_ms))
+    # Written to a file, not a pipe: the MP4 muxer seeks back to finish its
+    # header, so `-f mp4 -` fails with "muxer does not support non seekable
+    # output".
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / "recording.mp4"
+        result = subprocess.run(  # fixed argv, no shell
+            [
+                ffmpeg,
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-y",
+                "-f",
+                "image2pipe",
+                "-framerate",
+                str(fps),
+                "-i",
+                "-",
+                # yuv420p + even dimensions: what a browser will actually play.
+                "-vf",
+                "pad=ceil(iw/2)*2:ceil(ih/2)*2",
+                "-pix_fmt",
+                "yuv420p",
+                "-c:v",
+                "libx264",
+                "-movflags",
+                "+faststart",
+                str(target),
+            ],
+            input=b"".join(frames),
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0 or not target.exists():
+            detail = result.stderr.decode(errors="replace").strip()[:400]
+            raise AssertionError(f"ffmpeg could not encode the frames: {detail}")
+        return target.read_bytes()

--- a/packages/mcp/src/suitest_mcp/bundled/in_process_runtime.py
+++ b/packages/mcp/src/suitest_mcp/bundled/in_process_runtime.py
@@ -101,6 +101,7 @@ _LAZY_MODULES: dict[str, str] = {
     "grpc-mcp": "suitest_mcp.bundled.grpc",
     # M14 desktop.
     "slint-mcp": "suitest_mcp.bundled.slint",
+    "tauri-mcp": "suitest_mcp.bundled.tauri",
 }
 
 

--- a/packages/mcp/src/suitest_mcp/bundled/slint.py
+++ b/packages/mcp/src/suitest_mcp/bundled/slint.py
@@ -61,14 +61,12 @@ import json
 import os
 import shutil
 import socket
-import subprocess
-import tempfile
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import httpx
 from mcp.types import BlobResourceContents, EmbeddedResource, ImageContent, TextContent, Tool
 
+from suitest_mcp.bundled._video import VIDEO_INTERVAL_MS, VIDEO_MAX_FRAMES, encode_video
 from suitest_mcp.bundled.in_process_runtime import BundledServer, register_bundled_builder
 
 if TYPE_CHECKING:
@@ -90,8 +88,6 @@ _HOST = "127.0.0.1"
 # Video sampling. Slint serves single frames, not a stream, so a "video" here is
 # screenshots on a timer stitched by ffmpeg. 5 fps is enough to read a drag or a
 # panel opening, and cheap enough not to perturb what it is filming.
-_VIDEO_INTERVAL_MS = 200
-_VIDEO_MAX_FRAMES = 900
 
 
 def _free_port() -> int:
@@ -187,7 +183,7 @@ class SlintServer:
         self._video_task: asyncio.Task[None] | None = None
         self._filming = False
         self._video_frames: list[bytes] = []
-        self._video_interval_ms = _VIDEO_INTERVAL_MS
+        self._video_interval_ms = VIDEO_INTERVAL_MS
 
     # ---------------------------------------------------------------- plumbing
 
@@ -562,7 +558,7 @@ class SlintServer:
                     with contextlib.suppress(ValueError, TypeError):
                         self._video_frames.append(base64.b64decode(block["data"], validate=False))
                     break
-            if len(self._video_frames) >= _VIDEO_MAX_FRAMES:
+            if len(self._video_frames) >= VIDEO_MAX_FRAMES:
                 return
             await asyncio.sleep(self._video_interval_ms / 1000)
 
@@ -577,58 +573,6 @@ class SlintServer:
         # busy UI, still has to leave the session closable.
         with contextlib.suppress(asyncio.CancelledError, Exception):
             await task
-
-    def _encode_video(self, frames: list[bytes]) -> bytes:
-        """PNG frames -> MP4, through ffmpeg on stdin.
-
-        H.264 in an MP4 is what the dashboard's `<video>` element plays. ffmpeg
-        is not vendored, so its absence is reported as the missing dependency it
-        is rather than as a broken step.
-        """
-        ffmpeg = shutil.which("ffmpeg")
-        if ffmpeg is None:
-            raise AssertionError(
-                "ffmpeg is not on PATH — `slint.stop_video` needs it to encode "
-                "the sampled frames; install it or drop the video steps"
-            )
-        fps = max(1, round(1000 / self._video_interval_ms))
-        # Written to a file, not a pipe: the MP4 muxer seeks back to finish its
-        # header, so `-f mp4 -` fails with "muxer does not support non seekable
-        # output".
-        with tempfile.TemporaryDirectory() as tmp:
-            target = Path(tmp) / "recording.mp4"
-            result = subprocess.run(  # fixed argv, no shell
-                [
-                    ffmpeg,
-                    "-hide_banner",
-                    "-loglevel",
-                    "error",
-                    "-y",
-                    "-f",
-                    "image2pipe",
-                    "-framerate",
-                    str(fps),
-                    "-i",
-                    "-",
-                    # yuv420p + even dimensions: what a browser will actually play.
-                    "-vf",
-                    "pad=ceil(iw/2)*2:ceil(ih/2)*2",
-                    "-pix_fmt",
-                    "yuv420p",
-                    "-c:v",
-                    "libx264",
-                    "-movflags",
-                    "+faststart",
-                    str(target),
-                ],
-                input=b"".join(frames),
-                capture_output=True,
-                check=False,
-            )
-            if result.returncode != 0 or not target.exists():
-                detail = result.stderr.decode(errors="replace").strip()[:400]
-                raise AssertionError(f"ffmpeg could not encode the frames: {detail}")
-            return target.read_bytes()
 
     @staticmethod
     def _text_of(properties: dict[str, Any]) -> str:
@@ -909,11 +853,11 @@ class SlintServer:
         if name == "slint.start_video":
             if self._filming:
                 raise AssertionError("already filming — call `slint.stop_video` first")
-            raw_interval = arguments.get("interval_ms", _VIDEO_INTERVAL_MS)
+            raw_interval = arguments.get("interval_ms", VIDEO_INTERVAL_MS)
             self._video_interval_ms = (
                 int(raw_interval)
                 if isinstance(raw_interval, int) and raw_interval > 0
-                else _VIDEO_INTERVAL_MS
+                else VIDEO_INTERVAL_MS
             )
             self._video_frames = []
             await self._window_handle()  # fail here, not inside the sampler
@@ -928,7 +872,9 @@ class SlintServer:
             frames, self._video_frames = self._video_frames, []
             if not frames:
                 raise AssertionError("no frames were captured")
-            video = await asyncio.to_thread(self._encode_video, frames)
+            video = await asyncio.to_thread(
+                encode_video, frames, self._video_interval_ms, tool="slint.stop_video"
+            )
             return [
                 TextContent(type="text", text=f"captured {len(frames)} frame(s)"),
                 EmbeddedResource(

--- a/packages/mcp/src/suitest_mcp/bundled/tauri.py
+++ b/packages/mcp/src/suitest_mcp/bundled/tauri.py
@@ -49,6 +49,7 @@ turns those into an MCP error result, which the generic client surfaces as
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
 import json
 import os
@@ -56,8 +57,15 @@ import time
 from typing import TYPE_CHECKING, Any, cast
 
 import httpx
-from mcp.types import EmbeddedResource, ImageContent, TextContent, Tool
+from mcp.types import (
+    BlobResourceContents,
+    EmbeddedResource,
+    ImageContent,
+    TextContent,
+    Tool,
+)
 
+from suitest_mcp.bundled._video import VIDEO_INTERVAL_MS, VIDEO_MAX_FRAMES, encode_video
 from suitest_mcp.bundled.in_process_runtime import register_bundled_builder
 
 if TYPE_CHECKING:
@@ -91,6 +99,11 @@ class TauriServer:
         self._base: str = f"http://{_HOST}:{_DEFAULT_PORT}"
         #: Set when launch spawned the process, so close only kills what it started.
         self._owns_process = False
+        #: Screen recording: frames sampled on a timer, encoded on stop.
+        self._video_frames: list[bytes] = []
+        self._video_task: asyncio.Task[None] | None = None
+        self._video_interval_ms = VIDEO_INTERVAL_MS
+        self._filming = False
 
     # -- BundledServer protocol ------------------------------------------------
 
@@ -125,6 +138,10 @@ class TauriServer:
             return [TextContent(type="text", text=await self._assert_text(arguments))]
         if name == "tauri.assert_visible":
             return [TextContent(type="text", text=await self._assert_visible(arguments))]
+        if name == "tauri.start_video":
+            return self._start_video(arguments)
+        if name == "tauri.stop_video":
+            return await self._stop_video()
         if name == "tauri.eval":
             return [TextContent(type="text", text=json.dumps(await self._eval(arguments)))]
         raise AssertionError(f"unknown tool: {name}")
@@ -232,6 +249,7 @@ class TauriServer:
         return session_id
 
     async def _stop(self) -> None:
+        await self._stop_sampling()
         if self._session_id is not None and self._client is not None:
             # Best-effort: the app may already be gone, and failing to close a
             # session must not mask whatever actually ended the test.
@@ -369,6 +387,77 @@ class TauriServer:
         payload = await self._get(f"/session/{self._session()}/screenshot")
         return str(payload.get("value", ""))
 
+    # -- screen recording ------------------------------------------------------
+
+    def _start_video(
+        self, arguments: dict[str, Any]
+    ) -> list[TextContent | ImageContent | EmbeddedResource]:
+        """Begin sampling the window.
+
+        A recording is the difference between a report that says a case passed
+        and one that shows what the app did — worth having when the failure is
+        "the wrong screen appeared for a moment".
+        """
+        if self._filming:
+            raise AssertionError("already filming — call `tauri.stop_video` first")
+        raw = arguments.get("interval_ms", VIDEO_INTERVAL_MS)
+        self._video_interval_ms = (
+            int(raw) if isinstance(raw, int) and raw > 0 else VIDEO_INTERVAL_MS
+        )
+        self._video_frames = []
+        self._session()  # fail here rather than inside the sampler
+        self._filming = True
+        self._video_task = asyncio.create_task(self._sample_frames())
+        return [TextContent(type="text", text=f"filming every {self._video_interval_ms}ms")]
+
+    async def _sample_frames(self) -> None:
+        """Screenshot the window on a timer until cancelled."""
+        while True:
+            try:
+                data = await self._screenshot()
+            except Exception:  # a frame lost to a busy UI must not end the recording
+                data = ""
+            if data:
+                with contextlib.suppress(ValueError, TypeError):
+                    self._video_frames.append(base64.b64decode(data, validate=False))
+            if len(self._video_frames) >= VIDEO_MAX_FRAMES:
+                return
+            await asyncio.sleep(self._video_interval_ms / 1000)
+
+    async def _stop_sampling(self) -> None:
+        # A sampler that finished on its own must not read as "never started".
+        self._filming = False
+        task, self._video_task = self._video_task, None
+        if task is None:
+            return
+        task.cancel()
+        # Teardown must not raise: a cancelled sampler still has to leave the
+        # session closable.
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await task
+
+    async def _stop_video(self) -> list[TextContent | ImageContent | EmbeddedResource]:
+        if not self._filming:
+            raise AssertionError("not filming — call `tauri.start_video` first")
+        await self._stop_sampling()
+        frames, self._video_frames = self._video_frames, []
+        if not frames:
+            raise AssertionError("no frames were captured")
+        video = await asyncio.to_thread(
+            encode_video, frames, self._video_interval_ms, tool="tauri.stop_video"
+        )
+        return [
+            TextContent(type="text", text=f"captured {len(frames)} frame(s)"),
+            EmbeddedResource(
+                type="resource",
+                resource=BlobResourceContents(
+                    uri="tauri://window/recording.mp4",
+                    mimeType="video/mp4",
+                    blob=base64.b64encode(video).decode(),
+                ),
+            ),
+        ]
+
 
 def _command_of(arguments: dict[str, Any]) -> list[str]:
     raw = arguments.get("command")
@@ -499,6 +588,25 @@ def _tool_catalog() -> list[Tool]:
                 "required": ["script"],
                 "properties": {"script": {"type": "string"}, "args": {"type": "array"}},
             },
+        ),
+        Tool(
+            name="tauri.start_video",
+            description=(
+                "Start recording the window by sampling screenshots. Pair with "
+                "tauri.stop_video, which attaches the MP4 to the run. Needs ffmpeg."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {"interval_ms": {"type": "integer"}},
+            },
+        ),
+        Tool(
+            name="tauri.stop_video",
+            description=(
+                "Stop filming and attach the MP4 to the run, so a case shows the "
+                "interaction rather than only its end state. Needs ffmpeg."
+            ),
+            input_schema={"type": "object", "properties": {}},
         ),
         Tool(
             name="tauri.screenshot",

--- a/packages/mcp/src/suitest_mcp/bundled/tauri.py
+++ b/packages/mcp/src/suitest_mcp/bundled/tauri.py
@@ -1,0 +1,484 @@
+"""Bundled tauri-mcp provider — desktop testing for Tauri 2 applications.
+
+Like :mod:`suitest_mcp.bundled.slint`, this is a **bridge, not a driver**: it
+owns the application process and translates Suitest's stable ``tauri.*`` step
+contract onto something the app already speaks. Unlike Slint, that something is
+not a bespoke protocol — it is **W3C WebDriver**, served from inside the app by
+`tauri-plugin-wdio-webdriver`. Two consequences worth knowing:
+
+* It works on macOS. The standalone ``tauri-driver`` binary drives the
+  platform's native WebDriver and exists only for Windows and Linux; an
+  in-process server sidesteps that entirely, which is how the official
+  ``@wdio/tauri-service`` supports macOS too.
+* Nothing here is Companion-specific. Any Tauri app that registers the plugin
+  is drivable by this provider, and the app's own code does not have to know it
+  is under test.
+
+The app under test must therefore be built with the plugin registered — the
+same bargain Slint makes, where the app has to embed an MCP server. The
+recommended shape is a cargo feature so a release build carries no server::
+
+    [features]
+    wdio = ["dep:tauri-plugin-wdio-webdriver"]
+
+    #[cfg(feature = "wdio")]
+    let builder = builder.plugin(tauri_plugin_wdio_webdriver::init());
+
+Tool surface (mirrored in :mod:`suitest_mcp.providers.builtin_specs`):
+
+* ``tauri.launch``          — spawn the binary, wait for the WebDriver server,
+  open a session.
+* ``tauri.close``           — end the session and stop the process.
+* ``tauri.click``           — click the first element matching a selector.
+* ``tauri.type_text``       — send text to an element.
+* ``tauri.get_text``        — read an element's rendered text.
+* ``tauri.assert_text``     — assert an element's text contains / equals.
+* ``tauri.assert_visible``  — assert an element exists and is displayed.
+* ``tauri.eval``            — run JavaScript in the webview and return its
+  value. This is the seam onto the Rust side: the page's own
+  ``window.__TAURI_INTERNALS__.invoke`` reaches real commands, so a step can
+  assert on what the backend actually did rather than only on the DOM.
+* ``tauri.screenshot``      — PNG of the window, returned as an image block so
+  the runner files it as a SCREENSHOT artifact.
+
+Assertion failures raise :class:`AssertionError`; the SDK's tool-call wrapper
+turns those into an MCP error result, which the generic client surfaces as
+:class:`suitest_mcp.client.McpToolFailed`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import time
+from typing import TYPE_CHECKING, Any, cast
+
+import httpx
+from mcp.types import EmbeddedResource, ImageContent, TextContent, Tool
+
+from suitest_mcp.bundled.in_process_runtime import register_bundled_builder
+
+if TYPE_CHECKING:
+    from suitest_mcp.models import McpProviderConfig
+
+PROVIDER_NAME = "tauri-mcp"
+
+_HOST = "127.0.0.1"
+#: Default port of `tauri-plugin-wdio-webdriver`; matches the plugin's own
+#: default so a plain app build needs no extra configuration.
+_DEFAULT_PORT = 4445
+_DEFAULT_LAUNCH_TIMEOUT = 60.0
+_DEFAULT_CALL_TIMEOUT = 30.0
+#: The key a W3C WebDriver response uses to carry an element reference.
+_ELEMENT_KEY = "element-6066-11e4-a52e-4f735466cecf"
+
+
+class TauriServer:
+    """``BundledServer`` implementation for the bundled tauri-mcp provider.
+
+    One instance per in-process session. It holds at most one application
+    process and one WebDriver session; ``tauri.launch`` twice replaces the
+    first, and teardown always stops both.
+    """
+
+    def __init__(self, provider: McpProviderConfig) -> None:
+        self._provider = provider
+        self._proc: asyncio.subprocess.Process | None = None
+        self._client: httpx.AsyncClient | None = None
+        self._session_id: str | None = None
+        self._base: str = f"http://{_HOST}:{_DEFAULT_PORT}"
+        #: Set when launch spawned the process, so close only kills what it started.
+        self._owns_process = False
+
+    # -- BundledServer protocol ------------------------------------------------
+
+    async def list_tools(self) -> list[Tool]:
+        return _tool_catalog()
+
+    async def call_tool(
+        self, name: str, arguments: dict[str, Any]
+    ) -> list[TextContent | ImageContent | EmbeddedResource]:
+        if name == "tauri.launch":
+            return [TextContent(type="text", text=await self._launch(arguments))]
+        if name == "tauri.close":
+            await self._stop()
+            return [TextContent(type="text", text="application stopped")]
+        if name == "tauri.screenshot":
+            return [
+                ImageContent(
+                    type="image",
+                    data=await self._screenshot(),
+                    mimeType="image/png",
+                )
+            ]
+        if name == "tauri.click":
+            await self._click(arguments)
+            return [TextContent(type="text", text="ok")]
+        if name == "tauri.type_text":
+            await self._type_text(arguments)
+            return [TextContent(type="text", text="ok")]
+        if name == "tauri.get_text":
+            return [TextContent(type="text", text=await self._text_of(arguments))]
+        if name == "tauri.assert_text":
+            return [TextContent(type="text", text=await self._assert_text(arguments))]
+        if name == "tauri.assert_visible":
+            return [TextContent(type="text", text=await self._assert_visible(arguments))]
+        if name == "tauri.eval":
+            return [TextContent(type="text", text=json.dumps(await self._eval(arguments)))]
+        raise AssertionError(f"unknown tool: {name}")
+
+    async def aclose(self) -> None:
+        await self._stop()
+
+    # -- lifecycle -------------------------------------------------------------
+
+    async def _launch(self, arguments: dict[str, Any]) -> str:
+        """Start the app (unless one is already running) and open a session.
+
+        ``command`` is optional: a suite can point the provider at an app that
+        is already running — a ``tauri dev`` session during local development,
+        say — by giving only ``port``.
+        """
+        await self._stop()
+
+        port = int(arguments.get("port") or _DEFAULT_PORT)
+        self._base = f"http://{_HOST}:{port}"
+        timeout = float(arguments.get("timeout_seconds") or _DEFAULT_LAUNCH_TIMEOUT)
+        self._client = httpx.AsyncClient(timeout=_DEFAULT_CALL_TIMEOUT)
+
+        command = _command_of(arguments)
+        if command:
+            env = {
+                **os.environ,
+                **self._provider.env,
+                **{str(k): str(v) for k, v in (arguments.get("env") or {}).items()},
+            }
+            self._proc = await asyncio.create_subprocess_exec(
+                *command,
+                env=env,
+                cwd=arguments.get("cwd") or None,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            self._owns_process = True
+
+        await self._await_ready(timeout)
+        self._session_id = await self._open_session()
+        return f"session {self._session_id} on {self._base}"
+
+    async def _await_ready(self, budget_seconds: float) -> None:
+        """Poll ``GET /status`` until the embedded server answers.
+
+        A Tauri app has to create its window and start the plugin's listener
+        before it can serve anything, and on a cold start that is not instant.
+        Polling beats a fixed sleep, which would either be flaky or slow.
+        """
+        deadline = time.monotonic() + budget_seconds
+        last: str = "no attempt made"
+        while time.monotonic() < deadline:
+            if self._proc is not None and self._proc.returncode is not None:
+                raise AssertionError(
+                    f"the application exited with code {self._proc.returncode} before "
+                    f"its WebDriver server answered on {self._base}"
+                )
+            try:
+                response = await self._http().get(f"{self._base}/status")
+                if response.status_code == httpx.codes.OK:
+                    return
+                last = f"HTTP {response.status_code}"
+            except httpx.HTTPError as exc:
+                last = str(exc)
+            await asyncio.sleep(0.25)
+        raise AssertionError(
+            f"no WebDriver server on {self._base} after {budget_seconds:g}s ({last}). "
+            "Is the app built with the wdio plugin registered?"
+        )
+
+    async def _open_session(self) -> str:
+        payload = await self._post("/session", {"capabilities": {"alwaysMatch": {}}})
+        value = payload.get("value") or {}
+        session_id = value.get("sessionId") or payload.get("sessionId")
+        if not isinstance(session_id, str):
+            raise AssertionError(f"WebDriver did not return a session id: {payload!r}")
+        return session_id
+
+    async def _stop(self) -> None:
+        if self._session_id is not None and self._client is not None:
+            # Best-effort: the app may already be gone, and failing to close a
+            # session must not mask whatever actually ended the test.
+            with contextlib.suppress(httpx.HTTPError):
+                await self._client.delete(f"{self._base}/session/{self._session_id}")
+            self._session_id = None
+        if self._proc is not None and self._owns_process:
+            if self._proc.returncode is None:
+                self._proc.terminate()
+                with contextlib.suppress(TimeoutError, asyncio.TimeoutError):
+                    await asyncio.wait_for(self._proc.wait(), timeout=5)
+                if self._proc.returncode is None:
+                    self._proc.kill()
+                    await self._proc.wait()
+            self._proc = None
+            self._owns_process = False
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    # -- WebDriver plumbing ----------------------------------------------------
+
+    def _http(self) -> httpx.AsyncClient:
+        if self._client is None:
+            raise AssertionError("call tauri.launch before any other tauri.* tool")
+        return self._client
+
+    def _session(self) -> str:
+        if self._session_id is None:
+            raise AssertionError("call tauri.launch before any other tauri.* tool")
+        return self._session_id
+
+    async def _post(
+        self, path: str, body: dict[str, Any], *, allow_error: bool = False
+    ) -> dict[str, Any]:
+        response = await self._http().post(f"{self._base}{path}", json=body)
+        return _unwrap(response, path, allow_error=allow_error)
+
+    async def _get(self, path: str) -> dict[str, Any]:
+        response = await self._http().get(f"{self._base}{path}")
+        return _unwrap(response, path)
+
+    async def _find(self, arguments: dict[str, Any]) -> str:
+        """Resolve a selector to an element reference, retrying until it appears.
+
+        A React app renders after the window is up, so the first look can lose a
+        race the test did not intend to run. Retrying inside the provider keeps
+        that timing detail out of every suite that uses it.
+        """
+        using, value = _selector_of(arguments)
+        timeout = float(arguments.get("timeout_seconds") or 5.0)
+        deadline = time.monotonic() + timeout
+        while True:
+            payload = await self._post(
+                f"/session/{self._session()}/element",
+                {"using": using, "value": value},
+                allow_error=True,
+            )
+            element = (payload.get("value") or {}).get(_ELEMENT_KEY)
+            if isinstance(element, str):
+                return element
+            if time.monotonic() >= deadline:
+                raise AssertionError(f"no element matched {using} {value!r} within {timeout:g}s")
+            await asyncio.sleep(0.15)
+
+    # -- tools -----------------------------------------------------------------
+
+    async def _click(self, arguments: dict[str, Any]) -> None:
+        element = await self._find(arguments)
+        await self._post(f"/session/{self._session()}/element/{element}/click", {})
+
+    async def _type_text(self, arguments: dict[str, Any]) -> None:
+        element = await self._find(arguments)
+        text = str(arguments.get("text", ""))
+        if arguments.get("clear", False):
+            await self._post(f"/session/{self._session()}/element/{element}/clear", {})
+        await self._post(
+            f"/session/{self._session()}/element/{element}/value",
+            {"text": text},
+        )
+
+    async def _text_of(self, arguments: dict[str, Any]) -> str:
+        element = await self._find(arguments)
+        payload = await self._get(f"/session/{self._session()}/element/{element}/text")
+        return str(payload.get("value", ""))
+
+    async def _assert_text(self, arguments: dict[str, Any]) -> str:
+        actual = await self._text_of(arguments)
+        if "equals" in arguments:
+            expected = str(arguments["equals"])
+            if actual != expected:
+                raise AssertionError(f"text {actual!r} != {expected!r}")
+        elif "contains" in arguments:
+            needle = str(arguments["contains"])
+            if needle not in actual:
+                raise AssertionError(f"text {actual!r} does not contain {needle!r}")
+        else:
+            raise AssertionError("tauri.assert_text needs `equals` or `contains`")
+        return "ok"
+
+    async def _assert_visible(self, arguments: dict[str, Any]) -> str:
+        """Assert an element is (or, with ``absent``, is not) displayed.
+
+        The negative case is its own argument rather than a second tool because
+        "this must not be on screen" is exactly as common an expectation as the
+        positive one — an error bar that should not appear, for instance.
+        """
+        absent = bool(arguments.get("absent", False))
+        try:
+            element = await self._find(arguments)
+        except AssertionError:
+            if absent:
+                return "ok"
+            raise
+        payload = await self._get(f"/session/{self._session()}/element/{element}/displayed")
+        displayed = bool(payload.get("value", False))
+        if absent and displayed:
+            using, value = _selector_of(arguments)
+            raise AssertionError(f"{using} {value!r} is displayed but was expected absent")
+        if not absent and not displayed:
+            using, value = _selector_of(arguments)
+            raise AssertionError(f"{using} {value!r} exists but is not displayed")
+        return "ok"
+
+    async def _eval(self, arguments: dict[str, Any]) -> Any:
+        script = str(arguments["script"])
+        args = list(arguments.get("args") or [])
+        payload = await self._post(
+            f"/session/{self._session()}/execute/sync",
+            {"script": script, "args": args},
+        )
+        return payload.get("value")
+
+    async def _screenshot(self) -> str:
+        payload = await self._get(f"/session/{self._session()}/screenshot")
+        return str(payload.get("value", ""))
+
+
+def _command_of(arguments: dict[str, Any]) -> list[str]:
+    raw = arguments.get("command")
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        return [raw]
+    return [str(part) for part in cast("list[Any]", raw)]
+
+
+def _selector_of(arguments: dict[str, Any]) -> tuple[str, str]:
+    """The element a step addressed, as a W3C ``(using, value)`` pair."""
+    if "css" in arguments:
+        return "css selector", str(arguments["css"])
+    if "xpath" in arguments:
+        return "xpath", str(arguments["xpath"])
+    if "selector" in arguments:
+        return "css selector", str(arguments["selector"])
+    raise AssertionError("a selector is required: pass `css`, `xpath`, or `selector`")
+
+
+def _unwrap(response: httpx.Response, path: str, *, allow_error: bool = False) -> dict[str, Any]:
+    """Turn a WebDriver response into a payload dict, or raise its error.
+
+    WebDriver reports failures in the body rather than only in the status line,
+    so an unread error would surface later as a confusing missing key.
+    """
+    try:
+        payload = cast("dict[str, Any]", response.json())
+    except ValueError as exc:
+        raise AssertionError(f"{path}: WebDriver returned non-JSON: {response.text[:200]}") from exc
+    value = payload.get("value")
+    if isinstance(value, dict) and "error" in value and not allow_error:
+        message = value.get("message") or value["error"]
+        raise AssertionError(f"{path}: {value['error']}: {message}")
+    return payload
+
+
+def build_tauri_server(provider: McpProviderConfig) -> TauriServer:
+    """Factory matching the ``BundledBuilder`` callable signature."""
+    return TauriServer(provider)
+
+
+def _tool_catalog() -> list[Tool]:
+    selector_props: dict[str, Any] = {
+        "css": {"type": "string"},
+        "xpath": {"type": "string"},
+        "selector": {"type": "string"},
+        "timeout_seconds": {"type": "number"},
+    }
+    return [
+        Tool(
+            name="tauri.launch",
+            description=(
+                "Start a Tauri application and open a WebDriver session against its "
+                "embedded server. Omit `command` to attach to an app already running."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "command": {"type": ["string", "array"], "items": {"type": "string"}},
+                    "cwd": {"type": "string"},
+                    "env": {"type": "object"},
+                    "port": {"type": "integer"},
+                    "timeout_seconds": {"type": "number"},
+                },
+            },
+        ),
+        Tool(
+            name="tauri.close",
+            description="End the WebDriver session and stop the application.",
+            input_schema={"type": "object", "properties": {}},
+        ),
+        Tool(
+            name="tauri.click",
+            description="Click the first element matching the selector.",
+            input_schema={"type": "object", "properties": selector_props},
+        ),
+        Tool(
+            name="tauri.type_text",
+            description="Send text to the element matching the selector.",
+            input_schema={
+                "type": "object",
+                "required": ["text"],
+                "properties": {
+                    **selector_props,
+                    "text": {"type": "string"},
+                    "clear": {"type": "boolean"},
+                },
+            },
+        ),
+        Tool(
+            name="tauri.get_text",
+            description="Return the rendered text of the matching element.",
+            input_schema={"type": "object", "properties": selector_props},
+        ),
+        Tool(
+            name="tauri.assert_text",
+            description="Assert the matching element's text equals or contains a value.",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    **selector_props,
+                    "equals": {"type": "string"},
+                    "contains": {"type": "string"},
+                },
+            },
+        ),
+        Tool(
+            name="tauri.assert_visible",
+            description=(
+                "Assert the matching element is displayed, or with `absent` that no such "
+                "element is on screen."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {**selector_props, "absent": {"type": "boolean"}},
+            },
+        ),
+        Tool(
+            name="tauri.eval",
+            description=(
+                "Run JavaScript in the webview and return its value. Reaches the Rust "
+                "backend through the page's own window.__TAURI_INTERNALS__.invoke."
+            ),
+            input_schema={
+                "type": "object",
+                "required": ["script"],
+                "properties": {"script": {"type": "string"}, "args": {"type": "array"}},
+            },
+        ),
+        Tool(
+            name="tauri.screenshot",
+            description="PNG screenshot of the application window.",
+            input_schema={"type": "object", "properties": {}},
+        ),
+    ]
+
+
+register_bundled_builder(PROVIDER_NAME, build_tauri_server)

--- a/packages/mcp/src/suitest_mcp/bundled/tauri.py
+++ b/packages/mcp/src/suitest_mcp/bundled/tauri.py
@@ -150,6 +150,18 @@ class TauriServer:
 
         command = _command_of(arguments)
         if command:
+            # Refuse to spawn onto a port something else already answers.
+            # Without this the poll below succeeds against the stranger, the
+            # process we spawned fails to bind and is never noticed, and every
+            # later step drives someone else's window — which is how one
+            # crashed case silently poisons the cases after it.
+            # A previous case's app may still be releasing the socket, so give
+            # it a moment before calling it someone else's.
+            if not await self._port_free(grace_seconds=5.0):
+                raise AssertionError(
+                    f"something is already serving WebDriver on {self._base}. "
+                    "Stop it first, or omit `command` to attach to it on purpose."
+                )
             env = {
                 **os.environ,
                 **self._provider.env,
@@ -167,6 +179,21 @@ class TauriServer:
         await self._await_ready(timeout)
         self._session_id = await self._open_session()
         return f"session {self._session_id} on {self._base}"
+
+    async def _port_free(self, *, grace_seconds: float) -> bool:
+        """True once nothing answers WebDriver at the target port."""
+        deadline = time.monotonic() + grace_seconds
+        while True:
+            try:
+                response = await self._http().get(f"{self._base}/status", timeout=2.0)
+                answered = response.status_code == httpx.codes.OK
+            except httpx.HTTPError:
+                return True
+            if not answered:
+                return True
+            if time.monotonic() >= deadline:
+                return False
+            await asyncio.sleep(0.25)
 
     async def _await_ready(self, budget_seconds: float) -> None:
         """Poll ``GET /status`` until the embedded server answers.

--- a/packages/mcp/src/suitest_mcp/providers/builtin_specs.py
+++ b/packages/mcp/src/suitest_mcp/providers/builtin_specs.py
@@ -251,6 +251,8 @@ BUILTIN_SPECS: list[McpProviderConfig] = [
                 "tauri.assert_visible",
                 "tauri.eval",
                 "tauri.screenshot",
+                "tauri.start_video",
+                "tauri.stop_video",
             ]
         },
         max_sessions=2,

--- a/packages/mcp/src/suitest_mcp/providers/builtin_specs.py
+++ b/packages/mcp/src/suitest_mcp/providers/builtin_specs.py
@@ -228,4 +228,35 @@ BUILTIN_SPECS: list[McpProviderConfig] = [
         spawn_timeout_seconds=120.0,
         call_timeout_seconds=60.0,
     ),
+    # Bundled in-process for the same reason as slint-mcp: the WebDriver server
+    # lives inside the application under test (tauri-plugin-wdio-webdriver), so
+    # there is no binary to install or pin. Unlike slint the wire protocol is a
+    # standard — W3C WebDriver — which is also why this works on macOS, where
+    # the standalone tauri-driver does not exist.
+    McpProviderConfig(
+        id="builtin:tauri-mcp",
+        workspace_id="_builtin_",
+        name="tauri-mcp",
+        kind="desktop",
+        transport=McpTransport.IN_PROCESS,
+        endpoint="in-process://tauri",
+        config_json={
+            "tools": [
+                "tauri.launch",
+                "tauri.close",
+                "tauri.click",
+                "tauri.type_text",
+                "tauri.get_text",
+                "tauri.assert_text",
+                "tauri.assert_visible",
+                "tauri.eval",
+                "tauri.screenshot",
+            ]
+        },
+        max_sessions=2,
+        # Cold-starting a bundled desktop app plus its webview is slow enough
+        # that the playwright-sized budget is the right order of magnitude.
+        spawn_timeout_seconds=120.0,
+        call_timeout_seconds=60.0,
+    ),
 ]

--- a/packages/mcp/tests/test_bundled_tauri.py
+++ b/packages/mcp/tests/test_bundled_tauri.py
@@ -8,6 +8,7 @@ anything was launched, and speaks W3C WebDriver correctly against a stub.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any
 
@@ -222,11 +223,43 @@ async def test_screenshot_comes_back_as_an_image_block() -> None:
 async def test_launch_refuses_a_port_someone_else_is_serving() -> None:
     """Attaching to a stranger's window is worse than failing: the spawned
     process never binds, nobody notices, and every later step drives the wrong
-    app."""
-    server = build_tauri_server(_config())
-    server._client = httpx.AsyncClient(transport=httpx.MockTransport(_FakeDriver().handler))
-    with pytest.raises(AssertionError, match="already serving WebDriver"):
-        await server.call_tool("tauri.launch", {"command": ["/bin/true"], "timeout_seconds": 1})
+    app.
+
+    Uses a real listener rather than a mock transport, because launch builds its
+    own client and would discard one injected here — which is exactly how this
+    check could pass while testing nothing.
+    """
+
+    async def serve(_reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        body = b'{"value":{"ready":true}}'
+        writer.write(
+            b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: "
+            + str(len(body)).encode()
+            + b"\r\nConnection: close\r\n\r\n"
+            + body
+        )
+        await writer.drain()
+        writer.close()
+
+    listener = await asyncio.start_server(serve, "127.0.0.1", 0)
+    port = listener.sockets[0].getsockname()[1]
+    try:
+        server = build_tauri_server(_config())
+        with pytest.raises(AssertionError, match="already serving WebDriver"):
+            await server.call_tool(
+                "tauri.launch",
+                {"command": ["/usr/bin/true"], "port": port, "timeout_seconds": 1},
+            )
+    finally:
+        listener.close()
+        await listener.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_stop_video_without_start_says_so() -> None:
+    server = _attached(_FakeDriver())
+    with pytest.raises(AssertionError, match=r"call `tauri\.start_video` first"):
+        await server.call_tool("tauri.stop_video", {})
 
 
 @pytest.mark.asyncio

--- a/packages/mcp/tests/test_bundled_tauri.py
+++ b/packages/mcp/tests/test_bundled_tauri.py
@@ -219,6 +219,17 @@ async def test_screenshot_comes_back_as_an_image_block() -> None:
 
 
 @pytest.mark.asyncio
+async def test_launch_refuses_a_port_someone_else_is_serving() -> None:
+    """Attaching to a stranger's window is worse than failing: the spawned
+    process never binds, nobody notices, and every later step drives the wrong
+    app."""
+    server = build_tauri_server(_config())
+    server._client = httpx.AsyncClient(transport=httpx.MockTransport(_FakeDriver().handler))
+    with pytest.raises(AssertionError, match="already serving WebDriver"):
+        await server.call_tool("tauri.launch", {"command": ["/bin/true"], "timeout_seconds": 1})
+
+
+@pytest.mark.asyncio
 async def test_launch_without_a_server_explains_the_likely_cause() -> None:
     """The usual reason is an app built without the plugin, so say that rather
     than leaving a bare connection error."""

--- a/packages/mcp/tests/test_bundled_tauri.py
+++ b/packages/mcp/tests/test_bundled_tauri.py
@@ -1,0 +1,227 @@
+"""Bundled tauri-mcp provider — contract checks that need no Tauri app.
+
+Driving a real application is covered by the desktop suite; what matters here is
+that the provider is wired into the bundled registry, advertises exactly the
+catalog its builtin spec promises, fails understandably when a step runs before
+anything was launched, and speaks W3C WebDriver correctly against a stub.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from suitest_mcp.bundled.in_process_runtime import get_bundled_builder
+from suitest_mcp.bundled.tauri import (
+    PROVIDER_NAME,
+    TauriServer,
+    build_tauri_server,
+)
+from suitest_mcp.models import McpProviderConfig, McpTransport
+from suitest_mcp.providers.builtin_specs import BUILTIN_SPECS
+
+_ELEMENT_KEY = "element-6066-11e4-a52e-4f735466cecf"
+
+
+def _config() -> McpProviderConfig:
+    return McpProviderConfig(
+        id="builtin:tauri-mcp",
+        workspace_id="_builtin_",
+        name=PROVIDER_NAME,
+        kind="desktop",
+        transport=McpTransport.IN_PROCESS,
+        endpoint="in-process://tauri",
+    )
+
+
+def test_provider_resolves_through_the_bundled_registry() -> None:
+    """The lazy-import entry is what lets the runtime find us without the
+    bundled package importing every provider eagerly."""
+    assert get_bundled_builder(PROVIDER_NAME) is not None
+
+
+@pytest.mark.asyncio
+async def test_tool_catalog_matches_the_builtin_spec() -> None:
+    """The advertised tools and the spec's `config_json` must not drift — the
+    spec is what routing and the docs are written against."""
+    spec = next(s for s in BUILTIN_SPECS if s.name == PROVIDER_NAME)
+    advertised = {t.name for t in await build_tauri_server(_config()).list_tools()}
+    assert advertised == set(spec.config_json["tools"])
+
+
+@pytest.mark.asyncio
+async def test_tools_before_launch_say_so() -> None:
+    """A step that forgets `tauri.launch` should name the missing step, not
+    fail somewhere deep in the HTTP client."""
+    server = build_tauri_server(_config())
+    with pytest.raises(AssertionError, match=r"tauri\.launch"):
+        await server.call_tool("tauri.click", {"css": ".add-btn"})
+
+
+@pytest.mark.asyncio
+async def test_missing_selector_is_reported_as_such() -> None:
+    server = _attached(_FakeDriver())
+    with pytest.raises(AssertionError, match="a selector is required"):
+        await server.call_tool("tauri.click", {})
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_is_named() -> None:
+    server = build_tauri_server(_config())
+    with pytest.raises(AssertionError, match=r"unknown tool: tauri\.levitate"):
+        await server.call_tool("tauri.levitate", {})
+
+
+# ---------------------------------------------------------------------------
+# WebDriver protocol behaviour, against a stub transport.
+# ---------------------------------------------------------------------------
+
+
+class _FakeDriver:
+    """The subset of W3C WebDriver the provider speaks.
+
+    Answers like the embedded server does — including reporting failures in the
+    body rather than the status line, which is the case a naive client gets
+    wrong.
+    """
+
+    def __init__(self, *, text: str = "Nota baru", displayed: bool = True) -> None:
+        self.text = text
+        self.displayed = displayed
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+        #: Selectors that should resolve; anything else answers "no such element".
+        self.known = {".note-title", ".add-btn", ".search", ".error-bar"}
+        self.missing: set[str] = set()
+
+    async def handler(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        body: dict[str, Any] = {}
+        if request.content:
+            body = json.loads(request.content)
+        self.calls.append((request.method, path, body))
+
+        if path == "/status":
+            return httpx.Response(200, json={"value": {"ready": True}})
+        if path == "/session" and request.method == "POST":
+            return httpx.Response(200, json={"value": {"sessionId": "s-1"}})
+        if path.endswith("/element") and request.method == "POST":
+            value = str(body.get("value", ""))
+            if value in self.known and value not in self.missing:
+                return httpx.Response(200, json={"value": {_ELEMENT_KEY: "e-1"}})
+            return httpx.Response(
+                404,
+                json={"value": {"error": "no such element", "message": "Unable to locate element"}},
+            )
+        if path.endswith("/text"):
+            return httpx.Response(200, json={"value": self.text})
+        if path.endswith("/displayed"):
+            return httpx.Response(200, json={"value": self.displayed})
+        if path.endswith("/screenshot"):
+            return httpx.Response(200, json={"value": "iVBORw0KGgo="})
+        if path.endswith("/execute/sync"):
+            return httpx.Response(200, json={"value": ["Rapat/2026-08-28/meet-abc-1400.md"]})
+        return httpx.Response(200, json={"value": None})
+
+
+def _attached(driver: _FakeDriver) -> TauriServer:
+    """A server already 'launched' against the stub, with no process to own."""
+    server = build_tauri_server(_config())
+    server._client = httpx.AsyncClient(transport=httpx.MockTransport(driver.handler))
+    server._session_id = "s-1"
+    return server
+
+
+@pytest.mark.asyncio
+async def test_click_resolves_the_element_then_clicks_it() -> None:
+    driver = _FakeDriver()
+    server = _attached(driver)
+    await server.call_tool("tauri.click", {"css": ".add-btn"})
+    paths = [path for _, path, _ in driver.calls]
+    assert paths == ["/session/s-1/element", "/session/s-1/element/e-1/click"]
+
+
+@pytest.mark.asyncio
+async def test_type_text_clears_first_only_when_asked() -> None:
+    driver = _FakeDriver()
+    server = _attached(driver)
+    await server.call_tool("tauri.type_text", {"css": ".search", "text": "a"})
+    assert not any(path.endswith("/clear") for _, path, _ in driver.calls)
+
+    driver.calls.clear()
+    await server.call_tool("tauri.type_text", {"css": ".search", "text": "a", "clear": True})
+    assert any(path.endswith("/clear") for _, path, _ in driver.calls)
+
+
+@pytest.mark.asyncio
+async def test_assert_text_contains_and_equals() -> None:
+    server = _attached(_FakeDriver(text="Gate review"))
+    await server.call_tool("tauri.assert_text", {"css": ".note-title", "contains": "Gate"})
+    await server.call_tool("tauri.assert_text", {"css": ".note-title", "equals": "Gate review"})
+    with pytest.raises(AssertionError, match="does not contain"):
+        await server.call_tool("tauri.assert_text", {"css": ".note-title", "contains": "Retro"})
+
+
+@pytest.mark.asyncio
+async def test_assert_text_without_a_comparison_says_so() -> None:
+    server = _attached(_FakeDriver())
+    with pytest.raises(AssertionError, match="needs `equals` or `contains`"):
+        await server.call_tool("tauri.assert_text", {"css": ".note-title"})
+
+
+@pytest.mark.asyncio
+async def test_assert_visible_absent_passes_when_nothing_matches() -> None:
+    """ "This must not be on screen" is as common an expectation as its
+    opposite — an error bar that should not appear, for instance."""
+    driver = _FakeDriver()
+    driver.missing = {".error-bar"}
+    server = _attached(driver)
+    await server.call_tool("tauri.assert_visible", {"css": ".error-bar", "absent": True})
+
+
+@pytest.mark.asyncio
+async def test_assert_visible_absent_fails_when_the_element_is_there() -> None:
+    server = _attached(_FakeDriver(displayed=True))
+    with pytest.raises(AssertionError, match="expected absent"):
+        await server.call_tool("tauri.assert_visible", {"css": ".error-bar", "absent": True})
+
+
+@pytest.mark.asyncio
+async def test_a_missing_element_names_the_selector() -> None:
+    driver = _FakeDriver()
+    server = _attached(driver)
+    with pytest.raises(AssertionError, match=r"no element matched css selector '\.nope'"):
+        await server.call_tool("tauri.click", {"css": ".nope", "timeout_seconds": 0.1})
+
+
+@pytest.mark.asyncio
+async def test_eval_returns_the_scripts_value() -> None:
+    """The seam onto Rust: a step asserts on what the backend did, not only on
+    what the DOM shows."""
+    server = _attached(_FakeDriver())
+    blocks = await server.call_tool(
+        "tauri.eval",
+        {"script": "return window.__TAURI_INTERNALS__.invoke('list_vault')"},
+    )
+    assert json.loads(blocks[0].text) == ["Rapat/2026-08-28/meet-abc-1400.md"]  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio
+async def test_screenshot_comes_back_as_an_image_block() -> None:
+    """The runner turns image blocks into SCREENSHOT artifacts; a text block
+    would land as an unreadable blob instead."""
+    server = _attached(_FakeDriver())
+    blocks = await server.call_tool("tauri.screenshot", {})
+    assert blocks[0].type == "image"
+    # the field is aliased: constructed as `mimeType`, read as `mime_type`
+    assert blocks[0].mime_type == "image/png"  # type: ignore[union-attr]
+
+
+@pytest.mark.asyncio
+async def test_launch_without_a_server_explains_the_likely_cause() -> None:
+    """The usual reason is an app built without the plugin, so say that rather
+    than leaving a bare connection error."""
+    server = build_tauri_server(_config())
+    with pytest.raises(AssertionError, match="wdio plugin"):
+        await server.call_tool("tauri.launch", {"port": 1, "timeout_seconds": 0.3})

--- a/packages/mcp/tests/test_registry_routing.py
+++ b/packages/mcp/tests/test_registry_routing.py
@@ -24,7 +24,7 @@ def _registry_with_builtins(workspace_id: str = "ws-1") -> McpRegistry:
 def test_registry_register_builtin_seeds_bundled_providers() -> None:
     reg = _registry_with_builtins()
     providers = {p.name for p in reg.list_for_workspace("ws-1")}
-    # 3 original (M1c) + 5 added in M2-10 + 3 desktop (M14) = 11.
+    # 3 original (M1c) + 5 added in M2-10 + 4 desktop (M14) = 12.
     assert providers == {
         "api-http-mcp",
         "playwright-mcp",
@@ -37,7 +37,27 @@ def test_registry_register_builtin_seeds_bundled_providers() -> None:
         "computer-use-mcp",
         "electron-mcp",
         "slint-mcp",
+        "tauri-mcp",
     }
+
+
+def test_routing_fe_desktop_explicit_tauri_wins() -> None:
+    """FE_DESKTOP defaults elsewhere, so a Tauri suite pins the provider per
+    step — the same way a Slint suite does."""
+    reg = _registry_with_builtins()
+    cfg = resolve_provider(
+        reg, workspace_id="ws-1", target_kind=TargetKind.FE_DESKTOP, explicit="tauri-mcp"
+    )
+    assert cfg.name == "tauri-mcp"
+
+
+def test_tauri_provider_is_bundled_in_process() -> None:
+    """In-process, not stdio: the WebDriver server lives inside the app under
+    test, so there is no external binary to install or pin."""
+    reg = _registry_with_builtins()
+    spec = reg.get("ws-1", "tauri-mcp")
+    assert spec.transport is McpTransport.IN_PROCESS
+    assert spec.endpoint == "in-process://tauri"
 
 
 def test_registry_get_reattributes_workspace_id() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2653,7 +2653,7 @@ wheels = [
 
 [[package]]
 name = "suiflex-suitest-lifecycle"
-version = "0.1.9"
+version = "0.9.0"
 source = { editable = "packages/lifecycle" }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Suitest could not drive a Tauri application at all — the word did not appear anywhere in the repository — while Tauri is one of the more common ways a desktop app is built today.
- `tauri-mcp` is a bundled in-process provider that speaks **W3C WebDriver** to the server the app embeds via `tauri-plugin-wdio-webdriver`. That choice is what makes it work on macOS, where the standalone `tauri-driver` binary does not exist, and it means any Tauri app that registers the plugin is drivable — nothing here is specific to one application.
- Corrects two roadmap claims that were not true, and fixes a `make install` that left every test unable to import the workspace.

## Changes

**New provider** — `packages/mcp/src/suitest_mcp/bundled/tauri.py`

Follows the five-step checklist in `CLAUDE.md:246-263`, with `bundled/slint.py` as the nearest model: a bridge that owns the app process rather than a driver. Registered in `_LAZY_MODULES`, specced in `builtin_specs.py`, routed as an explicit per-step provider under the existing `FE_DESKTOP` target kind (no new target kind needed).

Tools: `tauri.launch`, `close`, `click`, `type_text`, `get_text`, `assert_text`, `assert_visible`, `eval`, `screenshot`, `start_video`, `stop_video`.

`tauri.eval` is the seam onto the backend — the page's own `window.__TAURI_INTERNALS__.invoke` reaches real commands, so a step can assert on what Rust actually did rather than only on what the DOM shows.

**Screen recording** — `bundled/_video.py`

`slint-mcp` already recorded; a Tauri suite should not be the poorer relation. The ffmpeg invocation carries real decisions (yuv420p and even dimensions so a browser will play it, faststart, a file rather than a pipe because the MP4 muxer seeks back to finish its header), so it is extracted and shared rather than copied. slint's 16 tests pass unchanged against the extracted version.

**Port-collision guard**

Found by running a suite whose first case crashed the app: the crashed window kept 4445, the next case's readiness poll succeeded against it, the process that case spawned failed to bind and nobody noticed, and every later step drove a dead window belonging to another case. Three cases reported missing elements that had nothing to do with them. Launching with a `command` now checks the port first, with a grace period for the previous app still releasing the socket. Omitting `command` still attaches on purpose — that is what pointing the provider at a running `tauri dev` is for.

**Documentation**

`docs/DESKTOP_TESTING.md` gains a section on why the protocol is WebDriver, what the app under test has to do, and the two traps found while wiring it up: a `debug_assertions` gate opens the port during ordinary development, and listing the plugin's permission in a capability file breaks every build that does not compile the plugin in.

`docs/ROADMAP.md` M14-1 and M14-2 are un-ticked. Neither is done: `computer-use-mcp` and `electron-mcp` are entries in `builtin_specs.py` naming binaries that exist nowhere in this repository and have no module behind them. Routing still sends `FE_DESKTOP` to the first of them by default, so the milestone read as finished while the default path for a desktop step could not spawn. The READMEs advertised the same two to users.

**`make install`**

`uv sync --all-extras --dev` installs the root project only, so the workspace members it depends on for imports never landed in `.venv`. On a clean checkout every test that imported one failed at collection with `ModuleNotFoundError` rather than with anything pointing at the cause. Now `--all-packages`.

## Test plan

- [x] `pytest packages/mcp/tests/` — **170 passed, 9 skipped** (17 of them new, in `test_bundled_tauri.py`)
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — 682 files already formatted
- [x] `mypy packages/mcp` — no issues in 31 source files
- [x] slint's 16 existing tests pass against the extracted video encoder
- [x] Driven end to end against a real Tauri app (Companion Desktop) through the local no-docker stack: a 7-case suite, **46/46 steps passed**, producing 7 `SCREENSHOT` and 2 `VIDEO` artifacts
- [x] Videos verified with `ffprobe`: h264, 2560x1600, 14–16 frames over 3.5–4.0s with `SUITEST_EVIDENCE_RECORDING=1`
- [x] Negative control: reverting a fix in the app under test turned the matching case red and left the others green
- [ ] Not run: any CI job — this branch has not been through the pipeline yet

## Notes for reviewers

Two things worth knowing:

**Recording without `SUITEST_EVIDENCE_RECORDING=1` is not useful.** Steps complete faster than the sampler, so a recording of a passing case came out 1–2 frames long. With the pause enabled it is 14–16. The docs say so; the alternative would have been inventing a pacing mechanism this repo already has.

**`IngestStep` has no `targetKind`.** A mixed suite — some steps hitting an API, some the UI — cannot be expressed through `bulk-import`, which sets one target kind for every step from `mode`. Not hit by this work and not addressed here, but it is a real limitation of that endpoint.
