### PR TITLE
feat(mcp): assert text inside PDF responses in api-http-mcp

### DIFF
--- a/docs/MCP_PLUGINS.md
+++ b/docs/MCP_PLUGINS.md
@@ -517,6 +517,51 @@ steps:
     assertions: [ { jsonpath: "$.email", equals: "{{user.email}}" } ]
 ```
 
+### 10.6 Printable document — PDF content assertions
+
+Verifying a generated document needs no browser: request it and assert its text
+layer. The runner feeds the `http.request` envelope into each assertion as
+`result`, so a single step covers status, content type and body.
+
+```yaml
+case: Report prints with the expected content
+steps:
+  - name: Preview carries the draft watermark
+    target_kind: BE_REST
+    mcp_provider: api-http-mcp
+    tool: http.request
+    arguments: { method: GET, url: "{{api_base}}/reports/{{report_id}}/print?draft=true", headers: { Authorization: "Bearer {{token}}" } }
+    assertions:
+      - { tool: http.assert_status, arguments: { equals: 200 } }
+      - { tool: http.assert_header, arguments: { name: content-type, equals: "application/pdf" } }
+      - { tool: http.assert_pdf_text, arguments: { contains: ["DRAFT"] } }
+
+  - name: Final print carries the report body, not the watermark
+    mcp_provider: api-http-mcp
+    tool: http.request
+    arguments: { method: GET, url: "{{api_base}}/reports/{{report_id}}/print", headers: { Authorization: "Bearer {{token}}" } }
+    assertions:
+      - { tool: http.assert_header, arguments: { name: content-disposition, equals: "attachment; filename=report.pdf" } }
+      - { tool: http.assert_pdf_text, arguments: { page: 1, contains: ["Report No.", "Facility Data"], matches: "No\\.\\s*\\d+/\\d{4}" } }
+```
+
+The persisted `TestStep.code` for the first step is the same thing as a JSON
+envelope (DATA_MODEL.md §3.4) — this is what the step editor stores:
+
+```json
+{
+  "tool": "http.request",
+  "arguments": { "method": "GET", "url": "{{api_base}}/reports/{{report_id}}/print?draft=true" },
+  "assertions": [
+    { "tool": "http.assert_status", "arguments": { "equals": 200 } },
+    { "tool": "http.assert_pdf_text", "arguments": { "contains": ["DRAFT"] } }
+  ]
+}
+```
+
+Pair it with a `postgres-mcp` step asserting the same values in the database
+when the printed content must match stored data.
+
 ---
 
 ## 11. MCP tool browser (UI dev aid)

--- a/docs/MCP_PLUGINS.md
+++ b/docs/MCP_PLUGINS.md
@@ -142,6 +142,8 @@ These providers ship inside the main Suitest image (see [DEPLOYMENT.md](./DEPLOY
 | `jirac-mcp` | issue-tracker | stdio | EXTERNAL_TOOL | Jira issue tracker (file defect, transition, comment, JQL search) | cloud-token / DC PAT |
 | `github-mcp` | issue-tracker | stdio | EXTERNAL_TOOL | GitHub Issues + labels + comments | github-app-installation-token / PAT |
 
+> `api-http-mcp` also asserts on binary responses: a response whose `Content-Type` is not textual carries `body_base64` in the envelope, and `http.assert_pdf_text` extracts the PDF's text (all pages, or one 1-based `page`) to assert `contains` substrings / a `matches` regex. Whitespace is normalized before the `contains` check — PDF text extraction breaks lines where the layout does. Scanned/image-only PDFs have no text layer; assert those visually instead.
+>
 > `api-http-mcp` runs **in-process** (same Python process as the runner). It is implemented as an MCP server with stdio transport but launched via an internal channel for zero subprocess overhead. All other built-ins spawn out-of-process for isolation.
 >
 > `jirac-mcp` bundled from `mulhamna/jira-commands@jira-mcp-v2.0.1`; `github-mcp` bundled from `github/github-mcp-server@v1.1.2`. See `DEPLOYMENT.md §15` for binary bundling Dockerfile pattern.

--- a/packages/mcp/pyproject.toml
+++ b/packages/mcp/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "psycopg[binary]>=3.3.4",
   "psycopg-pool>=3.2",
   "jsonpath-ng>=1.6",
+  "pypdf>=6.1",
   "suitest-shared",
   "suitest-db",
   "suitest-core",

--- a/packages/mcp/src/suitest_mcp/bundled/api_http.py
+++ b/packages/mcp/src/suitest_mcp/bundled/api_http.py
@@ -15,6 +15,8 @@ Tool surface (mirrored in :mod:`suitest_mcp.providers.builtin_specs`):
   (optionally) equals / regex-matches an expected value.
 * ``http.assert_header``     — assert a response header equals a value
   (case-insensitive name match).
+* ``http.assert_pdf_text``   — extract the text of a PDF response body and
+  assert it contains substrings / matches a regex.
 
 Assertion failures raise :class:`AssertionError`; the SDK's tool-call wrapper
 catches them and emits an MCP ``CallToolResult`` with ``isError=true``, which
@@ -27,6 +29,8 @@ of the session, instantiated lazily on first ``http.request`` and released by
 
 from __future__ import annotations
 
+import base64
+import io
 import json
 import re
 from typing import TYPE_CHECKING, Any, cast
@@ -34,6 +38,7 @@ from typing import TYPE_CHECKING, Any, cast
 import httpx
 from jsonpath_ng.ext import parse as jsonpath_parse
 from mcp.types import TextContent, Tool
+from pypdf import PdfReader
 
 if TYPE_CHECKING:
     from suitest_mcp.models import McpProviderConfig
@@ -73,6 +78,8 @@ class ApiHttpServer:
             return _assert_json_path(arguments)
         if name == "http.assert_header":
             return _assert_header(arguments)
+        if name == "http.assert_pdf_text":
+            return _assert_pdf_text(arguments)
         raise ValueError(f"unknown tool {name!r}")
 
     async def aclose(self) -> None:
@@ -134,6 +141,10 @@ class ApiHttpServer:
             "elapsed_ms": int(response.elapsed.total_seconds() * 1000),
             "url": str(response.url),
         }
+        if _is_binary(response.headers.get("content-type", "")):
+            # ``body_text`` is mojibake for binary payloads (PDF, images).
+            # Carry the raw bytes too so downstream assertions can parse them.
+            payload["body_base64"] = base64.b64encode(response.content).decode("ascii")
         return [TextContent(type="text", text=json.dumps(payload))]
 
 
@@ -192,6 +203,23 @@ def _tool_catalog() -> list[Tool]:
                     "path": {"type": "string"},
                     "equals": {},
                     "matches": {"type": "string"},
+                },
+            },
+        ),
+        Tool(
+            name="http.assert_pdf_text",
+            description=(
+                "Extract text from a PDF response body and assert it contains "
+                "every given substring and/or matches a regular expression."
+            ),
+            input_schema={
+                "type": "object",
+                "required": ["result"],
+                "properties": {
+                    "result": {"type": "object"},
+                    "contains": {"type": "array", "items": {"type": "string"}},
+                    "matches": {"type": "string"},
+                    "page": {"type": "integer", "description": "1-based page; default all"},
                 },
             },
         ),
@@ -278,3 +306,45 @@ def _require_result(args: dict[str, Any]) -> dict[str, Any]:
         if isinstance(parsed, dict):
             return cast("dict[str, Any]", parsed)
     raise AssertionError("`result` must be the http.request response envelope")
+
+
+def _is_binary(content_type: str) -> bool:
+    ct = content_type.split(";")[0].strip().lower()
+    return bool(ct) and not (
+        ct.startswith("text/")
+        or ct.endswith(("json", "xml", "javascript", "x-www-form-urlencoded"))
+    )
+
+
+def _pdf_text(result: dict[str, Any], page: int | None) -> str:
+    encoded = result.get("body_base64")
+    if not isinstance(encoded, str):
+        raise AssertionError("response has no binary body — did the endpoint return a PDF?")
+    pages = PdfReader(io.BytesIO(base64.b64decode(encoded))).pages
+    if page is None:
+        return "\n".join(p.extract_text() or "" for p in pages)
+    if not 1 <= page <= len(pages):
+        raise AssertionError(f"page {page} out of range (PDF has {len(pages)} pages)")
+    return pages[page - 1].extract_text() or ""
+
+
+def _assert_pdf_text(args: dict[str, Any]) -> list[TextContent]:
+    """Assert the extracted PDF text contains substrings / matches a regex.
+
+    Whitespace is normalized before the ``contains`` check: PDF extraction
+    breaks lines wherever the layout does, so a literal comparison against a
+    human-written phrase fails for reasons that have nothing to do with the
+    document being wrong.
+    """
+    result = _require_result(args)
+    page = args.get("page")
+    text = _pdf_text(result, int(page) if page is not None else None)
+    normalized = " ".join(text.split())
+    for needle in args.get("contains", []):
+        if " ".join(str(needle).split()) not in normalized:
+            raise AssertionError(f"pdf text does not contain {needle!r}")
+    if "matches" in args:
+        pattern = str(args["matches"])
+        if re.search(pattern, text) is None:
+            raise AssertionError(f"pdf text does not match /{pattern}/")
+    return [TextContent(type="text", text=json.dumps({"chars": len(text)}))]

--- a/packages/mcp/src/suitest_mcp/providers/builtin_specs.py
+++ b/packages/mcp/src/suitest_mcp/providers/builtin_specs.py
@@ -27,6 +27,7 @@ BUILTIN_SPECS: list[McpProviderConfig] = [
                 "http.assert_status",
                 "http.assert_json_path",
                 "http.assert_header",
+                "http.assert_pdf_text",
             ]
         },
         is_default_for_target={"BE_REST": True},

--- a/packages/mcp/tests/test_api_http_bundled.py
+++ b/packages/mcp/tests/test_api_http_bundled.py
@@ -80,6 +80,7 @@ async def test_list_tools_advertises_four_http_tools(server: ApiHttpServer) -> N
         "http.assert_status",
         "http.assert_json_path",
         "http.assert_header",
+        "http.assert_pdf_text",
     }
     for t in tools:
         assert t.description, f"{t.name} must have a description"
@@ -284,6 +285,7 @@ async def test_in_process_session_lists_tools(session: McpSession) -> None:
         "http.assert_status",
         "http.assert_json_path",
         "http.assert_header",
+        "http.assert_pdf_text",
     }
 
 
@@ -313,4 +315,105 @@ async def test_in_process_session_assertion_failure_surfaces_as_tool_failed(
             "http.assert_status",
             {"result": {"status": 500, "headers": {}}, "equals": 200},
             timeout_seconds=10.0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# PDF body assertions
+# ---------------------------------------------------------------------------
+
+
+def _sample_pdf() -> bytes:
+    """A hand-rolled one-page PDF with two text lines — no writer library needed."""
+    stream = b"BT /F1 12 Tf 50 800 Td (Inspection Report) Tj 0 -20 Td (No. 42/2026) Tj ET"
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] "
+        b"/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+        b"<< /Length %d >>\nstream\n%s\nendstream" % (len(stream), stream),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ]
+    out = bytearray(b"%PDF-1.4\n")
+    offsets = []
+    for number, body in enumerate(objects, start=1):
+        offsets.append(len(out))
+        out += b"%d 0 obj\n%s\nendobj\n" % (number, body)
+    xref = len(out)
+    out += b"xref\n0 %d\n0000000000 65535 f \n" % (len(objects) + 1)
+    for offset in offsets:
+        out += b"%010d 00000 n \n" % offset
+    out += b"trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n" % (
+        len(objects) + 1,
+        xref,
+    )
+    return bytes(out)
+
+
+@pytest_asyncio.fixture
+async def pdf_result(server: ApiHttpServer) -> dict[str, object]:
+    """Drive a real PDF response through ``http.request`` to get the envelope."""
+    with respx.mock(assert_all_called=True) as router:
+        router.get("https://example.test/report.pdf").mock(
+            return_value=httpx.Response(
+                200,
+                content=_sample_pdf(),
+                headers={"content-type": "application/pdf"},
+            )
+        )
+        out = await server.call_tool(
+            "http.request",
+            {"method": "GET", "url": "https://example.test/report.pdf"},
+        )
+    return json.loads(_text(out))
+
+
+async def test_request_carries_base64_body_for_binary_content(
+    pdf_result: dict[str, object],
+) -> None:
+    assert isinstance(pdf_result["body_base64"], str)
+
+
+async def test_request_omits_base64_body_for_json(server: ApiHttpServer) -> None:
+    with respx.mock(assert_all_called=True) as router:
+        router.get("https://example.test/ping").mock(
+            return_value=httpx.Response(200, json={"pong": True})
+        )
+        out = await server.call_tool(
+            "http.request", {"method": "GET", "url": "https://example.test/ping"}
+        )
+    assert "body_base64" not in json.loads(_text(out))
+
+
+async def test_assert_pdf_text_contains_passes(
+    server: ApiHttpServer, pdf_result: dict[str, object]
+) -> None:
+    out = await server.call_tool(
+        "http.assert_pdf_text",
+        {"result": pdf_result, "contains": ["Inspection Report"], "matches": r"No\.\s*\d+"},
+    )
+    assert json.loads(_text(out))["chars"] > 0
+
+
+async def test_assert_pdf_text_missing_substring_raises(
+    server: ApiHttpServer, pdf_result: dict[str, object]
+) -> None:
+    with pytest.raises(AssertionError, match="does not contain"):
+        await server.call_tool(
+            "http.assert_pdf_text", {"result": pdf_result, "contains": ["Nowhere"]}
+        )
+
+
+async def test_assert_pdf_text_page_out_of_range_raises(
+    server: ApiHttpServer, pdf_result: dict[str, object]
+) -> None:
+    with pytest.raises(AssertionError, match="out of range"):
+        await server.call_tool("http.assert_pdf_text", {"result": pdf_result, "page": 9})
+
+
+async def test_assert_pdf_text_on_non_binary_body_raises(server: ApiHttpServer) -> None:
+    with pytest.raises(AssertionError, match="no binary body"):
+        await server.call_tool(
+            "http.assert_pdf_text",
+            {"result": {"status": 200, "headers": {}, "body_text": "{}"}, "contains": ["x"]},
         )

--- a/uv.lock
+++ b/uv.lock
@@ -2237,6 +2237,15 @@ crypto = [
 ]
 
 [[package]]
+name = "pypdf"
+version = "6.16.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/66/54212e75406afd9f3e933d0dda23072f6aecc55c5a273077dc2e0b028b23/pypdf-6.16.2.tar.gz", hash = "sha256:595647f6191de6f402cfde1d0c455d6cbccbd509aac32b34783009c032de5d6e", size = 7008996, upload-time = "2026-08-23T13:50:07.135Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/f1/a2da3b55acd4ab737bf728c97edaaed5ec1d3c1236acb639dcdfa97e42c7/pypdf-6.16.2-py3-none-any.whl", hash = "sha256:c8b09a59399062fb45a1b8156c18a787a10a3dae03ac9674397a226712c94604", size = 385060, upload-time = "2026-08-23T13:50:05.349Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2840,6 +2849,7 @@ dependencies = [
     { name = "psycopg", extra = ["binary"] },
     { name = "psycopg-pool" },
     { name = "pydantic" },
+    { name = "pypdf" },
     { name = "redis", extra = ["hiredis"] },
     { name = "structlog" },
     { name = "suitest-core" },
@@ -2868,6 +2878,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3.4" },
     { name = "psycopg-pool", specifier = ">=3.2" },
     { name = "pydantic", specifier = ">=2.7" },
+    { name = "pypdf", specifier = ">=6.1" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.4.0" },
     { name = "pytest-mock", marker = "extra == 'test'", specifier = ">=3.14" },


### PR DESCRIPTION
## Summary

- Printable documents were only testable at the envelope level (status, content-type, filename), so a regression in the document body itself passed CI unnoticed.
- `api-http-mcp` can now read the text layer of a PDF response and assert on it, keeping document-format tests in the same deterministic ZERO-tier path as the rest of the suite.

## Changes

**`packages/mcp` — provider**
- `http.request` now adds `body_base64` to the response envelope when the `Content-Type` is not textual (PDF, images). JSON/text responses are unchanged.
- New tool `http.assert_pdf_text`: extracts text via `pypdf` and asserts `contains` substrings and/or a `matches` regex, over all pages or one 1-based `page`. Whitespace is normalized before the substring check, because extraction breaks lines wherever the page layout does.
- `providers/builtin_specs.py`: tool added to the advertised catalog (the provider contract test asserts this matches).
- New dependency `pypdf>=6.1` — needed because nothing in stdlib or the existing deps parses PDF; permissive BSD-3 license, pure Python, no native build.

**Tests**
- Hand-rolled single-page PDF fixture (no writer library) driven through a real `http.request` call under `respx`, so the envelope path is covered as well as the assertion.
- Covers: base64 body present for binary / absent for JSON, passing `contains` + `matches`, missing substring, page out of range, and a non-binary body.

**Docs**
- `docs/MCP_PLUGINS.md`: tool documented alongside the note about scanned/image-only PDFs having no text layer.

## Test plan

- [x] `pytest packages/mcp` — 176 passed, 9 skipped
- [x] `ruff format --check` + `ruff check` clean
- [x] `mypy` clean on the touched module