### PR TITLE
feat(docs-site): add google analytics tag

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -6,6 +6,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0a0a0a" />
     <title>Suitest</title>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-EZ8KXQPVDE"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-EZ8KXQPVDE');
+    </script>
   </head>
   <body class="bg-base text-fg-1 antialiased">
     <div id="root"></div>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -6,13 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0a0a0a" />
     <title>Suitest</title>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-EZ8KXQPVDE"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-EZ8KXQPVDE');
-    </script>
   </head>
   <body class="bg-base text-fg-1 antialiased">
     <div id="root"></div>

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -28,6 +28,15 @@ export default defineConfig({
       lastUpdated: true,
       head: [
         {
+          tag: "script",
+          attrs: { async: true, src: "https://www.googletagmanager.com/gtag/js?id=G-EZ8KXQPVDE" },
+        },
+        {
+          tag: "script",
+          content:
+            "window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-EZ8KXQPVDE');",
+        },
+        {
           tag: "meta",
           attrs: { property: "og:image", content: "https://suitest.suiflex.dev/og.png" },
         },

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -29,12 +29,12 @@ export default defineConfig({
       head: [
         {
           tag: "script",
-          attrs: { async: true, src: "https://www.googletagmanager.com/gtag/js?id=G-EZ8KXQPVDE" },
+          attrs: { async: true, src: "https://www.googletagmanager.com/gtag/js?id=G-RH105WWMNF" },
         },
         {
           tag: "script",
           content:
-            "window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-EZ8KXQPVDE');",
+            "window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-RH105WWMNF');",
         },
         {
           tag: "meta",


### PR DESCRIPTION
## Summary
- Track docs site traffic in the same GA4 property (`G-EZ8KXQPVDE`) as the marketing site.

## Changes
- `docs-site/astro.config.mjs`: add the gtag.js loader + config snippet via Starlight's `head`.

## Test plan
- [ ] `pnpm --filter docs-site build` succeeds
- [ ] Loaded page fires a `collect` request to google-analytics.com