### PR TITLE
feat(docs-site): add google analytics tag to landing page

### DIFF
--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -69,6 +69,15 @@ const softwareLd = JSON.stringify({
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImage} />
     <meta name="theme-color" content="#0a0a0a" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-RH105WWMNF" is:inline></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-RH105WWMNF');
+    </script>
     <script type="application/ld+json" set:html={softwareLd} />
     <script>
       // Gate reveal-hidden styles behind a js class so no-JS visitors see content.


### PR DESCRIPTION
## Summary
- Add Google Analytics (gtag.js `G-RH105WWMNF`) script to the landing page (`/`).
- Ensures complete analytics coverage across both the custom landing page and the Starlight documentation pages.

## Changes
- `docs-site/src/pages/index.astro`: Added Google Tag (`gtag.js`) script in `<head>` with `is:inline` directive.

## Test plan
- [x] Run `pnpm build` in `docs-site` and verify build succeeds.
- [x] Inspect generated `dist/index.html` to confirm `gtag.js` script tags render properly in `<head>`.