### PR TITLE
ci(release-please): prefix GitHub Release title with "Suitest"

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -109,13 +109,14 @@ jobs:
       # on `main`. Replace the body with that block so the credited notes are
       # what people see on the Release page. Skip if the block is missing or
       # has no section yet, so a race can't wipe the notes.
-      - name: Use the credited changelog block as the Release body
+      - name: Set the Release title and use the credited changelog block as the body
         if: ${{ steps.release.outputs.release_created }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.release.outputs.tag_name }}
         run: |
           git checkout main
+          gh release edit "$TAG" --title "Suitest ${TAG}"
           version="${TAG#v}"
           awk -v h="[$version](" '
             index($0, "## " h) == 1 || index($0, "## Suitest: " h) == 1 { grab = 1; next }


### PR DESCRIPTION
## Summary

- GitHub Releases currently show up as a bare `vX.Y.Z` because release-please names the release after the tag.
- This sets the Release title explicitly to `Suitest vX.Y.Z` so releases carry the product name.

## Changes

- `.github/workflows/release-please.yml`: in the `release_created` step, add `gh release edit "$TAG" --title "Suitest ${TAG}"` before the body edit, and rename the step accordingly. Reuses the step's existing `GH_TOKEN` + `TAG` env.
- No change to `release-please-config.json` / `.release-please-manifest.json` — the git tag stays `vX.Y.Z`, so the `v*` publish workflows keep triggering.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-please.yml'))"` parses clean
- [x] `git diff` scoped to one file, `+2 -1`; config + manifest untouched
- [ ] Next release: GitHub Release title reads `Suitest vX.Y.Z`, tag stays `vX.Y.Z`, publish workflows still trigger