### PR TITLE
fix(npx): ship the LLM client in the bundle and keep the Windows stack alive

### DIFF
--- a/packages/agent/pyproject.toml
+++ b/packages/agent/pyproject.toml
@@ -18,7 +18,9 @@ dependencies = [
 
 [project.optional-dependencies]
 # Cloud AI generation only. Core lifecycle loop (sampling + bridge) never needs
-# these; local bundle installs the base package without this extra.
+# these. The npm bundle cannot select an extra from a bare wheel path, so it
+# installs the same pins by hand — see CLOUD_DEPS in
+# packages/suitest-npx/lib/venv.js and move both together.
 cloud = [
     # M3-1 — LiteLLM router (100+ providers via one client). Imported lazily inside
     # providers/litellm_router.py so ZERO tier + tests never load it at import time.

--- a/packages/agent/src/suitest_agent/providers/litellm_router.py
+++ b/packages/agent/src/suitest_agent/providers/litellm_router.py
@@ -161,7 +161,19 @@ class LiteLLMProvider:
         """Set LiteLLM module globals once. Lazy ``import litellm`` lives here."""
         if self._configured:
             return
-        import litellm
+        # Every other method reaches litellm through here first, so this is the
+        # single place the dependency can be missing. It lives in the ``cloud``
+        # extra: without this guard an install that skipped it raises
+        # ModuleNotFoundError out of the request handler as a 500 rather than a
+        # reportable "your LLM is not usable" answer.
+        try:
+            import litellm
+        except ImportError as exc:
+            raise ProviderError(
+                "LLM_DEPS_MISSING",
+                "The LLM client (litellm) is not installed in this Suitest runtime. "
+                "Reinstall the local stack, or `pip install 'suitest-agent[cloud]'`.",
+            ) from exc
 
         litellm.drop_params = True
         self._configured = True
@@ -223,11 +235,17 @@ class LiteLLMProvider:
             else call.model_copy(update={"model": effective_model})
         )
 
+        # _normalize is inside the try on purpose: a custom OpenAI-compatible
+        # gateway can answer 200 with an empty ``choices`` or a body that is not
+        # OpenAI-shaped at all, and an IndexError there used to reach the client
+        # as a 500 instead of a reported provider failure.
         try:
             resp = await litellm.acompletion(**self._kwargs(effective_call))
+            return self._normalize(resp, effective_call)
+        except ProviderError:
+            raise
         except Exception as exc:
             raise ProviderError("PROVIDER_CALL_FAILED", str(exc)) from exc
-        return self._normalize(resp, effective_call)
 
     def _normalize(self, resp: object, call: ModelCall) -> CompletionResult:
         import litellm

--- a/packages/agent/tests/test_import_without_cloud_extra.py
+++ b/packages/agent/tests/test_import_without_cloud_extra.py
@@ -9,6 +9,11 @@ methods — so module-level import of any of these must succeed even when the
 from __future__ import annotations
 
 import importlib
+import sys
+
+import pytest
+from suitest_agent.providers.base import ChatMessage, ModelCall, ProviderError
+from suitest_agent.providers.litellm_router import LiteLLMProvider
 
 
 def test_agent_package_imports_without_cloud_deps() -> None:
@@ -22,3 +27,19 @@ def test_agent_package_imports_without_cloud_deps() -> None:
         "suitest_agent.graphs.diagnosis",
     ):
         importlib.import_module(mod)
+
+
+@pytest.mark.asyncio
+async def test_completion_without_litellm_is_a_provider_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # None in sys.modules makes `import litellm` raise ImportError — the shape a
+    # bundle that skipped the 'cloud' extra has. It must reach the caller as a
+    # ProviderError (reported as a failed test), never as an unhandled crash.
+    monkeypatch.setitem(sys.modules, "litellm", None)
+    provider = LiteLLMProvider(provider="custom", api_key="k", base_url="https://gw.example")
+    call = ModelCall(model="mimo", messages=[ChatMessage(role="user", content="ping")])
+
+    with pytest.raises(ProviderError) as excinfo:
+        await provider.complete(call)
+    assert excinfo.value.code == "LLM_DEPS_MISSING"

--- a/packages/suitest-npx/lib/stack.js
+++ b/packages/suitest-npx/lib/stack.js
@@ -70,21 +70,37 @@ function isAlive(pid) {
   }
 }
 
-function spawnLogged(cmd, args, { env, logFile }) {
+async function spawnLogged(cmd, args, { env, logFile }) {
   const out = fs.openSync(logFile, "a");
-  const child = spawn(cmd, args, {
-    env,
-    // ponytail: detached only off-Windows — detached:true forces a job-object
-    // assign that fails with AssignProcessToJobObject (87) when the parent is
-    // already in a no-breakaway job (VS Code terminal / CI). unref() alone keeps
-    // the child alive after the parent exits.
-    detached: process.platform !== "win32",
-    stdio: ["ignore", out, out],
-    windowsHide: true,
-  });
-  child.unref();
-  fs.closeSync(out);
-  return child.pid;
+  const base = { env, stdio: ["ignore", out, out], windowsHide: true };
+  // detached:true is what keeps the stack alive once the launcher exits — an
+  // attached child dies with the npx console on Windows, which surfaced as
+  // `suitest up` succeeding and `suitest status` immediately reporting "Not
+  // responding". It can still be refused with AssignProcessToJobObject (87)
+  // when the parent already sits in a no-breakaway job (VS Code terminal, CI),
+  // so fall back to attached rather than not starting at all. The refusal
+  // arrives as a sync throw on some hosts and an async 'error' event on others;
+  // awaiting 'spawn' covers both and keeps the returned pid the real one.
+  const attempt = (detached) =>
+    new Promise((resolve, reject) => {
+      const child = spawn(cmd, args, { ...base, detached });
+      child.once("spawn", () => resolve(child));
+      child.once("error", reject);
+    });
+  try {
+    let child;
+    try {
+      child = await attempt(true);
+    } catch {
+      child = await attempt(false);
+    }
+    child.unref();
+    return child.pid;
+  } finally {
+    // Both attempts can fail (a missing interpreter, say) — without the finally
+    // the log fd leaks out of every failed boot.
+    fs.closeSync(out);
+  }
 }
 
 function tailFile(file, lines = 15) {
@@ -153,7 +169,7 @@ async function up(cwd, { webDist, python, port: preferred }) {
   execFileSync(python, ["-m", "suitest_db.bootstrap"], { env, stdio: "inherit" });
 
   // Verified: create_app(settings=None) is a sync zero-arg-callable factory, so --factory works.
-  const api = spawnLogged(
+  const api = await spawnLogged(
     python,
     [
       "-m", "uvicorn", "suitest_api.main:create_app", "--factory",
@@ -172,7 +188,7 @@ async function up(cwd, { webDist, python, port: preferred }) {
     throw err;
   }
 
-  const supervisor = spawnLogged(
+  const supervisor = await spawnLogged(
     python,
     ["-m", "suitest_runner.local_supervisor"],
     { env, logFile: path.join(dirs.logs, "supervisor.log") },

--- a/packages/suitest-npx/lib/venv.js
+++ b/packages/suitest-npx/lib/venv.js
@@ -45,7 +45,7 @@ function venvPython(venvDir) {
 // ponytail: name+size+mtime, not a content hash — enough to catch a local
 // rebuild. Hash the bytes if a build ever starts preserving mtimes.
 function wheelsFingerprint(wheelsDir) {
-  const h = crypto.createHash("sha256").update(pkg.version);
+  const h = crypto.createHash("sha256").update(pkg.version).update(CLOUD_DEPS.join(","));
   const wheels = fs.existsSync(wheelsDir)
     ? fs
         .readdirSync(wheelsDir)
@@ -58,6 +58,13 @@ function wheelsFingerprint(wheelsDir) {
   }
   return h.digest("hex").slice(0, 16);
 }
+
+// suitest-agent keeps litellm/langgraph behind its `cloud` extra, and an extra
+// cannot be selected from a bare wheel path — so the bundle installed them
+// nowhere and every LLM call raised ModuleNotFoundError (a 500 from
+// /llm-config/test). Keep these floors in sync with the `cloud` extra in
+// packages/agent/pyproject.toml.
+const CLOUD_DEPS = ["litellm>=1.95.0", "langgraph>=0.2.40"];
 
 // Per-project venv from the release wheels; marker records the installed bundle.
 function ensureVenv(venvDir, wheelsDir) {
@@ -82,13 +89,14 @@ function ensureVenv(venvDir, wheelsDir) {
     throw new Error(`No wheels (*.whl) found in ${wheelsDir}`);
   }
   console.log(
-    "Setting up the Python runtime (first run or new version — may download Python 3.12, ~1 min)...",
+    "Setting up the Python runtime (first run or new version — may download Python 3.12 " +
+      "and the LLM client, a few minutes)...",
   );
   // --clear: reaching here means the venv is stale, and uv refuses to write over
   // an existing one without it. Without the flag every invalidation is a hard
   // failure the user has to clear by hand.
   execFileSync("uv", ["venv", venvDir, "--clear", "--python", "3.12"], { stdio: "inherit" });
-  execFileSync("uv", ["pip", "install", "--python", python, ...wheels], {
+  execFileSync("uv", ["pip", "install", "--python", python, ...wheels, ...CLOUD_DEPS], {
     stdio: "inherit",
   });
   fs.writeFileSync(marker, fingerprint);


### PR DESCRIPTION
## Summary

- Adding an LLM in a `npx @suiflex/suitest` install answered `POST /api/v1/workspaces/{id}/llm-config/test` with HTTP 500. `litellm` lives only in the `cloud` extra of `suitest-agent`, and an extra cannot be selected from the bare wheel paths the bundle installs — so the bundle shipped without it and every non-OAuth provider raised `ModuleNotFoundError` out of the request handler.
- On Windows the stack died the moment the launcher exited: `suitest up` reported success and `suitest status` immediately said "Not responding".
- Both failures are invisible in a dev environment, which installs `suitest-agent[cloud]` and spawns detached.

## Changes

**packages/suitest-npx**
- `lib/venv.js`: install `litellm>=1.95.0` and `langgraph>=0.2.40` alongside the wheels, pinned in `CLOUD_DEPS` and folded into the venv fingerprint so existing venvs rebuild. Setup message now says the first run takes a few minutes.
- `lib/stack.js`: spawn the API and supervisor detached on every platform, falling back to attached only when the job object actually refuses the breakaway. The refusal arrives as a sync throw on some hosts and an async `error` event on others, so the spawn is awaited and the recorded pid is the process that survived. The log fd is closed in a `finally`.

**packages/agent**
- `providers/litellm_router.py`: the lazy `import litellm` now raises `ProviderError("LLM_DEPS_MISSING")` with an actionable message, and `_normalize` moved inside the existing `try` — a custom OpenAI-compatible gateway that returns 200 with an empty `choices` array used to reach the client as a 500 too.
- `tests/test_import_without_cloud_extra.py`: covers an attempted completion without the extra, not just the module import.
- `pyproject.toml`: the comment claiming the local bundle ships without the extra is no longer true; it now points at `CLOUD_DEPS`.

## Test plan

- [x] Live stack booted from freshly built wheels: `POST /llm-config/test` with `provider=custom` against a real gateway returns **200** `{ok: false, error.code: PROVIDER_AUTH}` for a bad key — previously 500
- [x] Same call with `litellm` uninstalled and the API restarted returns **200** `{ok: false, error.code: LLM_DEPS_MISSING}`
- [x] `pytest packages/agent/tests` — 221 passed; the new test fails against the pre-fix `litellm_router.py` with the production `ModuleNotFoundError`
- [x] `npm test` in `packages/suitest-npx` — 48 passed
- [x] mypy, ruff check, ruff format clean on `litellm_router.py`
- [x] `spawnLogged` fallbacks exercised with injected refusals (sync `EPERM` and async `AssignProcessToJobObject 87`): both return a live attached pid; a missing binary now rejects with `ENOENT` instead of stalling until the health timeout
- [x] Detached child survives launcher exit on POSIX (reparented to `ppid 1`, still running)
- [ ] **Needs a Windows host:** `suitest up`, let the launcher exit, then `suitest status` in a new terminal must report `Running:`

## Notes for review

- The bundle venv grows from **127 MB to 316 MB** (measured on a fresh build) and the first run takes correspondingly longer. That is the cost of shipping a working LLM layer; flagging it explicitly in case a lazy install-on-demand is preferred instead.
- Out of scope, spotted while investigating: `packages/suitest-npx/package.json` pins `"@suiflex/suitest-mcp": "^0.7.2"`, so the 0.11.0 launcher resolves a 0.7.x MCP server; and `test_connection` never calls `_validate`, so a `custom` provider without a base URL silently hits `api.openai.com` and reports a misleading auth error.
