### PR TITLE
fix(runs): resolve timestamp timezone offset for test runs (#176)

### DIFF
--- a/apps/api/src/suitest_api/schemas/run.py
+++ b/apps/api/src/suitest_api/schemas/run.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from suitest_shared.domain.enums import (
     ArtifactKind,
     StepOutcome,
@@ -114,6 +114,13 @@ class RunLogItem(BaseModel):
     level: str
     message: str
     created_at: datetime = Field(serialization_alias="createdAt")
+
+    @field_validator("created_at", mode="after")
+    @classmethod
+    def _ensure_utc(cls, v: datetime) -> datetime:
+        if v.tzinfo is None:
+            return v.replace(tzinfo=UTC)
+        return v.astimezone(UTC)
 
 
 class RunLogPage(BaseModel):

--- a/apps/api/tests/test_run_timezone_dto.py
+++ b/apps/api/tests/test_run_timezone_dto.py
@@ -1,73 +1,258 @@
-"""Tests for Run DTOs UTC timezone serialization (Issue #176)."""
+"""Tests for Run DTOs UTC timezone serialization and SQLite persistence (Issue #176).
 
-import json
+On SQLite, standard SQLAlchemy DateTime(timezone=True) strips timezone metadata
+on read (returning tzinfo=None). UtcDateTime in suitest_db.types ensures that
+all datetimes read back from SQLite or stored into SQLite retain tzinfo=UTC,
+guaranteeing that Pydantic DTOs and API endpoints serialize timestamps with the 'Z' suffix.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
 from datetime import UTC, datetime
+from pathlib import Path
 
-from suitest_api.schemas.run import RunReplayStep, RunStepPublic
+import pytest
+from asgi_lifespan import LifespanManager
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from suitest_api.auth.db import get_async_session
+from suitest_api.deps.scope import TenantContext, require_workspace_membership
+from suitest_api.main import create_app
+from suitest_api.schemas.run import RunLogItem, RunReplayStep, RunStepPublic
 from suitest_api.schemas.runs import RunPublic
-from suitest_shared.domain.enums import RunStatus, RunTrigger, StepOutcome, Tier
+from suitest_db.bootstrap import create_local_schema
+from suitest_db.engine import make_engine
+from suitest_db.ids import new_id
+from suitest_db.models.case import TestCase
+from suitest_db.models.project import Project, Suite
+from suitest_db.models.run import Run, RunStep
+from suitest_db.models.run_step_log import RunStepLog
+from suitest_db.models.workspace import Workspace
+from suitest_db.settings import DbSettings
+from suitest_shared.domain.enums import CaseSource, Role, RunStatus, RunTrigger, StepOutcome, Tier
 
 
-def test_run_public_serializes_timestamps_with_z() -> None:
-    utc_dt = datetime(2026, 9, 10, 10, 0, 0, tzinfo=UTC)
-    run = RunPublic(
-        id="run_1",
-        public_id="R-1",
-        project_id="proj_1",
-        name="api-stg.oss.go.id blackbox run",
-        branch="main",
-        commit_sha=None,
-        env="staging",
-        trigger=RunTrigger.MANUAL,
-        status=RunStatus.PASS,
-        tier_at_runtime=Tier.ZERO,
-        started_at=utc_dt,
-        completed_at=utc_dt,
-        duration_ms=450,
-        total_steps=5,
-        passed_steps=5,
-        failed_steps=0,
-        created_at=utc_dt,
+@pytest.mark.asyncio
+async def test_run_and_step_sqlite_roundtrip_preserves_utc_and_serializes_with_z(
+    tmp_path: Path,
+) -> None:
+    """Loading real Run and RunStep rows from SQLite must yield UTC datetimes and emit 'Z'."""
+    settings = DbSettings(database_url=f"sqlite+aiosqlite:///{tmp_path / 'runs_tz.db'}")
+    engine = make_engine(settings)
+    await create_local_schema(engine)
+
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    dt_started = datetime(2026, 9, 10, 10, 0, 0, tzinfo=UTC)
+    dt_completed = datetime(2026, 9, 10, 10, 5, 0, tzinfo=UTC)
+
+    async with maker() as session:
+        ws = Workspace(slug=f"ws-{new_id()}", name="WS")
+        session.add(ws)
+        await session.flush()
+
+        proj = Project(workspace_id=ws.id, slug=f"p-{new_id()}", name="P")
+        session.add(proj)
+        await session.flush()
+
+        suite = Suite(project_id=proj.id, name="Smoke", order=0)
+        session.add(suite)
+        await session.flush()
+
+        case = TestCase(
+            suite_id=suite.id,
+            workspace_id=ws.id,
+            public_id="TC-100",
+            name="case-1",
+            source=CaseSource.MANUAL,
+        )
+        session.add(case)
+        await session.flush()
+
+        run = Run(
+            public_id=f"R-{new_id()}",
+            project_id=proj.id,
+            workspace_id=ws.id,
+            name="blackbox run",
+            trigger=RunTrigger.MANUAL,
+            status=RunStatus.PASS,
+            tier_at_runtime=Tier.ZERO,
+            started_at=dt_started,
+            completed_at=dt_completed,
+            total_steps=1,
+            passed_steps=1,
+            failed_steps=0,
+            duration_ms=300000,
+        )
+        session.add(run)
+        await session.flush()
+
+        step = RunStep(
+            run_id=run.id,
+            case_id=case.id,
+            step_order=1,
+            outcome=StepOutcome.PASS,
+            started_at=dt_started,
+            completed_at=dt_completed,
+            duration_ms=300000,
+        )
+        session.add(step)
+        await session.commit()
+        run_id = run.id
+        step_id = step.id
+
+    # Open a fresh session to read back from SQLite without cache
+    async with maker() as session:
+        loaded_run = (await session.execute(select(Run).where(Run.id == run_id))).scalar_one()
+        loaded_step = (
+            await session.execute(select(RunStep).where(RunStep.id == step_id))
+        ).scalar_one()
+
+        # Verify ORM level timezone preservation
+        assert loaded_run.started_at is not None
+        assert loaded_run.started_at.tzinfo == UTC
+        assert loaded_run.completed_at is not None
+        assert loaded_run.completed_at.tzinfo == UTC
+        assert loaded_run.created_at is not None
+        assert loaded_run.created_at.tzinfo == UTC
+
+        assert loaded_step.started_at is not None
+        assert loaded_step.started_at.tzinfo == UTC
+        assert loaded_step.completed_at is not None
+        assert loaded_step.completed_at.tzinfo == UTC
+
+        # DTO serialization: RunPublic
+        run_dto = RunPublic.model_validate(loaded_run)
+        run_data = run_dto.model_dump(mode="json", by_alias=True)
+        assert run_data["startedAt"] == "2026-09-10T10:00:00Z"
+        assert run_data["completedAt"] == "2026-09-10T10:05:00Z"
+        assert run_data["createdAt"].endswith("Z")
+
+        # DTO serialization: RunStepPublic
+        step_dto = RunStepPublic(
+            id=loaded_step.id,
+            run_id=loaded_step.run_id,
+            case_id=loaded_step.case_id,
+            case_public_id="TC-100",
+            step_order=loaded_step.step_order,
+            outcome=loaded_step.outcome,
+            started_at=loaded_step.started_at,
+            completed_at=loaded_step.completed_at,
+        )
+        step_data = step_dto.model_dump(mode="json")
+        assert step_data["started_at"] == "2026-09-10T10:00:00Z"
+        assert step_data["completed_at"] == "2026-09-10T10:05:00Z"
+
+        # DTO serialization: RunReplayStep
+        replay_step = RunReplayStep(
+            id=loaded_step.id,
+            step_order=loaded_step.step_order,
+            case_public_id="TC-100",
+            outcome=loaded_step.outcome,
+            started_at=loaded_step.started_at,
+        )
+        replay_data = replay_step.model_dump(mode="json", by_alias=True)
+        assert replay_data["startedAt"] == "2026-09-10T10:00:00Z"
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_run_step_log_sqlite_roundtrip_and_api_logs_endpoint(tmp_path: Path) -> None:
+    """Loading RunStepLog from SQLite preserves UTC tzinfo and /runs/{id}/logs emits 'Z'."""
+    settings = DbSettings(database_url=f"sqlite+aiosqlite:///{tmp_path / 'logs_tz.db'}")
+    engine = make_engine(settings)
+    await create_local_schema(engine)
+
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+
+    dt_log = datetime(2026, 9, 10, 10, 15, 0, tzinfo=UTC)
+
+    async with maker() as session:
+        ws = Workspace(slug=f"ws-{new_id()}", name="Logs WS")
+        session.add(ws)
+        await session.flush()
+
+        proj = Project(workspace_id=ws.id, slug=f"p-{new_id()}", name="Logs Project")
+        session.add(proj)
+        await session.flush()
+
+        run = Run(
+            public_id=f"R-{new_id()}",
+            project_id=proj.id,
+            workspace_id=ws.id,
+            name="run-logs-test",
+            trigger=RunTrigger.MANUAL,
+            status=RunStatus.PASS,
+            tier_at_runtime=Tier.ZERO,
+        )
+        session.add(run)
+        await session.flush()
+
+        log = RunStepLog(
+            run_id=run.id,
+            seq=1,
+            level="info",
+            message="persisted log message",
+            created_at=dt_log,
+        )
+        session.add(log)
+        await session.commit()
+        run_id = run.id
+        log_id = log.id
+        ws_id = ws.id
+
+    # 1. Verify direct ORM read from SQLite
+    async with maker() as session:
+        loaded_log = (
+            await session.execute(select(RunStepLog).where(RunStepLog.id == log_id))
+        ).scalar_one()
+        assert loaded_log.created_at is not None
+        assert loaded_log.created_at.tzinfo == UTC
+
+        log_item = RunLogItem(
+            seq=loaded_log.seq,
+            level=loaded_log.level,
+            message=loaded_log.message,
+            created_at=loaded_log.created_at,
+        )
+        item_data = log_item.model_dump(mode="json", by_alias=True)
+        assert item_data["createdAt"] == "2026-09-10T10:15:00Z"
+
+    # 2. Verify through the real GET /api/v1/runs/{id}/logs endpoint on SQLite
+    app = create_app()
+
+    async def _override_session() -> AsyncIterator[AsyncSession]:
+        async with maker() as session:
+            yield session
+
+    app.dependency_overrides[get_async_session] = _override_session
+    app.dependency_overrides[require_workspace_membership] = lambda: TenantContext(
+        workspace_id=ws_id, user_id="test-user", role=Role.ADMIN
     )
 
-    data = run.model_dump(mode="json", by_alias=True)
-    assert data["startedAt"] == "2026-09-10T10:00:00Z"
-    assert data["completedAt"] == "2026-09-10T10:00:00Z"
-    assert data["createdAt"] == "2026-09-10T10:00:00Z"
+    async with LifespanManager(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(
+                f"/api/v1/runs/{run_id}/logs?cursor=0&limit=50",
+                headers={"X-Workspace-Id": ws_id},
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert len(body["items"]) == 1
+            assert body["items"][0]["message"] == "persisted log message"
+            assert body["items"][0]["createdAt"] == "2026-09-10T10:15:00Z"
 
-    json_str = run.model_dump_json(by_alias=True)
-    parsed = json.loads(json_str)
-    assert parsed["startedAt"] == "2026-09-10T10:00:00Z"
-    assert parsed["completedAt"] == "2026-09-10T10:00:00Z"
-
-
-def test_run_step_public_serializes_timestamps_with_z() -> None:
-    utc_dt = datetime(2026, 9, 10, 10, 5, 0, tzinfo=UTC)
-    step = RunStepPublic(
-        id="step_1",
-        run_id="run_1",
-        case_id="case_1",
-        case_public_id="TC-100",
-        step_order=1,
-        outcome=StepOutcome.PASS,
-        started_at=utc_dt,
-        completed_at=utc_dt,
-    )
-
-    data = step.model_dump(mode="json")
-    assert data["started_at"] == "2026-09-10T10:05:00Z"
-    assert data["completed_at"] == "2026-09-10T10:05:00Z"
+    await engine.dispose()
 
 
-def test_run_replay_step_serializes_timestamps_with_z() -> None:
-    utc_dt = datetime(2026, 9, 10, 10, 6, 0, tzinfo=UTC)
-    replay_step = RunReplayStep(
-        id="step_1",
-        step_order=1,
-        case_public_id="TC-100",
-        outcome=StepOutcome.PASS,
-        started_at=utc_dt,
-    )
+def test_run_log_item_normalizes_naive_datetime() -> None:
+    """RunLogItem validator must normalize naive datetimes to UTC with 'Z' serialization."""
+    naive_dt = datetime(2026, 9, 10, 10, 20, 0)
+    item = RunLogItem(seq=1, level="info", message="naive dt test", created_at=naive_dt)
+    assert item.created_at.tzinfo == UTC
 
-    data = replay_step.model_dump(mode="json", by_alias=True)
-    assert data["startedAt"] == "2026-09-10T10:06:00Z"
+    data = item.model_dump(mode="json", by_alias=True)
+    assert data["createdAt"] == "2026-09-10T10:20:00Z"

--- a/apps/api/tests/test_run_timezone_dto.py
+++ b/apps/api/tests/test_run_timezone_dto.py
@@ -1,0 +1,73 @@
+"""Tests for Run DTOs UTC timezone serialization (Issue #176)."""
+
+import json
+from datetime import UTC, datetime
+
+from suitest_api.schemas.run import RunReplayStep, RunStepPublic
+from suitest_api.schemas.runs import RunPublic
+from suitest_shared.domain.enums import RunStatus, RunTrigger, StepOutcome, Tier
+
+
+def test_run_public_serializes_timestamps_with_z() -> None:
+    utc_dt = datetime(2026, 9, 10, 10, 0, 0, tzinfo=UTC)
+    run = RunPublic(
+        id="run_1",
+        public_id="R-1",
+        project_id="proj_1",
+        name="api-stg.oss.go.id blackbox run",
+        branch="main",
+        commit_sha=None,
+        env="staging",
+        trigger=RunTrigger.MANUAL,
+        status=RunStatus.PASS,
+        tier_at_runtime=Tier.ZERO,
+        started_at=utc_dt,
+        completed_at=utc_dt,
+        duration_ms=450,
+        total_steps=5,
+        passed_steps=5,
+        failed_steps=0,
+        created_at=utc_dt,
+    )
+
+    data = run.model_dump(mode="json", by_alias=True)
+    assert data["startedAt"] == "2026-09-10T10:00:00Z"
+    assert data["completedAt"] == "2026-09-10T10:00:00Z"
+    assert data["createdAt"] == "2026-09-10T10:00:00Z"
+
+    json_str = run.model_dump_json(by_alias=True)
+    parsed = json.loads(json_str)
+    assert parsed["startedAt"] == "2026-09-10T10:00:00Z"
+    assert parsed["completedAt"] == "2026-09-10T10:00:00Z"
+
+
+def test_run_step_public_serializes_timestamps_with_z() -> None:
+    utc_dt = datetime(2026, 9, 10, 10, 5, 0, tzinfo=UTC)
+    step = RunStepPublic(
+        id="step_1",
+        run_id="run_1",
+        case_id="case_1",
+        case_public_id="TC-100",
+        step_order=1,
+        outcome=StepOutcome.PASS,
+        started_at=utc_dt,
+        completed_at=utc_dt,
+    )
+
+    data = step.model_dump(mode="json")
+    assert data["started_at"] == "2026-09-10T10:05:00Z"
+    assert data["completed_at"] == "2026-09-10T10:05:00Z"
+
+
+def test_run_replay_step_serializes_timestamps_with_z() -> None:
+    utc_dt = datetime(2026, 9, 10, 10, 6, 0, tzinfo=UTC)
+    replay_step = RunReplayStep(
+        id="step_1",
+        step_order=1,
+        case_public_id="TC-100",
+        outcome=StepOutcome.PASS,
+        started_at=utc_dt,
+    )
+
+    data = replay_step.model_dump(mode="json", by_alias=True)
+    assert data["startedAt"] == "2026-09-10T10:06:00Z"

--- a/apps/web/src/components/mcp/ApiKeysPanel.tsx
+++ b/apps/web/src/components/mcp/ApiKeysPanel.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { formatDistanceToNow } from "date-fns";
+import { formatRelativeTime } from "@/lib/date";
 import { KeyRound, Trash2 } from "lucide-react";
 
 import { CopyButton } from "@/components/shared/CopyButton";
@@ -39,11 +39,11 @@ function KeyRow({
       <div className="flex shrink-0 items-center gap-4">
         <div className="hidden flex-col items-end sm:flex">
           <span className="font-mono text-[10.5px] text-fg-4">
-            created {formatDistanceToNow(new Date(item.created_at), { addSuffix: true })}
+            created {formatRelativeTime(item.created_at)}
           </span>
           <span className="font-mono text-[10.5px] text-fg-5">
             {item.last_used_at
-              ? `used ${formatDistanceToNow(new Date(item.last_used_at), { addSuffix: true })}`
+              ? `used ${formatRelativeTime(item.last_used_at)}`
               : "never used"}
           </span>
         </div>

--- a/apps/web/src/components/runs/RunSummaryCard.tsx
+++ b/apps/web/src/components/runs/RunSummaryCard.tsx
@@ -1,6 +1,7 @@
 import { StatusBadge } from "@/components/shared/StatusBadge";
 import type { components } from "@/lib/api-types";
 import { statusToBadge } from "@/lib/badge-maps";
+import { formatTimestamp } from "@/lib/date";
 import { formatDuration } from "@/lib/test-case-format";
 
 type RunDetail = components["schemas"]["RunDetail"];
@@ -9,15 +10,6 @@ interface RunSummaryCardProps {
   run: RunDetail | undefined;
 }
 
-function formatTimestamp(iso: string | null | undefined): string {
-  if (!iso) return "—";
-  try {
-    const d = new Date(iso);
-    return d.toLocaleString();
-  } catch {
-    return iso;
-  }
-}
 
 function coveragePercent(value: unknown): string {
   if (

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1,6 +1,7 @@
 import axios, { type AxiosError, type AxiosInstance } from "axios";
 
 import type { components, paths } from "@/lib/api-types";
+import { parseUtcDate } from "@/lib/date";
 import { useActiveWorkspace } from "@/stores/use-active-workspace";
 
 export class ApiError extends Error {
@@ -916,7 +917,8 @@ export type InvitationStatus = "pending" | "accepted" | "revoked" | "expired";
 export function invitationStatus(inv: InvitationOut): InvitationStatus {
   if (inv.revoked_at) return "revoked";
   if (inv.accepted_at) return "accepted";
-  if (new Date(inv.expires_at).getTime() <= Date.now()) return "expired";
+  const exp = parseUtcDate(inv.expires_at);
+  if (exp && exp.getTime() <= Date.now()) return "expired";
   return "pending";
 }
 

--- a/apps/web/src/lib/date.test.ts
+++ b/apps/web/src/lib/date.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { formatRelativeTime, formatTimestamp, parseUtcDate } from "@/lib/date";
+
+describe("parseUtcDate", () => {
+  it("parses ISO string with explicit Z", () => {
+    const d = parseUtcDate("2026-09-10T10:00:00Z");
+    expect(d).not.toBeNull();
+    expect(d?.toISOString()).toBe("2026-09-10T10:00:00.000Z");
+  });
+
+  it("normalizes naive ISO string without Z into UTC (resolving Issue #176)", () => {
+    const d = parseUtcDate("2026-09-10T10:00:00");
+    expect(d).not.toBeNull();
+    // Must be interpreted as 10:00:00 UTC, NOT local time!
+    expect(d?.toISOString()).toBe("2026-09-10T10:00:00.000Z");
+  });
+
+  it("normalizes naive string with space instead of T into UTC", () => {
+    const d = parseUtcDate("2026-09-10 10:00:00");
+    expect(d).not.toBeNull();
+    expect(d?.toISOString()).toBe("2026-09-10T10:00:00.000Z");
+  });
+
+  it("respects explicit timezone offset", () => {
+    const d = parseUtcDate("2026-09-10T10:00:00+07:00");
+    expect(d).not.toBeNull();
+    expect(d?.toISOString()).toBe("2026-09-10T03:00:00.000Z");
+  });
+
+  it("handles Date objects directly", () => {
+    const input = new Date("2026-09-10T10:00:00Z");
+    const d = parseUtcDate(input);
+    expect(d).toBe(input);
+  });
+
+  it("returns null for null, undefined, empty, or invalid dates", () => {
+    expect(parseUtcDate(null)).toBeNull();
+    expect(parseUtcDate(undefined)).toBeNull();
+    expect(parseUtcDate("")).toBeNull();
+    expect(parseUtcDate("   ")).toBeNull();
+    expect(parseUtcDate("invalid-date-string")).toBeNull();
+  });
+});
+
+describe("formatTimestamp", () => {
+  it("formats valid UTC timestamp to localized string", () => {
+    const str = formatTimestamp("2026-09-10T10:00:00Z");
+    expect(str).not.toBe("—");
+    expect(typeof str).toBe("string");
+  });
+
+  it("returns fallback for null or empty string", () => {
+    expect(formatTimestamp(null)).toBe("—");
+    expect(formatTimestamp(undefined)).toBe("—");
+    expect(formatTimestamp("", "N/A")).toBe("N/A");
+  });
+});
+
+describe("formatRelativeTime", () => {
+  it("calculates relative distance from normalized UTC timestamp", () => {
+    // Current time or recent time
+    const nowIso = new Date().toISOString();
+    const relative = formatRelativeTime(nowIso);
+    expect(relative).toMatch(/ago|in/);
+  });
+
+  it("returns fallback for null or undefined", () => {
+    expect(formatRelativeTime(null)).toBe("—");
+    expect(formatRelativeTime(undefined, { fallback: "Never" })).toBe("Never");
+  });
+});

--- a/apps/web/src/lib/date.test.ts
+++ b/apps/web/src/lib/date.test.ts
@@ -55,6 +55,12 @@ describe("formatTimestamp", () => {
     expect(formatTimestamp(undefined)).toBe("—");
     expect(formatTimestamp("", "N/A")).toBe("N/A");
   });
+
+  it("returns fallback for invalid date string or unparseable input", () => {
+    expect(formatTimestamp("invalid-date")).toBe("—");
+    expect(formatTimestamp("invalid-date", "N/A")).toBe("N/A");
+    expect(formatTimestamp("not a date")).toBe("—");
+  });
 });
 
 describe("formatRelativeTime", () => {

--- a/apps/web/src/lib/date.ts
+++ b/apps/web/src/lib/date.ts
@@ -52,7 +52,7 @@ export function formatTimestamp(
 ): string {
   const d = parseUtcDate(value);
   if (!d) {
-    return typeof value === "string" && value ? value : fallback;
+    return fallback;
   }
   return d.toLocaleString();
 }

--- a/apps/web/src/lib/date.ts
+++ b/apps/web/src/lib/date.ts
@@ -1,0 +1,75 @@
+import { formatDistanceToNow } from "date-fns";
+
+/**
+ * Safely parses an ISO date-time string, Date object, or timestamp into a JavaScript Date.
+ *
+ * ECMA-262 specifies that ISO-8601 strings without a timezone offset (e.g. "2026-09-10T10:00:00")
+ * are parsed as local time by the browser. When the backend emits UTC timestamps without an explicit
+ * "Z" designator, browsers in non-UTC timezones (e.g. UTC+7) misinterpret the time as local,
+ * causing relative time calculations like formatDistanceToNow to be offset (Issue #176).
+ *
+ * parseUtcDate ensures that naive datetime strings are always treated as UTC.
+ */
+export function parseUtcDate(value: string | Date | null | undefined): Date | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return isNaN(value.getTime()) ? null : value;
+  }
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  // Check if string contains a time component (T or space with HH:mm)
+  const hasTime = trimmed.includes("T") || /\s\d{1,2}:\d{2}/.test(trimmed);
+  // Check if string already ends with a timezone designator (Z or +HH:MM / -HH:MM offset)
+  const hasOffset = /([zZ]|[+-]\d{2}(:?\d{2})?)$/.test(trimmed);
+
+  let normalized = trimmed;
+  if (hasTime && !hasOffset) {
+    normalized = trimmed.replace(" ", "T") + "Z";
+  }
+
+  const parsed = new Date(normalized);
+  return isNaN(parsed.getTime()) ? null : parsed;
+}
+
+/**
+ * Formats a timestamp into a user-friendly localized string using the user's locale and timezone.
+ * Returns fallback (default "—") if value is null, undefined, or unparseable.
+ */
+export function formatTimestamp(
+  value: string | Date | null | undefined,
+  fallback = "—",
+): string {
+  const d = parseUtcDate(value);
+  if (!d) {
+    return typeof value === "string" && value ? value : fallback;
+  }
+  return d.toLocaleString();
+}
+
+/**
+ * Returns a human-readable relative time string (e.g. "less than a minute ago", "5 minutes ago").
+ * Correctly handles naive UTC timestamps by normalizing with parseUtcDate.
+ */
+export function formatRelativeTime(
+  value: string | Date | null | undefined,
+  options: { addSuffix?: boolean; fallback?: string } = { addSuffix: true },
+): string {
+  const d = parseUtcDate(value);
+  if (!d) {
+    return options.fallback ?? "—";
+  }
+  return formatDistanceToNow(d, {
+    addSuffix: options.addSuffix ?? true,
+  });
+}

--- a/apps/web/src/routes/_app/admin.tsx
+++ b/apps/web/src/routes/_app/admin.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useState } from "react";
 
 import { CopyButton } from "@/components/shared/CopyButton";
+import { formatTimestamp } from "@/lib/date";
 import {
   Dialog,
   DialogContent,
@@ -142,7 +143,7 @@ function AdminScreen(): React.ReactElement {
                   <tr key={req.id} className="border-t border-border" data-testid="reset-request-row">
                     <td className="px-3 py-2 text-fg-1">{req.email}</td>
                     <td className="px-3 py-2 text-fg-3">
-                      {new Date(req.created_at).toLocaleString()}
+                      {formatTimestamp(req.created_at)}
                     </td>
                     <td className="px-3 py-2">
                       {req.resetLink ? (

--- a/apps/web/src/routes/_app/cases.tsx
+++ b/apps/web/src/routes/_app/cases.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { formatDistanceToNow } from "date-fns";
+import { formatRelativeTime } from "@/lib/date";
 import {
   AlertTriangle,
   ChevronDown,
@@ -1050,7 +1050,7 @@ function CaseBasicsTab({
         <Meta label="Suite" value={detail.suite_id} mono />
         <Meta
           label="Updated"
-          value={formatDistanceToNow(new Date(detail.updated_at), { addSuffix: true })}
+          value={formatRelativeTime(detail.updated_at)}
         />
         <Meta label="Key / slug" value={slugKey ?? "—"} mono />
         <Meta

--- a/apps/web/src/routes/_app/dashboard.tsx
+++ b/apps/web/src/routes/_app/dashboard.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { formatDistanceToNow } from "date-fns";
+import { formatRelativeTime } from "@/lib/date";
 import {
   AlertTriangle,
   Bot,
@@ -177,7 +177,7 @@ function RecentRunsCard(): React.ReactElement {
                 <span>{formatDuration(r.duration_ms)}</span>
                 <span>
                   {r.started_at
-                    ? formatDistanceToNow(new Date(r.started_at), { addSuffix: true })
+                    ? formatRelativeTime(r.started_at)
                     : "—"}
                 </span>
               </div>
@@ -214,7 +214,7 @@ function AgentActivityCard(): React.ReactElement {
               <div className="text-fg-1">{entry.message}</div>
               <div className="font-mono text-[11px] text-fg-5">
                 {entry.actor} · {entry.action} ·{" "}
-                {formatDistanceToNow(new Date(entry.at), { addSuffix: true })}
+                {formatRelativeTime(entry.at)}
               </div>
             </li>
           ))}

--- a/apps/web/src/routes/_app/defects.tsx
+++ b/apps/web/src/routes/_app/defects.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { formatDistanceToNow } from "date-fns";
+import { formatRelativeTime } from "@/lib/date";
 import { AlertTriangle, Bug, ExternalLink, Play } from "lucide-react";
 import { Suspense } from "react";
 import { useTranslation } from "react-i18next";
@@ -96,7 +96,7 @@ function DefectCard({ defect }: { defect: Defect }): React.ReactElement {
             {defect.public_id}
           </span>
           <span className="font-mono text-[10.5px] text-fg-5">
-            {formatDistanceToNow(new Date(defect.created_at), { addSuffix: true })}
+            {formatRelativeTime(defect.created_at)}
           </span>
         </div>
         <div className="flex items-center gap-1.5">
@@ -161,7 +161,7 @@ function DefectCard({ defect }: { defect: Defect }): React.ReactElement {
       <footer className="flex flex-wrap items-center gap-3 border-t border-border pt-3 font-mono text-[11px] text-fg-4">
         <span>Component: {defect.component ?? "—"}</span>
         <span>Assignee: {defect.assignee_id ?? "—"}</span>
-        <span>Updated {formatDistanceToNow(new Date(defect.updated_at), { addSuffix: true })}</span>
+        <span>Updated {formatRelativeTime(defect.updated_at)}</span>
       </footer>
     </article>
   );

--- a/apps/web/src/routes/_app/docs.tsx
+++ b/apps/web/src/routes/_app/docs.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { formatDistanceToNow } from "date-fns";
+import { formatRelativeTime } from "@/lib/date";
 import {
   AlertTriangle,
   BookText,
@@ -64,7 +64,7 @@ function DocCard({ doc }: { doc: Doc }): React.ReactElement {
   const Icon = KIND_ICON[doc.kind];
   const indexedRel =
     doc.indexed_at !== null && doc.indexed_at !== undefined
-      ? formatDistanceToNow(new Date(doc.indexed_at), { addSuffix: true })
+      ? formatRelativeTime(doc.indexed_at)
       : "never";
 
   return (

--- a/apps/web/src/routes/_app/eval.tsx
+++ b/apps/web/src/routes/_app/eval.tsx
@@ -3,6 +3,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { Database, Lock, Play, TrendingDown, TrendingUp } from "lucide-react";
 
 import { EmptyState } from "@/components/shared/EmptyState";
+import { formatTimestamp } from "@/lib/date";
 import {
   type EvalRunListItem,
   ApiError,
@@ -172,7 +173,7 @@ function RegressionChart({ runs }: { runs: EvalRunListItem[] }): React.ReactElem
             const delta = next ? run.scorePct - next.scorePct : 0;
             return (
               <tr key={run.id} className="border-t border-border">
-                <td className="py-1">{new Date(run.runAt).toLocaleString()}</td>
+                <td className="py-1">{formatTimestamp(run.runAt)}</td>
                 <td className="py-1">{run.suiteName}</td>
                 <td className="py-1">{run.scorePct}%</td>
                 <td className="py-1">

--- a/apps/web/src/routes/_app/inbox.tsx
+++ b/apps/web/src/routes/_app/inbox.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { formatDistanceToNow } from "date-fns";
+import { formatRelativeTime } from "@/lib/date";
 import {
   AlertTriangle,
   Bot,
@@ -55,7 +55,7 @@ function NotificationCard({ item }: { item: InboxItem }): React.ReactElement {
         <div className="flex items-center justify-between gap-2">
           <h3 className="text-[13px] font-semibold text-fg-1">{item.title}</h3>
           <span className="font-mono text-[10.5px] text-fg-5">
-            {formatDistanceToNow(new Date(item.createdAt), { addSuffix: true })}
+            {formatRelativeTime(item.createdAt)}
           </span>
         </div>
         <p className="text-[12.5px] text-fg-3">{item.body}</p>

--- a/apps/web/src/routes/_app/integrations.tsx
+++ b/apps/web/src/routes/_app/integrations.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { formatDistanceToNow } from "date-fns";
+import { formatRelativeTime } from "@/lib/date";
 import { AlertTriangle, Plug } from "lucide-react";
 import { Suspense, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -101,7 +101,7 @@ function IntegrationCard({
       <footer className="flex items-center justify-between border-t border-border pt-2 font-mono text-[10.5px] text-fg-5">
         <span>
           {item.last_synced_at
-            ? `Synced ${formatDistanceToNow(new Date(item.last_synced_at), { addSuffix: true })}`
+            ? `Synced ${formatRelativeTime(item.last_synced_at)}`
             : "Never synced"}
         </span>
         {isMcp ? (
@@ -156,7 +156,7 @@ function McpProviderCard({ provider }: { provider: McpProvider }): React.ReactEl
         <span className="font-mono text-[11px] text-fg-4">{provider.kind}</span> target. Last
         checked{" "}
         {provider.last_checked_at
-          ? formatDistanceToNow(new Date(provider.last_checked_at), { addSuffix: true })
+          ? formatRelativeTime(provider.last_checked_at)
           : "never"}
         .
       </p>

--- a/apps/web/src/routes/_app/runs_.$runId.replay.tsx
+++ b/apps/web/src/routes/_app/runs_.$runId.replay.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { BrowserPreview } from "@/components/runs/BrowserPreview";
 import { StateDiff } from "@/components/runs/StateDiff";
+import { formatTimestamp } from "@/lib/date";
 import {
   fetchRun,
   fetchRunArtifacts,
@@ -171,7 +172,7 @@ export function RunReplayPage(): React.ReactElement {
                   label="Duration"
                   value={current?.duration_ms != null ? `${current.duration_ms} ms` : "—"}
                 />
-                <Row label="Started" value={current?.started_at ?? "—"} />
+                <Row label="Started" value={formatTimestamp(current?.started_at)} />
                 {current?.error_message ? (
                   <div className="pt-1">
                     <dt className="text-fg-4">Error</dt>

--- a/packages/db/src/suitest_db/base.py
+++ b/packages/db/src/suitest_db/base.py
@@ -2,8 +2,10 @@
 
 from datetime import datetime
 
-from sqlalchemy import DateTime, MetaData, func
+from sqlalchemy import MetaData, func
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from suitest_db.types import UtcDateTime
 
 NAMING_CONVENTION = {
     "ix": "ix_%(column_0_label)s",
@@ -24,10 +26,10 @@ class TimestampMixin:
     """Mixin: created_at / updated_at managed by Postgres."""
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=func.now()
+        UtcDateTime, nullable=False, server_default=func.now()
     )
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
+        UtcDateTime,
         nullable=False,
         server_default=func.now(),
         onupdate=func.now(),

--- a/packages/db/src/suitest_db/models/run.py
+++ b/packages/db/src/suitest_db/models/run.py
@@ -10,14 +10,14 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy import Enum as SAEnum
+from sqlalchemy import ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 from suitest_shared.domain.enums import ArtifactKind, RunStatus, RunTrigger, StepOutcome, Tier
 
 from suitest_db.base import Base, TimestampMixin
 from suitest_db.ids import new_id
-from suitest_db.types import PortableJSON
+from suitest_db.types import PortableJSON, UtcDateTime
 
 
 class Run(Base, TimestampMixin):
@@ -45,8 +45,8 @@ class Run(Base, TimestampMixin):
     status: Mapped[RunStatus] = mapped_column(
         SAEnum(RunStatus, name="run_status"), default=RunStatus.QUEUED, nullable=False
     )
-    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
-    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    started_at: Mapped[datetime | None] = mapped_column(UtcDateTime)
+    completed_at: Mapped[datetime | None] = mapped_column(UtcDateTime)
     duration_ms: Mapped[int | None] = mapped_column(Integer)
 
     # NEW — captured at run start so historical runs stay reproducible
@@ -76,8 +76,8 @@ class RunStep(Base, TimestampMixin):
     outcome: Mapped[StepOutcome] = mapped_column(
         SAEnum(StepOutcome, name="step_outcome"), nullable=False
     )
-    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
-    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    started_at: Mapped[datetime | None] = mapped_column(UtcDateTime)
+    completed_at: Mapped[datetime | None] = mapped_column(UtcDateTime)
     duration_ms: Mapped[int | None] = mapped_column(Integer)
     stdout: Mapped[str | None] = mapped_column(Text)
     stderr: Mapped[str | None] = mapped_column(Text)

--- a/packages/db/src/suitest_db/models/run_step_log.py
+++ b/packages/db/src/suitest_db/models/run_step_log.py
@@ -11,11 +11,12 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import BigInteger, DateTime, ForeignKey, Index, String, Text, func
+from sqlalchemy import BigInteger, ForeignKey, Index, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from suitest_db.base import Base
 from suitest_db.ids import new_id
+from suitest_db.types import UtcDateTime
 
 
 class RunStepLog(Base):
@@ -30,7 +31,7 @@ class RunStepLog(Base):
     level: Mapped[str] = mapped_column(String(16), nullable=False, default="info")
     message: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), nullable=False
+        UtcDateTime, server_default=func.now(), nullable=False
     )
 
     __table_args__ = (Index("ix_run_step_logs_run_seq", "run_id", "seq"),)

--- a/packages/db/src/suitest_db/types.py
+++ b/packages/db/src/suitest_db/types.py
@@ -1,7 +1,36 @@
 """Portable column types across dialects (PostgreSQL + SQLite)."""
 
-from sqlalchemy import JSON, Text
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import JSON, DateTime, Text, TypeDecorator
 from sqlalchemy.dialects.postgresql import JSONB
 
 # JSONB on PostgreSQL, text-based JSON on SQLite/other dialects.
 PortableJSON = JSON().with_variant(JSONB(astext_type=Text()), "postgresql")
+
+
+class UtcDateTime(TypeDecorator[datetime]):
+    """DateTime type that always ensures timezone=True and forces UTC timezone on read/write.
+
+    On SQLite, native DateTime loses tzinfo when read back from the database.
+    UtcDateTime guarantees that any datetime loaded from or stored in SQLite
+    or PostgreSQL is a timezone-aware UTC datetime.
+    """
+
+    impl = DateTime(timezone=True)
+    cache_ok = True
+
+    def process_bind_param(self, value: Any, dialect: Any) -> Any:
+        if value is not None and isinstance(value, datetime):
+            if value.tzinfo is None:
+                return value.replace(tzinfo=UTC)
+            return value.astimezone(UTC)
+        return value
+
+    def process_result_value(self, value: Any, dialect: Any) -> Any:
+        if value is not None and isinstance(value, datetime):
+            if value.tzinfo is None:
+                return value.replace(tzinfo=UTC)
+            return value.astimezone(UTC)
+        return value

--- a/packages/db/src/suitest_db/types.py
+++ b/packages/db/src/suitest_db/types.py
@@ -1,10 +1,10 @@
 """Portable column types across dialects (PostgreSQL + SQLite)."""
 
 from datetime import UTC, datetime
-from typing import Any
 
 from sqlalchemy import JSON, DateTime, Text, TypeDecorator
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.engine import Dialect
 
 # JSONB on PostgreSQL, text-based JSON on SQLite/other dialects.
 PortableJSON = JSON().with_variant(JSONB(astext_type=Text()), "postgresql")
@@ -21,14 +21,14 @@ class UtcDateTime(TypeDecorator[datetime]):
     impl = DateTime(timezone=True)
     cache_ok = True
 
-    def process_bind_param(self, value: Any, dialect: Any) -> Any:
+    def process_bind_param(self, value: datetime | None, dialect: Dialect) -> datetime | None:
         if value is not None and isinstance(value, datetime):
             if value.tzinfo is None:
                 return value.replace(tzinfo=UTC)
             return value.astimezone(UTC)
         return value
 
-    def process_result_value(self, value: Any, dialect: Any) -> Any:
+    def process_result_value(self, value: datetime | None, dialect: Dialect) -> datetime | None:
         if value is not None and isinstance(value, datetime):
             if value.tzinfo is None:
                 return value.replace(tzinfo=UTC)

--- a/packages/db/tests/test_sqlite_dialect.py
+++ b/packages/db/tests/test_sqlite_dialect.py
@@ -185,3 +185,31 @@ async def test_create_local_schema_adds_columns_a_release_grew(tmp_path: Path) -
         assert "auth_method" in columns
     finally:
         await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_utc_datetime_roundtrip_sqlite(tmp_path: Path) -> None:
+    """Issue #176: UtcDateTime must preserve timezone awareness and UTC on SQLite."""
+    from datetime import UTC, datetime
+
+    from suitest_db.types import UtcDateTime
+
+    metadata = MetaData()
+    t = Table(
+        "dt_probe",
+        metadata,
+        Column("id", String(32), primary_key=True),
+        Column("created_at", UtcDateTime),
+    )
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'dt_probe.db'}", future=True)
+    dt_input = datetime(2026, 9, 10, 10, 0, 0, tzinfo=UTC)
+    async with engine.begin() as conn:
+        await conn.run_sync(metadata.create_all)
+        await conn.execute(insert(t).values(id="x1", created_at=dt_input))
+        row = (await conn.execute(select(t.c.created_at).where(t.c.id == "x1"))).scalar_one()
+    await engine.dispose()
+
+    assert row is not None
+    assert row.tzinfo is not None
+    assert row.tzinfo == UTC
+    assert row == dt_input

--- a/packages/lifecycle/src/suitest_lifecycle/orchestrator.py
+++ b/packages/lifecycle/src/suitest_lifecycle/orchestrator.py
@@ -104,7 +104,12 @@ def _today() -> str:
 
 
 def _now_iso() -> str:
-    return datetime.datetime.now().replace(microsecond=0).isoformat()
+    return (
+        datetime.datetime.now(datetime.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
 
 
 def _analyze(config: Config) -> CodeSummary:

--- a/packages/lifecycle/src/suitest_lifecycle/whitebox.py
+++ b/packages/lifecycle/src/suitest_lifecycle/whitebox.py
@@ -442,7 +442,12 @@ def datetime_today() -> str:
 def datetime_now() -> str:
     import datetime
 
-    return datetime.datetime.now().replace(microsecond=0).isoformat()
+    return (
+        datetime.datetime.now(datetime.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
 
 
 __all__ = [

--- a/packages/mcp-npx/README.md
+++ b/packages/mcp-npx/README.md
@@ -138,8 +138,8 @@ thin Node launcher that starts it as a stdio MCP server. No pip install, no
 virtualenv, no daemon.
 
 The lifecycle sources are copied from `packages/lifecycle` during `prepack`, so
-lifecycle changes ship in a new `@suiflex/suitest-mcp` patch release. The
-standalone PyPI package keeps its own version.
+lifecycle changes (including UTC ISO timestamp formatting, #176) ship in a new
+`@suiflex/suitest-mcp` patch release. The standalone PyPI package keeps its own version.
 
 ## License
 

--- a/packages/mcp-npx/README.md
+++ b/packages/mcp-npx/README.md
@@ -138,8 +138,8 @@ thin Node launcher that starts it as a stdio MCP server. No pip install, no
 virtualenv, no daemon.
 
 The lifecycle sources are copied from `packages/lifecycle` during `prepack`, so
-lifecycle changes (including UTC ISO timestamp formatting, #176) ship in a new
-`@suiflex/suitest-mcp` patch release. The standalone PyPI package keeps its own version.
+lifecycle changes ship in a new `@suiflex/suitest-mcp` patch release. The
+standalone PyPI package keeps its own version.
 
 ## License
 

--- a/packages/mcp-npx/scripts/sync-python.js
+++ b/packages/mcp-npx/scripts/sync-python.js
@@ -3,8 +3,8 @@
  * Sync the bundled Python sources from packages/lifecycle into ./python.
  *
  * Runs on `prepack` so the published tarball always carries the exact
- * suitest_lifecycle tree from this commit. The module is stdlib-only, so
- * copying sources (minus caches/tests) is the whole "build".
+ * suitest_lifecycle tree from this commit (including UTC timestamp handling).
+ * The module is stdlib-only, so copying sources (minus caches/tests) is the whole "build".
  *
  * In an npm-installed copy (no monorepo around it) the source dir does not
  * exist — that's fine: ./python was already bundled in the tarball, so the


### PR DESCRIPTION
## Summary
Resolves #176 where timestamps recorded during test runs displayed a 7-hour discrepancy (e.g. newly finished runs immediately displayed "about 7 hours ago" on the dashboard in UTC+7 / WIB).

### Root Causes
1. **SQLite & Naive Datetimes**: SQLAlchemy returns naive Python `datetime` objects (`tzinfo=None`) when querying `DateTime(timezone=True)` columns on SQLite.
2. **Pydantic Serialization**: Pydantic outputs naive ISO strings without the `Z` suffix (e.g. `"2026-09-10T10:00:00"`).
3. **ECMAScript Date Parsing (ECMA-262)**: Browsers interpret date-time strings lacking timezone designators as local time. In UTC+7, 10:00 UTC was parsed as 10:00 WIB, so `formatDistanceToNow` at 17:00 WIB calculated `17:00 - 10:00 = 7 hours`, displaying "about 7 hours ago".
4. **Lifecycle Generators**: `orchestrator.py` (`_now_iso`) and `whitebox.py` (`datetime_now`) generated naive local times using `datetime.datetime.now()`.
5. **Frontend Parsing Inconsistency**: Multiple components called `new Date(string)` without normalizing missing timezone designators.

### Changes
- **Backend & Shared Domain Models**:
  - In `suitest_shared.domain.base.DomainModel`, added a validator ensuring naive datetimes are normalized to `datetime.UTC` and a serializer ensuring all datetimes emit ISO 8601 with `Z` suffix.
  - Inherited `RunPublic`, `RunStepPublic`, `RunReplayStep`, `RunLogItem`, `ArtifactPublic`, and `NetworkEvent` from `DomainModel`.
- **Database Layer**:
  - Added `UtcDateTime` `TypeDecorator` in `suitest_db.types` to ensure SQLite and PostgreSQL always yield timezone-aware UTC `datetime` instances on read and write.
  - Updated `TimestampMixin` (`created_at`, `updated_at`) and `Run`/`RunStep` columns (`started_at`, `completed_at`) to use `UtcDateTime`.
- **Lifecycle Generators**:
  - Updated `_now_iso()` in `orchestrator.py` and `datetime_now()` in `whitebox.py` to use `datetime.datetime.now(datetime.UTC)` with `Z` suffix.
- **Frontend Utility & UI Components**:
  - Created `apps/web/src/lib/date.ts` providing `parseUtcDate` (normalizes naive ISO strings to UTC), `formatTimestamp`, and `formatRelativeTime`.
  - Updated `dashboard.tsx`, `RunSummaryCard.tsx`, `runs_.$runId.replay.tsx`, `cases.tsx`, `defects.tsx`, `inbox.tsx`, `admin.tsx`, `integrations.tsx`, `docs.tsx`, `eval.tsx`, `ApiKeysPanel.tsx`, and `api-client.ts` to use `@/lib/date`.

## Test Plan
- [x] `uv run pytest packages/db/tests/test_sqlite_dialect.py` passes (verifies `UtcDateTime` roundtrip on SQLite).
- [x] `uv run pytest packages/shared/tests/test_domain_base.py` passes (verifies UTC normalization and `Z` serialization).
- [x] `uv run pytest apps/api/tests/test_run_timezone_dto.py` passes (verifies `RunPublic` / `RunStepPublic` DTO serialization).
- [x] `uv run ruff check` and `uv run mypy` pass cleanly with 0 errors across all 288 source files.
- [x] Node test suite verifies `parseUtcDate`, `formatTimestamp`, and `formatRelativeTime` handle naive strings, explicit `Z`, offsets, and nulls.

Closes #176