### PR TITLE
ci: grant the Guardener report stub actions read

### DIFF
--- a/.github/workflows/guardener-report.yml
+++ b/.github/workflows/guardener-report.yml
@@ -21,6 +21,10 @@ on:
 
 permissions:
   contents: read
+  # The workflow this calls reads the scan's artifact, which belongs to another
+  # workflow run. A called workflow cannot hold a permission its caller does not,
+  # so granting it there and not here is a startup failure, not a smaller grant.
+  actions: read
 
 jobs:
   report:


### PR DESCRIPTION
## Summary

- The reporting half of the gate ended in `startup_failure` on its first real run (run 34512540911), which is the first time it could run at all — a `workflow_run` workflow only ever runs from the default branch.
- A called workflow cannot hold a permission its caller does not. `report.yml` in suiflex/Guardener asks for `actions: read` to fetch the scan's artifact; this stub granted only `contents: read`, so the workflow refused to load rather than running with less.

## Changes

- `.github/workflows/guardener-report.yml` — adds `actions: read`.

The same one-line fix is in suiflex/Guardener#4 for the template and for Guardener's own copy, so the five repositories that have not migrated yet get it right the first time.

## Test plan

- [x] YAML parses; permissions block asserted to be `{contents: read, actions: read}`
- [x] Checked against the called workflow by parsing both and diffing the permission maps — nothing else is missing
- [ ] **Only observable after merge:** the reporting half actually posting a check run, for the same `workflow_run` reason that hid this defect until now